### PR TITLE
Move a pinned machine onto a newer browser, keeping its hardware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **A pinned machine can move onto a newer browser.** A pin never ages by
+  itself, so a profile created on one Firefox release kept claiming it — and a
+  browser several versions behind is itself unusual, since real machines update.
+  *Update* in the Machine panel replaces only the browser version and keeps the
+  screen, GPU, cores, fonts and noise seeds, which is what a real computer looks
+  like after an update. The profile response now reports `browser_major`,
+  `installed_major` and `browser_outdated`, and the button appears only when the
+  pin is behind. The user agent is resolved for the OS the *pin* describes rather
+  than the profile's setting: the two can disagree, and following the setting put
+  a macOS user agent on Windows hardware.
 - **`stable_canvas`, a per-profile setting.** By default a site sees a different
   canvas each session, which makes a long-lived account look like new hardware
   every visit. Turning this on keeps the canvas reproducible across launches. It

--- a/docs/api.md
+++ b/docs/api.md
@@ -108,6 +108,18 @@ GET  /api/profiles/{id}/stats
 `reset-fingerprint` generates new settings **and drops the pinned machine**, so
 the next launch assigns fresh hardware.
 
+```http
+POST /api/profiles/{id}/refresh-browser
+```
+
+Moves the pinned machine onto the installed browser version, changing only the
+browser: the hardware and the noise seeds are kept. Use it when a profile's pin
+has fallen behind the browser on disk — `fingerprint.browser_outdated` in the
+profile response says when. Returns `400` if the profile has no pin yet.
+
+The response's `fingerprint` summary carries `browser_major`, `installed_major`
+and `browser_outdated` so a client does not have to parse the user agent.
+
 ## Running browsers
 
 ```http

--- a/docs/profile-settings.md
+++ b/docs/profile-settings.md
@@ -79,6 +79,23 @@ contradicts the exit IP is easier to spot than no spoofing at all.
 *Regenerate fingerprint* clears the pin, so the next launch assigns new hardware.
 The pinned values are shown read-only in the profile form.
 
+### Keeping a pin from going stale
+
+A pin never ages by itself. A profile created on Firefox 152 still claims 152 a
+year later, and a browser several releases behind is itself unusual — real
+machines update.
+
+*Update* in the Machine panel (or `POST /api/profiles/{id}/refresh-browser`)
+moves the pin onto the installed browser and changes **only** the browser
+version. Screen, GPU, cores, fonts and the noise seeds stay exactly as they were,
+which is what a real computer looks like after a browser update. The button
+appears only when the pin is behind the browser on disk.
+
+The user agent is resolved for the OS **the pin describes**, taken from its
+`navigator.platform`, not from the profile's OS setting. The two can disagree if
+someone changed the dropdown after the machine was pinned, and following the
+setting would put a macOS browser on Windows hardware.
+
 ## Real device presets
 
 Camoufox bundles fingerprints captured from actual machines — 180 Windows, 67

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,6 +10,9 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
 - Profiles can be created from Camoufox's real device presets.
 - A whole profile — settings, pinned fingerprint and browser data — exports to a
   single archive and imports elsewhere.
+- A profile's pin can be moved onto a newer browser without changing its
+  hardware, so a long-lived profile does not keep advertising the version it was
+  created with.
 - The web UI covers the product: creating profiles, groups, and a settings screen
   reporting how the instance is configured.
 
@@ -25,8 +28,6 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
 - Warn when a profile's timezone contradicts its proxy's country — the mismatch
   the pinned-fingerprint work deliberately avoids creating, but which a user can
   still configure by hand.
-- Keep the pinned machine coherent when the operating system changes, instead of
-  asking the user to regenerate.
 - Authentication for multi-user or hosted deployments, beyond the optional API key.
 - Task scheduling and automated fingerprint rotation.
 - Windows App-Bound Encryption support for the Chrome-migration module.

--- a/src/camoufox_pm/api/routes/profiles.py
+++ b/src/camoufox_pm/api/routes/profiles.py
@@ -380,6 +380,33 @@ async def get_profile_stats(profile_id: str):
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
+@router.post(
+    "/profiles/{profile_id}/refresh-browser",
+    response_model=ProfileResponse,
+    summary="Refresh the browser version",
+    description=(
+        "Move the profile's pinned machine onto the installed browser version, "
+        "keeping its hardware. A pin never ages on its own, and a browser several "
+        "releases behind is itself unusual."
+    ),
+)
+async def refresh_browser_version(profile_id: str):
+    """Update only the browser-version part of a profile's pinned fingerprint."""
+    try:
+        profile_manager = get_profile_manager()
+        profile = await profile_manager.refresh_browser_version(profile_id)
+        if not profile:
+            raise HTTPException(status_code=404, detail=f"Profile with ID {profile_id} not found")
+        return ProfileResponse.from_profile(profile)
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error(f"Failed to refresh the browser version for {profile_id}: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
 @router.get(
     "/profiles/{profile_id}/export",
     summary="Export a profile",

--- a/src/camoufox_pm/core/fingerprint_store.py
+++ b/src/camoufox_pm/core/fingerprint_store.py
@@ -17,6 +17,7 @@ that is trivial to detect and worse than no spoofing at all.
 """
 
 import json
+import re
 from functools import lru_cache
 from typing import Any
 
@@ -54,6 +55,24 @@ _NEVER_FROZEN = frozenset(
         "addons",
     }
 )
+
+
+# Values that describe the browser *build* rather than the machine it runs on.
+# A real computer updates its browser while staying the same computer, so these
+# are the only parts a version refresh replaces. Everything else in the pin —
+# GPU, screen, cores, fonts, noise seeds — is the device and must survive.
+#
+# Only navigator.userAgent carries the version in Camoufox 152 (the HTTP
+# User-Agent header is derived from it, so freezing one keeps both in step, and
+# navigator.buildID is not emitted). buildID is listed for when it is.
+_BROWSER_VERSION_KEYS = frozenset(
+    {
+        "navigator.userAgent",
+        "navigator.buildID",
+    }
+)
+
+_UA_VERSION = re.compile(r"rv:(\d+)")
 
 
 def freeze(resolved: dict[str, Any]) -> dict[str, Any]:
@@ -164,6 +183,85 @@ def _presets() -> dict[str, list[dict[str, Any]]]:
         return {}
 
 
+# navigator.platform is the pin's own statement of which OS it is, independent of
+# whatever the profile's settings currently say.
+_PLATFORM_OS = {
+    "Win32": "windows",
+    "Win64": "windows",
+    "MacIntel": "macos",
+    "Linux x86_64": "linux",
+    "Linux i686": "linux",
+}
+
+
+def pinned_os(fingerprint: dict[str, Any] | None) -> str | None:
+    """The operating system a pinned fingerprint describes.
+
+    Read from the pin rather than the profile's settings, which can disagree with
+    it: someone may change the OS dropdown long after the machine was pinned.
+    Resolving a new user agent from the settings in that case would put a macOS
+    browser on Windows hardware.
+    """
+    if not fingerprint:
+        return None
+    platform = str(fingerprint.get("navigator.platform", ""))
+    if platform in _PLATFORM_OS:
+        return _PLATFORM_OS[platform]
+    oscpu = str(fingerprint.get("navigator.oscpu", "")).lower()
+    for needle, name in (("windows", "windows"), ("mac", "macos"), ("linux", "linux")):
+        if needle in oscpu:
+            return name
+    return None
+
+
+def browser_major(fingerprint: dict[str, Any] | None) -> int | None:
+    """The Firefox major version a pinned fingerprint claims, from its user agent."""
+    if not fingerprint:
+        return None
+    match = _UA_VERSION.search(str(fingerprint.get("navigator.userAgent", "")))
+    return int(match.group(1)) if match else None
+
+
+def installed_major() -> int | None:
+    """The Firefox major version of the browser on disk."""
+    try:
+        from camoufox.pkgman import installed_verstr
+
+        match = re.match(r"(\d+)", installed_verstr())
+        return int(match.group(1)) if match else None
+    except Exception:  # noqa: BLE001 - the browser may not be installed
+        return None
+
+
+def is_outdated(fingerprint: dict[str, Any] | None) -> bool:
+    """Whether a pin claims an older browser than the one now installed.
+
+    A pinned fingerprint never ages on its own, so a profile kept for months
+    keeps advertising the version it was created with. Real machines update, and
+    a browser several releases behind is itself unusual enough to notice.
+    """
+    pinned = browser_major(fingerprint)
+    current = installed_major()
+    return pinned is not None and current is not None and pinned < current
+
+
+def refresh_browser_version(pinned: dict[str, Any], resolved: dict[str, Any]) -> dict[str, Any]:
+    """Move a pin onto a newer browser without changing the machine.
+
+    Takes the browser-version values from ``resolved`` and keeps everything else
+    from ``pinned``, which is what a real device looks like after an update: same
+    GPU, screen, cores, fonts and noise seeds; newer user agent.
+    """
+    updated = dict(pinned)
+    for key in _BROWSER_VERSION_KEYS:
+        if key in resolved:
+            updated[key] = resolved[key]
+        else:
+            # The new build no longer emits it; a stale value would be worse.
+            updated.pop(key, None)
+    return updated
+
+
 def can_resolve() -> bool:
     """Whether a fingerprint can be resolved right now.
 
@@ -251,4 +349,8 @@ def summarize(fingerprint: dict[str, Any] | None) -> dict[str, Any] | None:
         "gpu": fingerprint.get("webGl:renderer"),
         "font_count": len(fonts) if isinstance(fonts, list) else None,
         "property_count": len(fingerprint),
+        # So the UI can offer an update without re-deriving this itself.
+        "browser_major": browser_major(fingerprint),
+        "installed_major": installed_major(),
+        "browser_outdated": is_outdated(fingerprint),
     }

--- a/src/camoufox_pm/core/models.py
+++ b/src/camoufox_pm/core/models.py
@@ -150,8 +150,10 @@ class BrowserSettings(BaseModel):
             config["navigator.hardwareConcurrency"] = self.hardware_concurrency
         if self.max_touch_points:
             config["navigator.maxTouchPoints"] = self.max_touch_points
-        # Camoufox only exposes the public ICE address (webrtc:ipv4/ipv6); there is
-        # no local-IP config key, so webrtc_local_ips is intentionally not emitted.
+        # webrtc_local_ips is intentionally not emitted. Camoufox does have a
+        # webrtc:localipv4 key, but setting it replaces the mDNS candidate a real
+        # Firefox sends with a literal address — and Camoufox's own default there
+        # is the bogon 240.0.0.2. Leaving it alone keeps the real behaviour.
         if self.webrtc_public_ip:
             config["webrtc:ipv4"] = self.webrtc_public_ip
         return config

--- a/src/camoufox_pm/core/profile_manager.py
+++ b/src/camoufox_pm/core/profile_manager.py
@@ -507,6 +507,56 @@ class ProfileManager:
 
         return success
 
+    async def refresh_browser_version(self, profile_id: str) -> Profile | None:
+        """Move a profile's pinned machine onto the installed browser version.
+
+        A pin never ages: a profile kept for months keeps advertising the browser
+        it was created with, and a version several releases behind is itself
+        unusual. This replaces only the browser-version part of the pin and keeps
+        the hardware, which is what a real computer looks like after an update.
+        """
+        profile = await self.get_profile(profile_id)
+        if not profile:
+            return None
+        if not profile.fingerprint:
+            # Nothing pinned yet, so there is nothing to age. The first launch
+            # will resolve against the current browser anyway.
+            raise ValueError("This profile has no pinned machine yet; launch it once first.")
+
+        # Resolve for the OS the *pin* describes, not the profile's current
+        # setting. The two can disagree — someone may have changed the OS dropdown
+        # after the machine was pinned — and taking the user agent from the
+        # setting would then put, say, a macOS browser on Windows hardware.
+        options = profile.to_camoufox_launch_options()
+        pinned_os = fingerprint_store.pinned_os(profile.fingerprint)
+        if pinned_os:
+            options["os"] = pinned_os
+
+        resolved = fingerprint_store.resolve(options)
+        if not resolved:
+            raise ValueError(
+                "Could not read the installed browser to refresh from. "
+                "Check that Camoufox is installed ('camoufox fetch')."
+            )
+
+        before = fingerprint_store.browser_major(profile.fingerprint)
+        profile.fingerprint = fingerprint_store.refresh_browser_version(
+            profile.fingerprint, resolved
+        )
+        after = fingerprint_store.browser_major(profile.fingerprint)
+        profile.updated_at = datetime.now()
+        await self.storage.update_profile(profile)
+
+        await self.storage.log_usage(
+            UsageStats(
+                profile_id=profile_id,
+                action="refresh_browser_version",
+                details={"from": before, "to": after},
+            )
+        )
+        logger.info(f"Profile {profile_id} browser version refreshed: {before} -> {after}")
+        return profile
+
     # -- Portability --------------------------------------------------------
 
     async def export_profile(self, profile_id: str, destination: Path) -> Path:

--- a/tests/browser/test_fingerprint_stability.py
+++ b/tests/browser/test_fingerprint_stability.py
@@ -197,6 +197,95 @@ async def test_stable_canvas_is_linkable_across_sites(tmp_path):
 
 @pytest.mark.browser
 @pytest.mark.asyncio
+async def test_refreshing_the_browser_version_keeps_the_device(tmp_path):
+    """A profile can move onto the installed browser and stay the same computer.
+
+    Simulates a profile pinned months ago on an older release, then refreshed
+    against the browser actually on disk. What a page sees afterwards must be the
+    old device with the current browser.
+    """
+    profile = Profile(name="ageing", browser_settings=BrowserSettings(os="windows"))
+    profile.fingerprint = fingerprint_store.resolve(profile.to_camoufox_launch_options())
+    assert profile.fingerprint
+
+    before = await observe(pinned_options(profile), tmp_path / "before")
+
+    # Age the pin: an older browser, same hardware.
+    aged = dict(profile.fingerprint)
+    aged["navigator.userAgent"] = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:100.0) Gecko/20100101 Firefox/100.0"
+    )
+    profile.fingerprint = aged
+    assert fingerprint_store.is_outdated(profile.fingerprint)
+
+    stale = await observe(pinned_options(profile), tmp_path / "stale")
+    assert "rv:100.0" in stale["userAgent"], "the aged pin should be what the page sees"
+
+    profile.fingerprint = fingerprint_store.refresh_browser_version(
+        profile.fingerprint,
+        fingerprint_store.resolve(profile.to_camoufox_launch_options()),
+    )
+    after = await observe(pinned_options(profile), tmp_path / "after")
+
+    assert not fingerprint_store.is_outdated(profile.fingerprint)
+    assert after["userAgent"] == before["userAgent"], "back on the installed version"
+    # The device is untouched, which is the point.
+    for key in ("screen", "cores", "gpu", "platform"):
+        assert after[key] == before[key], f"{key} changed across a version refresh"
+
+
+@pytest.mark.browser
+@pytest.mark.asyncio
+async def test_refreshing_follows_the_pinned_os_not_the_settings(tmp_path):
+    """The refreshed user agent must match the hardware, not a drifted setting.
+
+    Regression: a Windows pin on a profile whose OS setting had been changed to
+    macOS came back with a macOS user agent while still reporting Win32 and an
+    ANGLE Direct3D11 GPU — a Mac browser on a Windows machine.
+    """
+    profile = Profile(name="drifted", browser_settings=BrowserSettings(os="windows"))
+    profile.fingerprint = fingerprint_store.resolve(profile.to_camoufox_launch_options())
+    assert profile.fingerprint
+    assert fingerprint_store.pinned_os(profile.fingerprint) == "windows"
+
+    # The setting drifts away from the pinned machine.
+    profile.browser_settings.os = "macos"
+
+    options = profile.to_camoufox_launch_options()
+    options["os"] = fingerprint_store.pinned_os(profile.fingerprint)
+    profile.fingerprint = fingerprint_store.refresh_browser_version(
+        profile.fingerprint, fingerprint_store.resolve(options)
+    )
+
+    seen = await observe(pinned_options(profile), tmp_path / "drift")
+    assert "Windows" in seen["userAgent"], f"user agent left the pinned OS: {seen['userAgent']}"
+    assert seen["platform"] == "Win32"
+
+
+@pytest.mark.browser
+@pytest.mark.asyncio
+async def test_refreshing_keeps_the_canvas_identical(tmp_path):
+    """The seeds must survive a refresh, or the canvas silently changes."""
+    profile = Profile(
+        name="refresh-canvas",
+        browser_settings=BrowserSettings(os="windows", stable_canvas=True),
+    )
+    profile.fingerprint = fingerprint_store.resolve(profile.to_camoufox_launch_options())
+    assert profile.fingerprint
+
+    before = await read_canvas(pinned_options(profile), tmp_path / "c1", "https://example.com")
+
+    profile.fingerprint = fingerprint_store.refresh_browser_version(
+        profile.fingerprint,
+        fingerprint_store.resolve(profile.to_camoufox_launch_options()),
+    )
+    after = await read_canvas(pinned_options(profile), tmp_path / "c2", "https://example.com")
+
+    assert before == after, "a version refresh must not move the canvas"
+
+
+@pytest.mark.browser
+@pytest.mark.asyncio
 async def test_profile_overrides_still_win_over_the_pin(tmp_path):
     """A pinned machine must not freeze out the user's own settings."""
     profile = Profile(

--- a/tests/integration/test_api_profiles.py
+++ b/tests/integration/test_api_profiles.py
@@ -398,6 +398,91 @@ async def test_unknown_preset_is_rejected(client):
     assert "preset" in response.json()["detail"].lower()
 
 
+STALE_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:100.0) Gecko/20100101 Firefox/100.0"
+FRESH_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:199.0) Gecko/20100101 Firefox/199.0"
+
+
+@pytest.mark.asyncio
+async def test_refresh_browser_version_keeps_the_machine(client, monkeypatch):
+    """A pin must be able to move to a newer browser without changing device.
+
+    A pin never ages on its own, so a profile kept for months keeps advertising
+    the browser it was created with — and a browser several releases behind is
+    itself unusual enough to notice.
+
+    ``resolve`` is stubbed so this covers the wiring without needing the browser
+    binary; ``tests/browser`` exercises it against a real Camoufox.
+    """
+    from camoufox_pm.api.dependencies import get_profile_manager
+
+    # A newly resolved fingerprint describes a completely different machine.
+    monkeypatch.setattr(
+        fingerprint_store,
+        "resolve",
+        lambda *a, **k: {
+            "navigator.userAgent": FRESH_UA,
+            "navigator.hardwareConcurrency": 2,
+            "screen.width": 800,
+            "screen.height": 600,
+            "webGl:renderer": "ANGLE (Intel, Intel(R) HD Graphics)",
+            "canvas:seed": 999999,
+            "fonts:spacing_seed": 5,
+        },
+    )
+    monkeypatch.setattr(fingerprint_store, "installed_major", lambda: 199)
+
+    created = await client.post("/api/profiles", json={"name": "ageing"})
+    profile_id = created.json()["id"]
+
+    manager = get_profile_manager()
+    profile = await manager.get_profile(profile_id)
+    # A pin as it would look after months on an older release.
+    profile.fingerprint = {
+        "navigator.userAgent": STALE_UA,
+        "navigator.hardwareConcurrency": 12,
+        "screen.width": 2560,
+        "screen.height": 1440,
+        "webGl:renderer": "ANGLE (NVIDIA, GeForce GTX 980)",
+        "canvas:seed": 424242,
+        "fonts:spacing_seed": 777,
+    }
+    await manager.storage.update_profile(profile)
+
+    stale = (await client.get(f"/api/profiles/{profile_id}")).json()["fingerprint"]
+    assert stale["browser_major"] == 100
+    assert stale["browser_outdated"] is True
+
+    response = await client.post(f"/api/profiles/{profile_id}/refresh-browser")
+    assert response.status_code == 200
+    refreshed = response.json()["fingerprint"]
+
+    assert refreshed["browser_major"] == 199, "the browser should have moved forward"
+    assert refreshed["browser_outdated"] is False
+    # The device is unchanged.
+    assert refreshed["screen"] == "2560x1440"
+    assert refreshed["hardware_concurrency"] == 12
+    assert refreshed["gpu"] == "ANGLE (NVIDIA, GeForce GTX 980)"
+
+    stored = await manager.get_profile(profile_id)
+    assert stored.fingerprint["canvas:seed"] == 424242, "changing the seed would alter the canvas"
+    assert stored.fingerprint["fonts:spacing_seed"] == 777
+
+
+@pytest.mark.asyncio
+async def test_refresh_browser_version_needs_a_pin_first(client):
+    """Refreshing an unpinned profile would silently invent a machine."""
+    created = await client.post("/api/profiles", json={"name": "unpinned"})
+    response = await client.post(f"/api/profiles/{created.json()['id']}/refresh-browser")
+    assert response.status_code == 400
+    assert "launch it once" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_browser_version_on_a_missing_profile_is_404(client):
+    response = await client.post("/api/profiles/does-not-exist/refresh-browser")
+    assert response.status_code == 404
+
+
 @pytest.mark.asyncio
 async def test_fingerprint_is_absent_until_the_first_launch(client):
     """A profile has no pinned machine until it is opened for the first time."""

--- a/tests/unit/test_fingerprint_store.py
+++ b/tests/unit/test_fingerprint_store.py
@@ -102,6 +102,118 @@ def test_summarize_without_a_pin():
     assert fingerprint_store.summarize({}) is None
 
 
+UA_OLD = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:149.0) Gecko/20100101 Firefox/149.0"
+UA_NEW = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:152.0) Gecko/20100101 Firefox/152.0"
+
+
+def test_browser_major_reads_the_version_from_the_user_agent():
+    assert fingerprint_store.browser_major({"navigator.userAgent": UA_OLD}) == 149
+    assert fingerprint_store.browser_major({"navigator.userAgent": "nonsense"}) is None
+    assert fingerprint_store.browser_major({}) is None
+    assert fingerprint_store.browser_major(None) is None
+
+
+def test_is_outdated_compares_against_the_installed_browser(monkeypatch):
+    monkeypatch.setattr(fingerprint_store, "installed_major", lambda: 152)
+    assert fingerprint_store.is_outdated({"navigator.userAgent": UA_OLD}) is True
+    assert fingerprint_store.is_outdated({"navigator.userAgent": UA_NEW}) is False
+    # Never claim staleness without both numbers.
+    assert fingerprint_store.is_outdated(None) is False
+    monkeypatch.setattr(fingerprint_store, "installed_major", lambda: None)
+    assert fingerprint_store.is_outdated({"navigator.userAgent": UA_OLD}) is False
+
+
+def test_refresh_replaces_the_browser_but_keeps_the_machine():
+    """The whole point: same computer, newer browser."""
+    pinned = {
+        "navigator.userAgent": UA_OLD,
+        "navigator.hardwareConcurrency": 12,
+        "navigator.platform": "Win32",
+        "navigator.oscpu": "Windows NT 10.0; Win64; x64",
+        "screen.width": 2560,
+        "screen.height": 1440,
+        "webGl:renderer": "ANGLE (NVIDIA, GeForce GTX 980)",
+        "webGl:vendor": "Google Inc. (NVIDIA)",
+        "canvas:seed": 424242,
+        "audio:seed": 111,
+        "fonts": ["Arial", "Calibri"],
+        "fonts:spacing_seed": 777,
+    }
+    # A newly resolved fingerprint describes a *different* machine entirely.
+    resolved = {
+        "navigator.userAgent": UA_NEW,
+        "navigator.hardwareConcurrency": 4,
+        "screen.width": 1366,
+        "screen.height": 768,
+        "webGl:renderer": "ANGLE (Intel, Intel(R) HD Graphics)",
+        "canvas:seed": 999999,
+        "fonts": ["Segoe UI"],
+        "fonts:spacing_seed": 5,
+    }
+
+    updated = fingerprint_store.refresh_browser_version(pinned, resolved)
+
+    assert updated["navigator.userAgent"] == UA_NEW, "the browser must move forward"
+    # Everything that makes it this device must be untouched — especially the
+    # seeds, since changing one would alter the canvas the profile presents.
+    for key in (
+        "navigator.hardwareConcurrency",
+        "navigator.platform",
+        "navigator.oscpu",
+        "screen.width",
+        "screen.height",
+        "webGl:renderer",
+        "webGl:vendor",
+        "canvas:seed",
+        "audio:seed",
+        "fonts",
+        "fonts:spacing_seed",
+    ):
+        assert updated[key] == pinned[key], f"{key} is the machine and must survive"
+
+
+def test_refresh_does_not_mutate_the_stored_pin():
+    pinned = {"navigator.userAgent": UA_OLD, "screen.width": 2560}
+    fingerprint_store.refresh_browser_version(pinned, {"navigator.userAgent": UA_NEW})
+    assert pinned["navigator.userAgent"] == UA_OLD
+
+
+def test_refresh_drops_a_version_key_the_new_build_stopped_emitting():
+    """A stale buildID would be worse than none at all."""
+    pinned = {"navigator.userAgent": UA_OLD, "navigator.buildID": "20240101000000"}
+    updated = fingerprint_store.refresh_browser_version(pinned, {"navigator.userAgent": UA_NEW})
+    assert "navigator.buildID" not in updated
+
+
+def test_summary_reports_the_version_and_whether_it_is_behind(monkeypatch):
+    monkeypatch.setattr(fingerprint_store, "installed_major", lambda: 152)
+    summary = fingerprint_store.summarize({"navigator.userAgent": UA_OLD, "screen.width": 800})
+    assert summary["browser_major"] == 149
+    assert summary["installed_major"] == 152
+    assert summary["browser_outdated"] is True
+
+
+def test_pinned_os_is_read_from_the_pin_not_the_settings():
+    """A refresh must resolve for the OS the pin describes.
+
+    Regression: refreshing a Windows pin on a profile whose settings had drifted
+    to macOS produced a macOS user agent on Windows hardware — a Mac browser
+    reporting Win32 and an ANGLE Direct3D11 GPU.
+    """
+    assert fingerprint_store.pinned_os({"navigator.platform": "Win32"}) == "windows"
+    assert fingerprint_store.pinned_os({"navigator.platform": "MacIntel"}) == "macos"
+    assert fingerprint_store.pinned_os({"navigator.platform": "Linux x86_64"}) == "linux"
+    # Falls back to oscpu when the platform string is unfamiliar.
+    assert (
+        fingerprint_store.pinned_os(
+            {"navigator.platform": "Weird", "navigator.oscpu": "Windows NT 10.0; Win64; x64"}
+        )
+        == "windows"
+    )
+    assert fingerprint_store.pinned_os({}) is None
+    assert fingerprint_store.pinned_os(None) is None
+
+
 def test_get_preset_rejects_malformed_ids():
     """Only a plain run of ASCII digits names a preset.
 

--- a/web/src/components/profile-form.tsx
+++ b/web/src/components/profile-form.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { Loader2, RefreshCw } from 'lucide-react'
+import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
 
 import { Modal } from '@/components/modal'
 import { useToast } from '@/components/toast'
@@ -101,6 +101,11 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
   const [form, setForm] = useState<FormState>(EMPTY)
   const [saving, setSaving] = useState(false)
   const [regenerating, setRegenerating] = useState(false)
+  const [refreshingBrowser, setRefreshingBrowser] = useState(false)
+  // The `profile` prop is a snapshot from the list; regenerating or updating the
+  // browser returns a new machine, and the panel has to show it without waiting
+  // for the dialog to be reopened.
+  const [machine, setMachine] = useState<FingerprintSummary | null | undefined>(undefined)
   const [presets, setPresets] = useState<DevicePreset[]>([])
   const [presetId, setPresetId] = useState('')
   const toast = useToast()
@@ -108,6 +113,7 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
   useEffect(() => {
     if (open) {
       setForm(profile ? fromProfile(profile) : EMPTY)
+      setMachine(profile?.fingerprint)
       setPresetId('')
     }
   }, [open, profile])
@@ -223,12 +229,32 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
     }
   }
 
+  async function handleRefreshBrowser() {
+    if (!profile) return
+    setRefreshingBrowser(true)
+    try {
+      const updated = await profilesAPI.refreshBrowserVersion(profile.id)
+      setMachine(updated.fingerprint)
+      toast(
+        'ok',
+        `Browser updated to Firefox ${updated.fingerprint?.browser_major}`,
+        'The machine is unchanged.',
+      )
+      onSaved()
+    } catch (err) {
+      toast('error', 'Could not update the browser version', String(err))
+    } finally {
+      setRefreshingBrowser(false)
+    }
+  }
+
   async function handleRegenerate() {
     if (!profile) return
     setRegenerating(true)
     try {
       const updated = await profilesAPI.resetFingerprint(profile.id)
       setForm(fromProfile(updated))
+      setMachine(updated.fingerprint)
       toast('ok', 'Fingerprint regenerated')
       onSaved()
     } catch (err) {
@@ -437,7 +463,11 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
         </Section>
 
         {isEdit ? (
-          <PinnedMachine fingerprint={profile.fingerprint} />
+          <PinnedMachine
+            fingerprint={machine}
+            onRefreshBrowser={handleRefreshBrowser}
+            refreshing={refreshingBrowser}
+          />
         ) : (
           <fieldset>
             <legend className="mb-0.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-ink-faint">
@@ -651,7 +681,15 @@ function shortGpu(gpu?: string | null): string {
  * The machine a profile is pinned to. Without this the profile would look like
  * different hardware every session, so it is worth showing that it does not.
  */
-function PinnedMachine({ fingerprint }: { fingerprint?: FingerprintSummary | null }) {
+function PinnedMachine({
+  fingerprint,
+  onRefreshBrowser,
+  refreshing,
+}: {
+  fingerprint?: FingerprintSummary | null
+  onRefreshBrowser: () => void
+  refreshing: boolean
+}) {
   if (!fingerprint) {
     return (
       <fieldset>
@@ -667,11 +705,12 @@ function PinnedMachine({ fingerprint }: { fingerprint?: FingerprintSummary | nul
   }
 
   const rows: [string, string | number | null | undefined][] = [
-    ['User agent', fingerprint.user_agent],
+    ['Browser', fingerprint.browser_major ? `Firefox ${fingerprint.browser_major}` : null],
     ['Screen', fingerprint.screen],
     ['CPU cores', fingerprint.hardware_concurrency],
     ['GPU', fingerprint.gpu],
     ['Fonts', fingerprint.font_count],
+    ['User agent', fingerprint.user_agent],
   ]
 
   return (
@@ -693,6 +732,34 @@ function PinnedMachine({ fingerprint }: { fingerprint?: FingerprintSummary | nul
             </div>
           ))}
       </div>
+
+      {/* A pin never ages by itself. A profile kept for months keeps claiming the
+          browser it was created with, and a version well behind is itself odd —
+          so offer the update a real machine would have taken. */}
+      {fingerprint.browser_outdated && (
+        <div className="mt-2 flex items-start gap-2.5 rounded-md border border-line bg-raised p-2.5">
+          <AlertTriangle size={14} className="mt-0.5 shrink-0 text-signal" />
+          <div className="flex-1">
+            <p className="text-ink">
+              This profile still reports Firefox {fingerprint.browser_major}; the installed browser
+              is {fingerprint.installed_major}.
+            </p>
+            <p className="mt-0.5 text-ink-faint">
+              Updating changes only the browser version. The screen, GPU, cores, fonts and canvas
+              stay exactly as they are — the same computer, with its browser updated.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="btn btn-default shrink-0"
+            onClick={onRefreshBrowser}
+            disabled={refreshing}
+          >
+            {refreshing && <Loader2 size={13} className="animate-spin" />}
+            Update
+          </button>
+        </div>
+      )}
     </fieldset>
   )
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -49,6 +49,12 @@ export interface FingerprintSummary {
   gpu?: string | null
   font_count?: number | null
   property_count?: number
+  /** Firefox major version this pin claims. */
+  browser_major?: number | null
+  /** Firefox major version of the browser on disk. */
+  installed_major?: number | null
+  /** The pin claims an older browser than the one installed. */
+  browser_outdated?: boolean
 }
 
 export interface Profile {
@@ -191,6 +197,10 @@ export const profilesAPI = {
 
   resetFingerprint(id: string): Promise<Profile> {
     return request<Profile>(`/api/profiles/${id}/reset-fingerprint`, { method: 'POST' })
+  },
+
+  refreshBrowserVersion(id: string): Promise<Profile> {
+    return request<Profile>(`/api/profiles/${id}/refresh-browser`, { method: 'POST' })
   },
 
   async exportExcel(): Promise<Blob> {


### PR DESCRIPTION
## Why

Pinning gave a profile one machine for life. It also froze the browser version:
a profile created on Firefox 152 still claims 152 a year from now, and a browser
several releases behind is itself unusual — real machines update. That was the
last long-term signal left after the pinning work, and the one thing commercial
antidetect browsers do that we did not.

## What

**Update** in the Machine panel (`POST /api/profiles/{id}/refresh-browser`) moves
the pin onto the installed browser and changes **only** the browser version.
Screen, GPU, cores, fonts and the noise seeds are kept — which is exactly what a
real computer looks like after a browser update.

- The button appears only when the pin is behind the browser on disk.
- The profile response now carries `browser_major`, `installed_major` and
  `browser_outdated`, so a client never has to parse a user agent.
- The user agent is resolved for the OS **the pin describes**, read from its
  `navigator.platform` — not from the profile's OS setting.

That last point is a bug this PR found and fixes. The two can disagree if someone
changes the OS dropdown after the machine was pinned, and resolving from the
setting produced `Macintosh; Intel Mac OS X 10.15` on hardware still reporting
`Win32` and an ANGLE Direct3D11 GPU. A Mac browser on a Windows machine is worse
than a stale version.

## Verified in the running app

A profile with a planted outdated pin (`rv:100.0`, Win32, 12 cores, 2560x1440,
GTX 980, `canvas:seed 424242`):

- the API reported `browser: Firefox 100 | installed: 152 | outdated: True`
- the UI showed "This profile still reports Firefox 100; the installed browser is
  152" with an Update button
- clicking it returned "Browser updated to Firefox 152 / The machine is
  unchanged", the warning disappeared
- the user agent came back **Windows**, and every hardware value and seed was
  byte-identical

## Tests

- `tests/unit/test_fingerprint_store.py` — `pinned_os` from platform and from
  `oscpu`, version parsing, outdated detection, refresh keeping every non-version
  key, and the OS-drift regression named in its docstring
- `tests/browser/test_fingerprint_stability.py` — three new real-browser tests:
  the device survives a refresh, the refreshed UA follows the pinned OS, and the
  canvas does not move

`ruff`, `mypy`, 97 unit/integration tests and all 18 browser tests pass.

## Docs

`docs/profile-settings.md` (why a pin goes stale and what refresh does),
`docs/api.md` (the endpoint), `docs/roadmap.md`, `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)