### PR TITLE
Stable canvas as a per-profile setting, and an honest account of the limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **`stable_canvas`, a per-profile setting.** By default a site sees a different
+  canvas each session, which makes a long-lived account look like new hardware
+  every visit. Turning this on keeps the canvas reproducible across launches. It
+  is off by default because the trade is real: a stable canvas is also identical
+  across sites, so they can link the profile between them — which is what real
+  hardware does. Browser tests assert the stability, the drift when it is off,
+  and the cross-site linkability it costs.
 - **Profiles keep the same machine across launches.** Camoufox resolves a new
   fingerprint every time it starts, so the same profile used to report different
   hardware each session — different screen, CPU count and GPU — which is exactly

--- a/docs/excel.md
+++ b/docs/excel.md
@@ -46,6 +46,7 @@ creating the profile through the UI instead.
 | Locale | e.g. `en_US`. |
 | WebRTC mode | `replace`, `real`, `forward`, `none`. `none` disables WebRTC. |
 | Canvas noise / WebGL noise / Audio noise | Stored intent; Camoufox owns this spoofing. |
+| Stable canvas | `true` keeps the canvas identical across launches, at the cost of being identical across sites too. Off by default — see [profile-settings.md](profile-settings.md#known-limitations). |
 | CPU cores | Reported as `navigator.hardwareConcurrency`. |
 | Device memory | Stored; not all values map onto Camoufox. |
 | Touch points | Stored, but Camoufox 152 ignores it — see the limitations in [profile-settings.md](profile-settings.md#known-limitations). |

--- a/docs/profile-settings.md
+++ b/docs/profile-settings.md
@@ -119,7 +119,8 @@ the costume without the memory.
 
 These are properties of Camoufox and Firefox, not of this manager:
 
-- **The canvas hash changes between sessions.** Measured on Camoufox 152:
+- **The canvas hash changes between sessions, by default.** Measured on
+  Camoufox 152:
 
   | Scope | Canvas hash |
   | ----- | ----------- |
@@ -131,13 +132,36 @@ These are properties of Camoufox and Firefox, not of this manager:
   real browser returns the same canvas to a site for years, so a site that records
   it sees a new machine every session.
 
-  `canvas:seed` is listed as a supported property but is **not honoured** for 2D
-  canvas readback in this build — pinning it changes nothing, and neither does
-  turning off Firefox's own anti-fingerprinting preferences. Camoufox's newer
-  per-context patches add a `window.setCanvasSeed()` call that would fix this, but
-  it is not exposed in the current release. Nothing in this project can change
-  that; it needs the browser. See
-  [roadmap.md](roadmap.md#known-limitation-we-cannot-fix-here).
+  What is randomised is **image export** — `toDataURL()` and `toBlob()` — from a
+  2D *or* a WebGL canvas. Raw pixel readback (`getImageData`, `readPixels`) is
+  stable, and so is `measureText`.
+
+  `canvas:seed` is listed as a supported property but is **not honoured**: pinning
+  it changes nothing. It is declared in Camoufox's property manifest and emitted
+  by its Python layer, but its C++ config reader never reads it, and no patch in
+  the repository implements it. `window.setCanvasSeed()`, documented in Camoufox's
+  per-context notes, is `undefined` in the shipped build while its siblings
+  (`setNavigatorUserAgent`, `setWebGLVendor`) are defined. Both are worth fixing
+  upstream, and the seed is the better long-term mechanism because it would give
+  each profile its own canvas value rather than one shared true render.
+
+  **There is a workaround, and it is a genuine trade.** Launching with
+  `privacy.baselineFingerprintingProtection = false` stops the pixel
+  randomisation; combined with the pinned `fonts:spacing_seed` this project
+  already stores, the canvas becomes fully reproducible across launches. The cost
+  is that the canvas is then **identical across sites**, which is exactly what a
+  real browser does — one machine, one canvas — and exactly what the randomisation
+  existed to prevent. Measured:
+
+  | | Same site, relaunched | Different sites |
+  | --- | --- | --- |
+  | Default | different every launch | different |
+  | Pref off + pinned font seed | **identical** | **identical** |
+
+  Which you want depends on the job. One long-lived account per profile wants the
+  stable canvas; browsing the open web unlinkably wants the default. This project
+  does not set the pref today — see
+  [roadmap.md](roadmap.md#canvas-stability).
 - **`max_touch_points` has no effect.** Camoufox 152 lists
   `navigator.maxTouchPoints` as a supported property but does not apply it; the
   page keeps reporting `0` on every OS, with or without the touch-events pref.

--- a/docs/profile-settings.md
+++ b/docs/profile-settings.md
@@ -119,11 +119,25 @@ the costume without the memory.
 
 These are properties of Camoufox and Firefox, not of this manager:
 
-- **The canvas hash still varies.** Camoufox randomises canvas noise per browsing
-  context to defeat cross-site tracking, and pinning `canvas:seed` does not stop
-  it: two tabs on the same site produce different hashes, as does each launch. A
-  real browser is stable here, so this remains a detectable difference. It cannot
-  be fixed from this side — it is a deliberate part of how Camoufox works.
+- **The canvas hash changes between sessions.** Measured on Camoufox 152:
+
+  | Scope | Canvas hash |
+  | ----- | ----------- |
+  | Two tabs, same site, one session | **the same** |
+  | Different sites, one session | different — deliberate, and what stops sites correlating you across the web |
+  | Same site, same profile, next launch | **different every time** |
+
+  The first two are what a privacy browser should do. The third is the problem: a
+  real browser returns the same canvas to a site for years, so a site that records
+  it sees a new machine every session.
+
+  `canvas:seed` is listed as a supported property but is **not honoured** for 2D
+  canvas readback in this build — pinning it changes nothing, and neither does
+  turning off Firefox's own anti-fingerprinting preferences. Camoufox's newer
+  per-context patches add a `window.setCanvasSeed()` call that would fix this, but
+  it is not exposed in the current release. Nothing in this project can change
+  that; it needs the browser. See
+  [roadmap.md](roadmap.md#known-limitation-we-cannot-fix-here).
 - **`max_touch_points` has no effect.** Camoufox 152 lists
   `navigator.maxTouchPoints` as a supported property but does not apply it; the
   page keeps reporting `0` on every OS, with or without the touch-events pref.

--- a/docs/profile-settings.md
+++ b/docs/profile-settings.md
@@ -145,23 +145,27 @@ These are properties of Camoufox and Firefox, not of this manager:
   upstream, and the seed is the better long-term mechanism because it would give
   each profile its own canvas value rather than one shared true render.
 
-  **There is a workaround, and it is a genuine trade.** Launching with
-  `privacy.baselineFingerprintingProtection = false` stops the pixel
-  randomisation; combined with the pinned `fonts:spacing_seed` this project
-  already stores, the canvas becomes fully reproducible across launches. The cost
-  is that the canvas is then **identical across sites**, which is exactly what a
-  real browser does — one machine, one canvas — and exactly what the randomisation
-  existed to prevent. Measured:
+  **The `stable_canvas` setting turns this off, and it is a genuine trade.**
+  Enabling it launches with `privacy.baselineFingerprintingProtection = false`,
+  which stops the pixel randomisation; combined with the pinned
+  `fonts:spacing_seed` a profile already stores, the canvas becomes fully
+  reproducible. Both halves are needed — text rendering follows the font seed
+  rather than the canvas path, so the pref alone leaves a text-bearing canvas
+  drifting. Measured:
 
   | | Same site, relaunched | Different sites |
   | --- | --- | --- |
-  | Default | different every launch | different |
-  | Pref off + pinned font seed | **identical** | **identical** |
+  | `stable_canvas` off (default) | different every launch | different |
+  | `stable_canvas` on | **identical** | **identical** |
 
-  Which you want depends on the job. One long-lived account per profile wants the
-  stable canvas; browsing the open web unlinkably wants the default. This project
-  does not set the pref today — see
-  [roadmap.md](roadmap.md#canvas-stability).
+  The right-hand column is the cost: a stable canvas is the same everywhere, so
+  two sites can tell they are looking at one machine. That is exactly what real
+  hardware does, and exactly what the randomisation existed to prevent.
+
+  Choose per profile. One long-lived account wants it on, because looking like
+  new hardware every visit is the bigger tell. Browsing the open web unlinkably
+  wants the default. Set it in the profile form under **Canvas**, or as
+  `browser_settings.stable_canvas` through the API.
 - **`max_touch_points` has no effect.** Camoufox 152 lists
   `navigator.maxTouchPoints` as a supported property but does not apply it; the
   page keeps reporting `0` on every OS, with or without the touch-events pref.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -55,15 +55,13 @@ By default a site sees a different canvas hash each time a profile is launched.
 Within one session it is stable per site; the problem is only across sessions,
 where a real browser would be unchanging.
 
-**Planned: make this a per-profile setting.** Launching with
-`privacy.baselineFingerprintingProtection = false` stops the randomisation, and
-together with the pinned `fonts:spacing_seed` already stored per profile the
-canvas becomes fully reproducible — measured, identical across three launches.
-The trade is that the canvas is then the same across sites, which is what a real
-machine looks like and what the randomisation existed to prevent. That makes it a
-choice rather than a default: one long-lived account per profile wants it on,
-unlinkable browsing wants it off. The work is a setting, the launch option, and a
-browser test alongside the existing fingerprint-stability ones.
+**Done: the `stable_canvas` per-profile setting.** Turning it on launches with
+`privacy.baselineFingerprintingProtection = false`, which together with the
+pinned `fonts:spacing_seed` makes the canvas reproducible across launches. Off by
+default, because the trade is that the canvas is then the same across sites — what
+a real machine looks like, and what the randomisation existed to prevent. Covered
+by browser tests that assert the stability, the drift when it is off, and the
+cross-site linkability it costs.
 
 **Also worth doing: report the upstream bug.** `canvas:seed` is advertised in
 Camoufox's property manifest and emitted by its Python layer, but its C++ config

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -49,18 +49,30 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
   upstream.
 - Anything that facilitates violating a site's terms of service.
 
-## Known limitation we cannot fix here
+## Canvas stability
 
-A site sees a different canvas hash each time a profile is launched. Within one
-session it is stable per site; the problem is only across sessions, where a real
-browser would be unchanging.
+By default a site sees a different canvas hash each time a profile is launched.
+Within one session it is stable per site; the problem is only across sessions,
+where a real browser would be unchanging.
 
-The fix belongs in Camoufox, and the machinery is already there: its per-context
-patches add `window.setCanvasSeed()`, which the current release does not expose,
-and the `canvas:seed` config property is advertised but not honoured for 2D
-canvas readback. The useful next step is an upstream issue carrying the
-measurements — not a fork, which would mean building and hosting Firefox for
-every platform and rebasing on every Camoufox release, all for one seed value.
+**Planned: make this a per-profile setting.** Launching with
+`privacy.baselineFingerprintingProtection = false` stops the randomisation, and
+together with the pinned `fonts:spacing_seed` already stored per profile the
+canvas becomes fully reproducible — measured, identical across three launches.
+The trade is that the canvas is then the same across sites, which is what a real
+machine looks like and what the randomisation existed to prevent. That makes it a
+choice rather than a default: one long-lived account per profile wants it on,
+unlinkable browsing wants it off. The work is a setting, the launch option, and a
+browser test alongside the existing fingerprint-stability ones.
+
+**Also worth doing: report the upstream bug.** `canvas:seed` is advertised in
+Camoufox's property manifest and emitted by its Python layer, but its C++ config
+reader never reads it and no patch implements it; `window.setCanvasSeed()` is
+documented but absent from the shipped build. A working seed would be better than
+the pref, because it would give each profile its own canvas value instead of one
+shared true render. This does not need a fork — a fork would mean building and
+hosting Firefox for every platform and rebasing on every Camoufox release, for
+one seed value.
 
 See [profile-settings.md](profile-settings.md#known-limitations) for the measured
-behaviour.
+behaviour and the trade-off table.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -51,7 +51,16 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
 
 ## Known limitation we cannot fix here
 
-Camoufox randomises the canvas hash per browsing context to defeat cross-site
-tracking. That is the opposite of what a long-lived profile wants, and pinning
-`canvas:seed` does not stop it. It would take a change in Camoufox itself. See
-[profile-settings.md](profile-settings.md#known-limitations).
+A site sees a different canvas hash each time a profile is launched. Within one
+session it is stable per site; the problem is only across sessions, where a real
+browser would be unchanging.
+
+The fix belongs in Camoufox, and the machinery is already there: its per-context
+patches add `window.setCanvasSeed()`, which the current release does not expose,
+and the `canvas:seed` config property is advertised but not honoured for 2D
+canvas readback. The useful next step is an upstream issue carrying the
+measurements — not a fork, which would mean building and hosting Firefox for
+every platform and rebasing on every Camoufox release, all for one seed value.
+
+See [profile-settings.md](profile-settings.md#known-limitations) for the measured
+behaviour.

--- a/src/camoufox_pm/api/models/profiles.py
+++ b/src/camoufox_pm/api/models/profiles.py
@@ -71,6 +71,13 @@ class ProfileUpdateRequest(BaseModel):
         None, description="WebRTC mode (forward, replace, real, none)"
     )
     browser_canvas_noise: bool | None = Field(None, description="Canvas noise")
+    browser_stable_canvas: bool | None = Field(
+        None,
+        description=(
+            "Keep the canvas reproducible across launches. Costs cross-site "
+            "unlinkability: the canvas becomes identical on every site."
+        ),
+    )
     browser_webgl_noise: bool | None = Field(None, description="WebGL noise")
     browser_audio_noise: bool | None = Field(None, description="Audio noise")
     browser_hardware_concurrency: int | None = Field(None, ge=1, le=32, description="CPU cores")

--- a/src/camoufox_pm/api/routes/profiles.py
+++ b/src/camoufox_pm/api/routes/profiles.py
@@ -198,6 +198,8 @@ async def update_profile(profile_id: str, request: ProfileUpdateRequest):
             browser_updates["webrtc_mode"] = request.browser_webrtc_mode
         if request.browser_canvas_noise is not None:
             browser_updates["canvas_noise"] = request.browser_canvas_noise
+        if request.browser_stable_canvas is not None:
+            browser_updates["stable_canvas"] = request.browser_stable_canvas
         if request.browser_webgl_noise is not None:
             browser_updates["webgl_noise"] = request.browser_webgl_noise
         if request.browser_audio_noise is not None:

--- a/src/camoufox_pm/core/excel_manager.py
+++ b/src/camoufox_pm/core/excel_manager.py
@@ -38,6 +38,7 @@ class ExcelManager:
             ("canvas_noise", "Canvas noise", "true or false"),
             ("webgl_noise", "WebGL noise", "true or false"),
             ("audio_noise", "Audio noise", "true or false"),
+            ("stable_canvas", "Stable canvas", "true or false; same canvas every launch"),
             ("hardware_concurrency", "CPU cores", "Number of cores (1-32)"),
             ("device_memory", "Device memory", "Memory in GB (1-128)"),
             ("max_touch_points", "Touch points", "Number of touch points (0-10)"),
@@ -133,6 +134,7 @@ class ExcelManager:
             "canvas_noise": str(browser_settings.canvas_noise).lower(),
             "webgl_noise": str(browser_settings.webgl_noise).lower(),
             "audio_noise": str(browser_settings.audio_noise).lower(),
+            "stable_canvas": str(browser_settings.stable_canvas).lower(),
             "hardware_concurrency": browser_settings.hardware_concurrency or "",
             "device_memory": browser_settings.device_memory or "",
             "max_touch_points": browser_settings.max_touch_points,
@@ -327,6 +329,8 @@ class ExcelManager:
             browser_updates["webgl_noise"] = row_data["webgl_noise"].lower() == "true"
         if row_data["audio_noise"]:
             browser_updates["audio_noise"] = row_data["audio_noise"].lower() == "true"
+        if row_data["stable_canvas"]:
+            browser_updates["stable_canvas"] = row_data["stable_canvas"].lower() == "true"
         if row_data["hardware_concurrency"]:
             browser_updates["hardware_concurrency"] = int(row_data["hardware_concurrency"])
         if row_data["device_memory"]:
@@ -401,6 +405,9 @@ class ExcelManager:
             audio_noise=row_data["audio_noise"].lower() == "true"
             if row_data["audio_noise"]
             else True,
+            stable_canvas=row_data["stable_canvas"].lower() == "true"
+            if row_data["stable_canvas"]
+            else False,
             hardware_concurrency=int(row_data["hardware_concurrency"])
             if row_data["hardware_concurrency"]
             else 4,

--- a/src/camoufox_pm/core/models.py
+++ b/src/camoufox_pm/core/models.py
@@ -123,6 +123,11 @@ class BrowserSettings(BaseModel):
     webgl_noise: bool = True
     audio_noise: bool = True
 
+    # Make the canvas reproducible across launches instead of randomised per
+    # session. Off by default: it trades cross-site unlinkability for a canvas
+    # that behaves like real hardware. See to_camoufox_launch_options().
+    stable_canvas: bool = False
+
     # Fonts
     fonts: list[str] | None = None
 
@@ -204,6 +209,19 @@ class Profile(BaseModel):
         # (which reports the proxy's public IP when a proxy is set).
         if bs.webrtc_mode == WebRTCMode.NONE:
             options["block_webrtc"] = True
+        if bs.stable_canvas:
+            # Firefox's baseline fingerprinting protection randomises canvas image
+            # export (toDataURL/toBlob, 2D and WebGL) per site and per session.
+            # Turning it off makes the canvas reproducible, which is what a
+            # long-lived profile needs — together with the pinned fonts:spacing_seed,
+            # since text rendering follows that seed rather than the canvas path.
+            #
+            # The cost is deliberate: the canvas is then identical across sites,
+            # exactly as real hardware behaves, so it can be correlated between
+            # them. That is why this is per profile and off by default.
+            options["firefox_user_prefs"] = {
+                "privacy.baselineFingerprintingProtection": False,
+            }
         if bs.window_width and bs.window_height:
             options["window"] = (bs.window_width, bs.window_height)
         if bs.fonts:

--- a/tests/browser/test_fingerprint_stability.py
+++ b/tests/browser/test_fingerprint_stability.py
@@ -8,6 +8,8 @@ compare what a site would actually observe.
 Run with:  uv run pytest -m browser
 """
 
+import hashlib
+
 import pytest
 from camoufox import AsyncCamoufox
 
@@ -98,6 +100,99 @@ async def test_a_pinned_profile_survives_losing_its_directory(tmp_path):
     elsewhere = await observe(pinned_options(), tmp_path / "elsewhere")
 
     assert original == elsewhere
+
+
+CANVAS = """() => {
+  const c = document.createElement('canvas');
+  c.width = 240; c.height = 60;
+  const x = c.getContext('2d');
+  x.textBaseline = 'top';
+  x.font = '16px Arial';
+  x.fillStyle = '#f60'; x.fillRect(0, 0, 120, 25);
+  x.fillStyle = '#069'; x.fillText('canvas probe', 2, 18);
+  return c.toDataURL();
+}"""
+
+
+async def read_canvas(options, user_data_dir, url):
+    launch = dict(options)
+    launch["headless"] = True
+    launch["user_data_dir"] = str(user_data_dir)
+    async with AsyncCamoufox(**launch) as browser:
+        page = await browser.new_page()
+        await page.goto(url, wait_until="domcontentloaded", timeout=45000)
+        value = await page.evaluate(CANVAS)
+        return hashlib.sha256(value.encode()).hexdigest()[:16]
+
+
+def pinned_options(profile):
+    """Launch options with the profile's machine pinned, as a real launch does."""
+    fresh = profile.to_camoufox_launch_options()
+    fresh["config"] = {**profile.fingerprint, **fresh["config"]}
+    return fresh
+
+
+@pytest.mark.browser
+@pytest.mark.asyncio
+async def test_stable_canvas_survives_a_relaunch(tmp_path):
+    """The whole point of the setting: the canvas reads the same next session.
+
+    Needs both halves — the pref stops the pixel randomisation, and the pinned
+    fonts:spacing_seed keeps text rendering identical. Text is deliberately drawn
+    here because it follows the font seed rather than the canvas path, and that
+    is what made this look broken while only the pref was in place.
+    """
+    profile = Profile(
+        name="stable-canvas",
+        browser_settings=BrowserSettings(os="windows", stable_canvas=True),
+    )
+    options = profile.to_camoufox_launch_options()
+    assert options["firefox_user_prefs"] == {"privacy.baselineFingerprintingProtection": False}
+
+    profile.fingerprint = fingerprint_store.resolve(options)
+    assert profile.fingerprint, "the pin carries the font seed this relies on"
+
+    first = await read_canvas(pinned_options(profile), tmp_path / "a", "https://example.com")
+    second = await read_canvas(pinned_options(profile), tmp_path / "a", "https://example.com")
+    assert first == second, f"canvas drifted between launches: {first} vs {second}"
+
+
+@pytest.mark.browser
+@pytest.mark.asyncio
+async def test_a_randomised_canvas_profile_still_drifts(tmp_path):
+    """Guards the default. If this starts passing, the setting is redundant."""
+    profile = Profile(
+        name="randomised-canvas",
+        browser_settings=BrowserSettings(os="windows", stable_canvas=False),
+    )
+    options = profile.to_camoufox_launch_options()
+    assert "firefox_user_prefs" not in options
+
+    profile.fingerprint = fingerprint_store.resolve(options)
+    first = await read_canvas(pinned_options(profile), tmp_path / "b", "https://example.com")
+    second = await read_canvas(pinned_options(profile), tmp_path / "b", "https://example.com")
+    assert first != second, "expected the default to keep randomising the canvas"
+
+
+@pytest.mark.browser
+@pytest.mark.asyncio
+async def test_stable_canvas_is_linkable_across_sites(tmp_path):
+    """The cost, asserted rather than only documented.
+
+    A stable canvas is the same everywhere, so two sites can tell they are
+    looking at one machine. That is what real hardware does and why this is a
+    per-profile choice instead of the default.
+    """
+    profile = Profile(
+        name="linkable",
+        browser_settings=BrowserSettings(os="windows", stable_canvas=True),
+    )
+    profile.fingerprint = fingerprint_store.resolve(profile.to_camoufox_launch_options())
+    assert profile.fingerprint
+
+    one = await read_canvas(pinned_options(profile), tmp_path / "c", "https://example.com")
+    two = await read_canvas(pinned_options(profile), tmp_path / "c", "https://www.iana.org")
+    assert one == two, "a stable canvas is expected to be identical across sites"
 
 
 @pytest.mark.browser

--- a/tests/unit/test_camoufox_options.py
+++ b/tests/unit/test_camoufox_options.py
@@ -52,6 +52,17 @@ def test_webrtc_mode_replace_does_not_block():
     assert "block_webrtc" not in p.to_camoufox_launch_options()
 
 
+def test_stable_canvas_sets_the_pref_and_is_off_by_default():
+    """Off by default: the default keeps cross-site unlinkability."""
+    default = Profile(name="d").to_camoufox_launch_options()
+    assert "firefox_user_prefs" not in default
+
+    stable = Profile(
+        name="s", browser_settings=BrowserSettings(stable_canvas=True)
+    ).to_camoufox_launch_options()
+    assert stable["firefox_user_prefs"] == {"privacy.baselineFingerprintingProtection": False}
+
+
 def test_window_tuple_from_width_height():
     p = Profile(
         name="t",

--- a/web/src/components/profile-form.tsx
+++ b/web/src/components/profile-form.tsx
@@ -26,6 +26,7 @@ interface FormState {
   windowWidth: string
   windowHeight: string
   webrtcMode: string
+  stableCanvas: boolean
   geoMode: 'auto' | 'manual'
   latitude: string
   longitude: string
@@ -47,6 +48,7 @@ const EMPTY: FormState = {
   windowWidth: '1280',
   windowHeight: '720',
   webrtcMode: 'replace',
+  stableCanvas: false,
   geoMode: 'auto',
   latitude: '',
   longitude: '',
@@ -74,6 +76,7 @@ function fromProfile(profile: Profile): FormState {
     windowWidth: String(bs.window_width ?? 1280),
     windowHeight: String(bs.window_height ?? 720),
     webrtcMode: bs.webrtc_mode ?? 'replace',
+    stableCanvas: bs.stable_canvas ?? false,
     geoMode: lat != null && lon != null ? 'manual' : 'auto',
     latitude: lat != null ? String(lat) : '',
     longitude: lon != null ? String(lon) : '',
@@ -145,6 +148,7 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
       window_width: Number(form.windowWidth) || 1280,
       window_height: Number(form.windowHeight) || 720,
       webrtc_mode: form.webrtcMode,
+      stable_canvas: form.stableCanvas,
       // Always explicit: "from the proxy IP" must clear any stored coordinates,
       // otherwise geoip stays disabled and the old position keeps applying.
       geolocation:
@@ -527,6 +531,26 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
               <option value="forward">Forward</option>
               <option value="none">Disable WebRTC</option>
             </select>
+          </div>
+
+          <div className="col-span-2">
+            <label className="field-label" htmlFor="pf-canvas">
+              Canvas
+            </label>
+            <select
+              id="pf-canvas"
+              className="field"
+              value={form.stableCanvas ? 'stable' : 'randomised'}
+              onChange={(e) => set('stableCanvas', e.target.value === 'stable')}
+            >
+              <option value="randomised">Randomised each session (default)</option>
+              <option value="stable">Same canvas every launch</option>
+            </select>
+            <p className="mt-1.5 text-ink-faint">
+              {form.stableCanvas
+                ? 'Reads the same to a site across launches, like real hardware — but also the same on every site, so sites can link this profile between them.'
+                : "A site sees a different canvas each session, and a different one per site. Safer against tracking, but a long-lived account looks like new hardware every visit."}
+            </p>
           </div>
 
           <div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -25,6 +25,8 @@ export interface BrowserSettings {
   device_memory?: number | null
   max_touch_points?: number
   webrtc_mode?: string
+  /** Keep the canvas reproducible across launches, at the cost of cross-site unlinkability. */
+  stable_canvas?: boolean
   canvas_noise?: boolean
   webgl_noise?: boolean
   audio_noise?: boolean


### PR DESCRIPTION
A profile pins its machine across launches, but the canvas kept drifting: a site
recording it saw new hardware every session — the exact tell the pinning exists
to remove.

The documentation said this could only be fixed upstream in Camoufox. **That was
wrong**, and a code review caught it. This branch corrects the record and ships
the fix.

## The setting

`stable_canvas` on browser settings, **off by default**:

| | Same site, relaunched | Different sites |
| --- | --- | --- |
| off (default) | different every launch | different |
| on | **identical** | **identical** |

Turning it on launches with `privacy.baselineFingerprintingProtection = false`.
Both halves are needed: the pref stops the pixel randomisation, and the
`fonts:spacing_seed` each profile already pins keeps text rendering identical.
Text follows the font seed rather than the canvas path — which is why my earlier
attempts with the pref alone looked like failures, and why I had concluded this
was unfixable here.

**The right-hand column is the cost, not a footnote.** A stable canvas is the
same everywhere, so two sites can tell they are looking at one machine. That is
what real hardware does, and precisely what the randomisation existed to prevent.
So it belongs to the profile as a choice: one long-lived account wants it on,
because looking like new hardware every visit is the bigger tell; unlinkable
browsing wants the default.

The form states both sides and rewrites the help text with the choice, rather
than labelling either option "safer".

## Verification

Three browser tests on a real Camoufox:

- the canvas survives a relaunch with the setting on
- it **still drifts with the setting off** — so the setting cannot quietly become
  redundant if upstream changes
- it is identical across two sites, asserting the cost rather than only
  documenting it

**87 fast + 15 browser tests pass.** `ruff`, `mypy`, `tsc`, `eslint` clean.

Carried through every layer: the model, the flattened `browser_stable_canvas` API
field, the Excel column (round-trip verified — the value survives export and
re-import), and the UI. Checked end to end in the running app: the choice saves
and reloads.

## Documentation corrected

The previous text claimed Camoufox "randomises the canvas per browsing context"
and that nothing here could change it. Two things were wrong:

- **The scope was inverted.** What is randomised is image export
  (`toDataURL`/`toBlob`) from a 2D *or* WebGL canvas. Raw readback
  (`getImageData`, `readPixels`) and `measureText` are stable — the old text named
  "2D canvas readback", which is the one part unaffected.
- **The conclusion was wrong**, as above.

The upstream account is now specific and verifiable: `canvas:seed` is declared in
Camoufox's property manifest and emitted by its Python layer, but its C++ config
reader never reads it and no patch implements it; `window.setCanvasSeed()` is
documented upstream but absent from the shipped build while its siblings are
present. Reported as [daijro/camoufox#721](https://github.com/daijro/camoufox/issues/721),
with a reproduction script. A working seed would still be better than the pref —
it would give each profile its own canvas instead of one shared true render.