### PR TITLE
Check a proxy, and whether the profile agrees with it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,9 @@ name: CI
 on:
   push:
     branches: [main]
+  # Every pull request, not only those targeting main: a PR stacked on another
+  # branch got no checks at all, which is when review needs them most.
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **Check a proxy, and what it says about the profile.** *Check proxy* — in the
+  form and in a profile's row menu — reaches the internet through the proxy and
+  reports where it comes out, how long it took, and everything a page could
+  notice: a timezone on a different clock from the exit country, coordinates far
+  from it, or SOCKS credentials Firefox will refuse to send. The form checks what
+  is on screen, so a proxy can be tested and a mismatch fixed before saving.
+  `POST /api/profiles/{id}/check-proxy` and `POST /api/proxy/check`.
 - **A pinned machine can move onto a newer browser.** A pin never ages by
   itself, so a profile created on one Firefox release kept claiming it — and a
   browser several versions behind is itself unusual, since real machines update.
@@ -97,6 +104,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   and it was mounted without the API-key guard.
 
 ### Fixed
+- **A new profile no longer picks a random country.** Every generated profile got
+  a timezone, coordinates and languages from a randomly chosen region, so a fresh
+  profile might claim Shanghai and then be given a German proxy — the manager was
+  manufacturing the contradiction it exists to avoid. Geography is now left unset
+  and follows the proxy; a region can still be asked for explicitly.
+- **Coordinates no longer leak the host machine's timezone.** Setting coordinates
+  turns Camoufox's IP lookup off, which is the only way it keeps them — and that
+  same branch is what fills the timezone and the WebRTC address. Both were left
+  unset, so Firefox fell back to this computer's own zone: a profile with Tokyo
+  coordinates reported `Europe/Moscow`. The launch path now fills them from the
+  same exit address and database Camoufox would have used. Verified in a real
+  browser.
 - **Profiles created from the UI had an incomplete fingerprint.** Blank optional
   fields were sent as explicit nulls, which cleared the generated timezone,
   geolocation and CPU count — leaving exactly the kind of inconsistency this

--- a/docs/api.md
+++ b/docs/api.md
@@ -120,6 +120,23 @@ profile response says when. Returns `400` if the profile has no pin yet.
 The response's `fingerprint` summary carries `browser_major`, `installed_major`
 and `browser_outdated` so a client does not have to parse the user agent.
 
+## Checking a proxy
+
+```http
+POST /api/profiles/{id}/check-proxy
+POST /api/proxy/check      {"proxy_config": {...}, "browser_settings": {...}}
+```
+
+Both reach the internet through the proxy and return the same shape: `reachable`,
+`error`, `latency_ms`, the `location` it comes out at (`ip`, `country`,
+`timezone`, `latitude`, `longitude`) and a list of `findings`, each with a
+`level` of `error`, `warning` or `info`, the `field` it concerns and a message.
+
+A proxy that does not answer is reported with `reachable: false` and an `error`,
+not raised as a 5xx. The second form takes an unsaved proxy, which is what the
+profile form uses so a proxy can be checked before the profile exists; omit
+`proxy_config` to check the direct connection.
+
 ## Running browsers
 
 ```http

--- a/docs/profile-settings.md
+++ b/docs/profile-settings.md
@@ -96,6 +96,41 @@ The user agent is resolved for the OS **the pin describes**, taken from its
 someone changed the dropdown after the machine was pinned, and following the
 setting would put a macOS browser on Windows hardware.
 
+## Where the profile appears to be
+
+A pinned machine keeps the hardware honest. Geography is the other half, and it
+is deliberately **not** pinned: a profile that keeps a Berlin timezone after
+moving to a Tokyo proxy contradicts itself in a way any page can measure with two
+lines of JavaScript.
+
+So a new profile is created without a timezone and without coordinates, and
+Camoufox derives both — plus the WebRTC address — from where the proxy comes out.
+Set either field only when you want to override that.
+
+Setting **coordinates** is the exception worth understanding. Camoufox overwrites
+the geolocation keys from the exit address whenever its IP lookup is on, so the
+only way to keep coordinates is to turn that lookup off — and the same branch is
+what fills the timezone and the WebRTC address. This manager therefore fills
+those two itself, from the same address and the same database Camoufox would have
+used. Without that, Firefox falls back to *this computer's* timezone: measured,
+a profile with Tokyo coordinates reported `Europe/Moscow`, the host's own zone.
+
+### Checking a proxy
+
+*Check proxy* in the profile form (and in a profile's row menu) reaches the
+internet through the proxy and reports the address it comes out at, the country
+and timezone that address resolves to, and the round trip. It then lists anything
+a page could notice:
+
+| Reported as | When |
+| --- | --- |
+| Error | The profile cannot launch at all — SOCKS with credentials, which Firefox refuses |
+| Warning | A page can see the contradiction: a timezone on a different clock, or coordinates more than 500 km from the exit |
+| Note | Worth knowing, not detectable as a conflict: a different zone name on the same clock, or coordinates in a nearby city |
+
+The check reads the form as it is on screen, so a proxy can be tested — and a
+mismatch fixed and re-tested — before anything is saved.
+
 ## Real device presets
 
 Camoufox bundles fingerprints captured from actual machines — 180 Windows, 67

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,21 +13,18 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
 - A profile's pin can be moved onto a newer browser without changing its
   hardware, so a long-lived profile does not keep advertising the version it was
   created with.
+- A proxy can be checked from the UI: where it comes out, how fast, and whether
+  the profile's timezone and coordinates agree with it.
 - The web UI covers the product: creating profiles, groups, and a settings screen
   reporting how the instance is configured.
 
 ## Now (0.1.x)
 
 - Stabilise the REST API before `1.0`.
-- Proxy testing and health checks in the UI, so a dead proxy is visible before a
-  profile is launched with it.
 - Fill remaining gaps in test coverage.
 
 ## Next
 
-- Warn when a profile's timezone contradicts its proxy's country — the mismatch
-  the pinned-fingerprint work deliberately avoids creating, but which a user can
-  still configure by hand.
 - Authentication for multi-user or hosted deployments, beyond the optional API key.
 - Task scheduling and automated fingerprint rotation.
 - Windows App-Bound Encryption support for the Chrome-migration module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ dependencies = [
     "cryptography>=44.0",
     "loguru>=0.7",
     "psutil>=6.1",
+    # socks so a SOCKS5 proxy can be checked, not only HTTP ones.
+    "httpx[socks]>=0.28",
 ]
 
 [project.optional-dependencies]
@@ -45,7 +47,6 @@ dev = [
     "pytest>=8.3",
     "pytest-asyncio>=0.24",
     "pytest-cov>=6.0",
-    "httpx>=0.28",
     "ruff>=0.8",
     "mypy>=1.13",
 ]

--- a/src/camoufox_pm/api/models/profiles.py
+++ b/src/camoufox_pm/api/models/profiles.py
@@ -1,11 +1,13 @@
 """API models for profile endpoints."""
 
+from dataclasses import asdict
 from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from camoufox_pm.core.models import Profile, ProfileStatus
+from camoufox_pm.core.proxy_check import ProxyCheckResult
 
 
 class ProfileCreateRequest(BaseModel):
@@ -211,3 +213,63 @@ class ProfileLaunchResponse(BaseModel):
     status: str
     message: str
     camoufox_options: dict[str, Any]
+
+
+class ProxyCheckRequest(BaseModel):
+    """Request body for checking a proxy that is not saved yet."""
+
+    proxy_config: dict[str, Any] | None = Field(
+        None, description="Proxy to check. Omit to check the direct connection."
+    )
+    browser_settings: dict[str, Any] | None = Field(
+        None, description="Settings to compare against the exit address"
+    )
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "proxy_config": {"type": "http", "server": "proxy.example.com:8080"},
+                "browser_settings": {"timezone": "Europe/Berlin"},
+            }
+        }
+    )
+
+
+class ProxyLocationResponse(BaseModel):
+    """Where a proxy actually comes out."""
+
+    ip: str
+    country: str | None = None
+    timezone: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+
+
+class ProxyFindingResponse(BaseModel):
+    """One thing worth telling the user about this proxy and this profile."""
+
+    level: str = Field(..., description="error, warning or info")
+    field: str = Field(..., description="The setting the finding is about")
+    message: str
+
+
+class ProxyCheckResponse(BaseModel):
+    """The result of reaching the internet through a proxy and comparing it."""
+
+    reachable: bool
+    error: str | None = None
+    latency_ms: int | None = None
+    location: ProxyLocationResponse | None = None
+    findings: list[ProxyFindingResponse] = Field(default_factory=list)
+
+    @classmethod
+    def from_result(cls, result: ProxyCheckResult) -> "ProxyCheckResponse":
+        return cls(
+            reachable=result.reachable,
+            error=result.error,
+            latency_ms=result.latency_ms,
+            location=(
+                ProxyLocationResponse(**asdict(result.location)) if result.location else None
+            ),
+            findings=[ProxyFindingResponse(**asdict(f)) for f in result.findings],
+        )

--- a/src/camoufox_pm/api/routes/profiles.py
+++ b/src/camoufox_pm/api/routes/profiles.py
@@ -26,10 +26,13 @@ from camoufox_pm.api.models.profiles import (
     ProfileResponse,
     ProfileStatsResponse,
     ProfileUpdateRequest,
+    ProxyCheckRequest,
+    ProxyCheckResponse,
 )
 from camoufox_pm.api.models.system import ApiResponse
+from camoufox_pm.core import proxy_check
 from camoufox_pm.core.excel_manager import ExcelManager
-from camoufox_pm.core.models import ProfileStatus
+from camoufox_pm.core.models import BrowserSettings, ProfileStatus, ProxyConfig
 
 router = APIRouter()
 
@@ -343,6 +346,46 @@ async def clone_profile(profile_id: str, request: ProfileCloneRequest):
     except Exception as e:
         logger.error(f"Failed to clone profile {profile_id}: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.post(
+    "/profiles/{profile_id}/check-proxy",
+    response_model=ProxyCheckResponse,
+    summary="Check a profile's proxy",
+    description=(
+        "Reach the internet through the profile's proxy, report where it comes out, "
+        "and list everything a page could notice between that and the profile's settings."
+    ),
+)
+async def check_profile_proxy(profile_id: str):
+    """Check a saved profile's proxy against its settings."""
+    profile = await get_profile_manager().get_profile(profile_id)
+    if not profile:
+        raise HTTPException(status_code=404, detail=f"Profile with ID {profile_id} not found")
+
+    result = await proxy_check.check(profile.proxy, profile.browser_settings)
+    return ProxyCheckResponse.from_result(result)
+
+
+@router.post(
+    "/proxy/check",
+    response_model=ProxyCheckResponse,
+    summary="Check a proxy",
+    description=(
+        "The same check for a proxy that has not been saved yet, so a profile can be "
+        "checked while it is still being filled in."
+    ),
+)
+async def check_proxy(request: ProxyCheckRequest):
+    """Check an unsaved proxy against unsaved settings."""
+    try:
+        proxy = ProxyConfig(**request.proxy_config) if request.proxy_config else None
+        settings = BrowserSettings(**(request.browser_settings or {}))
+    except ValidationError as e:
+        raise HTTPException(status_code=422, detail=e.errors()) from e
+
+    result = await proxy_check.check(proxy, settings)
+    return ProxyCheckResponse.from_result(result)
 
 
 @router.get(

--- a/src/camoufox_pm/core/fingerprint_generator.py
+++ b/src/camoufox_pm/core/fingerprint_generator.py
@@ -91,27 +91,31 @@ class FingerprintGenerator:
             constraints = constraints.model_dump()
 
         os_choice = (constraints or {}).get("os") or random.choice(["windows", "macos", "linux"])
-        region = (constraints or {}).get("region") or random.choice(list(self.language_sets))
+        region = (constraints or {}).get("region")
 
         screen = random.choice(self.os_screen_combinations[os_choice])
-        languages = self.language_sets.get(region, ["en-US", "en"])
-        locale = self.locale_map.get(region, "en_US")
-        timezone = self.timezone_map.get(region, "UTC")
-        geolocation = self._geolocation_for_region(region)
         hardware = random.choice(self.hardware_specs)
-        max_touch_points = 0  # desktop operating systems only
 
-        return BrowserSettings(
+        # A new profile is a machine, not a place. Where it appears to be comes
+        # from its proxy: Camoufox derives the timezone, the coordinates and the
+        # WebRTC address from the exit address, but only for the values a profile
+        # leaves unset. Picking a random country here — as this used to — gave
+        # every new profile a timezone and coordinates that contradicted whatever
+        # proxy it was later given, and coordinates additionally turn the whole
+        # IP lookup off. Geography is pinned only when a region is asked for.
+        settings = BrowserSettings(
             os=os_choice,
             screen=screen,
-            languages=languages,
-            locale=locale,
-            timezone=timezone,
-            geolocation=geolocation,
             hardware_concurrency=hardware["cores"],
             device_memory=hardware["memory"],
-            max_touch_points=max_touch_points,
+            max_touch_points=0,  # desktop operating systems only
         )
+        if region:
+            settings.languages = self.language_sets.get(region, ["en-US", "en"])
+            settings.locale = self.locale_map.get(region, "en_US")
+            settings.timezone = self.timezone_map.get(region, "UTC")
+            settings.geolocation = self._geolocation_for_region(region)
+        return settings
 
     async def reset_fingerprint(self, profile_id: str) -> BrowserSettings:
         """Regenerate a fingerprint from scratch."""

--- a/src/camoufox_pm/core/profile_manager.py
+++ b/src/camoufox_pm/core/profile_manager.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from loguru import logger
 
-from . import fingerprint_store, profile_archive
+from . import fingerprint_store, profile_archive, proxy_check
 from .browser_session import BrowserSessionManager
 from .database import StorageManager
 from .fingerprint_generator import FingerprintGenerator
@@ -676,6 +676,11 @@ class ProfileManager:
                 profile_id=profile_id, action="launch_browser", details={"headless": headless}
             )
         )
+
+        # After the write on purpose: this only touches the launch options, so it
+        # cannot clobber the row, and it is the first await that is allowed to run
+        # between reading the profile and saving it.
+        await proxy_check.fill_what_geoip_would_have(profile.proxy, options)
 
         session = await self.browser_sessions.launch(
             profile_id, options, on_exit=self._on_browser_exit

--- a/src/camoufox_pm/core/proxy_check.py
+++ b/src/camoufox_pm/core/proxy_check.py
@@ -1,0 +1,353 @@
+"""Does what a profile claims match where its proxy actually comes out?
+
+A pinned fingerprint keeps a profile's hardware honest. The parts deliberately
+left dynamic — timezone, coordinates, locale — follow the proxy only as long as
+the profile does not override them. A profile that reports ``Europe/Berlin``
+while its proxy exits in Tokyo contradicts itself in a way any page can measure
+with two lines of JavaScript, and no amount of fingerprint pinning hides it.
+
+This module resolves where a proxy really comes out and compares that with what
+the profile would tell a page.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import ssl
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from math import asin, cos, radians, sin, sqrt
+from typing import Literal
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import httpx
+from loguru import logger
+
+from .models import BrowserSettings, ProxyConfig, ProxyType
+
+Level = Literal["error", "warning", "info"]
+
+# The same endpoints Camoufox asks for the exit address, so a check sees what the
+# browser will see. We make the request ourselves rather than calling
+# camoufox.ip.public_ip: that answer is cached for the life of the process, and a
+# check button has to see the proxy as it is now, not as it was an hour ago.
+IP_ENDPOINTS = (
+    "https://api.ipify.org",
+    "https://checkip.amazonaws.com",
+    "https://icanhazip.com",
+)
+
+# MaxMind places an address in a city, not on a street. Below this a difference
+# is database noise rather than a contradiction; above the second, no plausible
+# reading of the coordinates puts them near the exit.
+NEARBY_KM = 100.0
+FAR_KM = 500.0
+
+DEFAULT_TIMEOUT = 10.0
+
+
+class LocationUnavailable(RuntimeError):
+    """The exit address could not be placed on the map."""
+
+
+@dataclass(frozen=True)
+class ProxyLocation:
+    """Where a proxy actually comes out, as the browser's own database sees it."""
+
+    ip: str
+    country: str | None = None
+    timezone: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One thing worth telling the user about this proxy and this profile."""
+
+    level: Level
+    field: str
+    message: str
+
+
+@dataclass
+class ProxyCheckResult:
+    reachable: bool
+    error: str | None = None
+    latency_ms: int | None = None
+    location: ProxyLocation | None = None
+    findings: list[Finding] = field(default_factory=list)
+
+
+def proxy_url(proxy: ProxyConfig) -> str:
+    """The proxy as a URL, with credentials if it has them."""
+    credentials = ""
+    if proxy.username:
+        credentials = proxy.username
+        if proxy.password:
+            credentials += f":{proxy.password}"
+        credentials += "@"
+    return f"{proxy.type.value}://{credentials}{proxy.server}"
+
+
+def preflight(proxy: ProxyConfig) -> list[Finding]:
+    """What can be said about a proxy without touching the network."""
+    findings: list[Finding] = []
+    if proxy.type in (ProxyType.SOCKS4, ProxyType.SOCKS5) and (proxy.username or proxy.password):
+        findings.append(
+            Finding(
+                "error",
+                "proxy",
+                "Firefox refuses to authenticate to a SOCKS proxy, so this profile will "
+                "fail to launch. Use an HTTP or HTTPS proxy for credentials.",
+            )
+        )
+    return findings
+
+
+def _utc_offset(zone: str) -> float | None:
+    """Hours from UTC in this zone right now, or None if the name is unknown."""
+    try:
+        offset = datetime.now(timezone.utc).astimezone(ZoneInfo(zone)).utcoffset()
+    except (ZoneInfoNotFoundError, ValueError):
+        return None
+    return None if offset is None else offset.total_seconds() / 3600
+
+
+def _distance_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great-circle distance between two points."""
+    lat1, lon1, lat2, lon2 = (radians(v) for v in (lat1, lon1, lat2, lon2))
+    a = sin((lat2 - lat1) / 2) ** 2 + cos(lat1) * cos(lat2) * sin((lon2 - lon1) / 2) ** 2
+    return 2 * asin(sqrt(a)) * 6371.0
+
+
+def locate(ip: str) -> ProxyLocation:
+    """Place an address using the database Camoufox itself uses at launch.
+
+    Raises LocationUnavailable when the database is missing or does not know the
+    address, so the caller can still report a working proxy it cannot place.
+    """
+    try:
+        from camoufox.geolocation import get_geolocation
+    except ImportError as exc:  # pragma: no cover - the geoip extra is a hard dependency
+        raise LocationUnavailable(str(exc)) from exc
+
+    try:
+        geo = get_geolocation(ip)
+    except Exception as exc:
+        raise LocationUnavailable(str(exc)) from exc
+
+    # Only the region is taken from geo.locale. Its language is sampled
+    # statistically for that region, so the same address answered "de-BG" and then
+    # "bg-BG" — not something to report as a fact about the proxy.
+    return ProxyLocation(
+        ip=ip,
+        country=geo.locale.region,
+        timezone=geo.timezone,
+        latitude=geo.latitude,
+        longitude=geo.longitude,
+    )
+
+
+def compare(settings: BrowserSettings, location: ProxyLocation) -> list[Finding]:
+    """Everything a page could notice between this profile and this exit address.
+
+    Pure: no network, no clock beyond the current UTC offsets, so the rules are
+    testable on their own.
+    """
+    findings: list[Finding] = []
+    where = location.country or location.ip
+
+    if settings.timezone and location.timezone and settings.timezone != location.timezone:
+        profile_offset = _utc_offset(settings.timezone)
+        exit_offset = _utc_offset(location.timezone)
+        if profile_offset is not None and profile_offset == exit_offset:
+            findings.append(
+                Finding(
+                    "info",
+                    "timezone",
+                    f"This profile reports {settings.timezone} while the proxy exits in "
+                    f"{where} ({location.timezone}). The clock agrees; the zone names "
+                    "name different places.",
+                )
+            )
+        else:
+            findings.append(
+                Finding(
+                    "warning",
+                    "timezone",
+                    f"This profile reports {settings.timezone} but the proxy exits in "
+                    f"{where} ({location.timezone}). A page can compare its clock with "
+                    "the address it sees and find the contradiction.",
+                )
+            )
+    elif not settings.timezone and location.timezone:
+        findings.append(
+            Finding(
+                "info",
+                "timezone",
+                f"No timezone is set, so it follows the proxy: {location.timezone}.",
+            )
+        )
+
+    if settings.geolocation:
+        lat, lon = settings.geolocation.get("lat"), settings.geolocation.get("lon")
+        placed = location.latitude is not None and location.longitude is not None
+        if lat is not None and lon is not None and placed:
+            distance = _distance_km(lat, lon, location.latitude, location.longitude)  # type: ignore[arg-type]
+            if distance > FAR_KM:
+                findings.append(
+                    Finding(
+                        "warning",
+                        "geolocation",
+                        f"The coordinates are {distance:,.0f} km from where the proxy "
+                        f"exits ({where}). A site granted location permission sees one "
+                        "place and the address says another.",
+                    )
+                )
+            elif distance > NEARBY_KM:
+                findings.append(
+                    Finding(
+                        "info",
+                        "geolocation",
+                        f"The coordinates are {distance:,.0f} km from where the proxy "
+                        f"exits ({where}) — the same region, a different city.",
+                    )
+                )
+
+    return findings
+
+
+async def resolve_exit_ip(
+    proxy: ProxyConfig | None, timeout: float = DEFAULT_TIMEOUT
+) -> tuple[str, int]:
+    """Ask, through the proxy, what address the internet sees. Returns (ip, ms)."""
+    url = proxy_url(proxy) if proxy else None
+    last_error: Exception | None = None
+
+    # TLS is verified. A proxy that intercepts it fails the check with an SSL error,
+    # which is worth knowing rather than papering over.
+    async with httpx.AsyncClient(proxy=url, timeout=timeout) as client:
+        for endpoint in IP_ENDPOINTS:
+            started = time.monotonic()
+            try:
+                response = await client.get(endpoint)
+                response.raise_for_status()
+            except Exception as exc:
+                last_error = exc
+                logger.debug(f"Proxy check via {endpoint} failed: {exc}")
+                continue
+            return response.text.strip(), int((time.monotonic() - started) * 1000)
+
+    raise ConnectionError(_readable(last_error))
+
+
+def _readable(error: Exception | None) -> str:
+    """Turn an httpx failure into something worth showing a user."""
+    if error is None:
+        return "The proxy did not answer."
+    if isinstance(error, httpx.HTTPStatusError):
+        if error.response.status_code == 407:
+            return "The proxy rejected the credentials."
+        return f"The proxy answered {error.response.status_code}."
+    if isinstance(error, httpx.ProxyError):
+        # httpx reports a failed CONNECT as a ProxyError, not as a status, so the
+        # common case of wrong credentials arrives here rather than above.
+        if "407" in str(error):
+            return "The proxy rejected the credentials."
+        return f"The proxy refused the connection: {error}"
+    if isinstance(error, httpx.TimeoutException):
+        return "The proxy did not answer in time."
+    if (
+        isinstance(error, ssl.SSLError)
+        or isinstance(error, httpx.ConnectError)
+        and ("SSL" in str(error) or "CERTIFICATE" in str(error))
+    ):
+        return f"The proxy intercepts TLS, so its certificate could not be verified: {error}"
+    if isinstance(error, httpx.UnsupportedProtocol):
+        return "This proxy protocol cannot be checked; SOCKS4 is not supported."
+    return f"Could not reach the internet through the proxy: {error}"
+
+
+async def fill_what_geoip_would_have(proxy: ProxyConfig | None, options: dict) -> None:
+    """Supply the IP-derived values Camoufox skips when geoip is off.
+
+    Setting coordinates turns geoip off, because that is the only way Camoufox
+    keeps them — with geoip on it overwrites the geolocation keys from the exit
+    address. But the same branch is what fills the timezone and the WebRTC
+    address, so turning it off leaves both unset and Firefox falls back to *this
+    computer's* timezone. Measured: a profile with Tokyo coordinates reported
+    Europe/Moscow, the host's own zone. That is worse than any mismatch, because
+    it is the real machine showing through.
+
+    So we do that part ourselves, from the same exit address and the same
+    database Camoufox would have used. A lookup that fails leaves the launch
+    alone rather than blocking it.
+    """
+    if options.get("geoip"):
+        return
+
+    config = options.setdefault("config", {})
+    needs_timezone = "timezone" not in config
+    needs_webrtc = "webrtc:ipv4" not in config and not options.get("block_webrtc")
+    if not needs_timezone and not needs_webrtc:
+        return
+
+    try:
+        ip, _ = await resolve_exit_ip(proxy)
+    except ConnectionError as exc:
+        logger.warning(f"Could not find the exit address, leaving the launch alone: {exc}")
+        return
+
+    if needs_webrtc:
+        config["webrtc:ipv4"] = ip
+    if not needs_timezone:
+        return
+
+    try:
+        location = await asyncio.to_thread(locate, ip)
+    except LocationUnavailable as exc:
+        logger.warning(f"Could not place {ip}, leaving the timezone alone: {exc}")
+        return
+
+    if location.timezone:
+        config["timezone"] = location.timezone
+        logger.info(f"Timezone {location.timezone} taken from the exit address {ip}")
+
+
+async def check(
+    proxy: ProxyConfig | None,
+    settings: BrowserSettings,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> ProxyCheckResult:
+    """Reach the internet through the proxy, place it, and compare it with the profile."""
+    findings = preflight(proxy) if proxy else []
+
+    try:
+        ip, latency = await resolve_exit_ip(proxy, timeout=timeout)
+    except ConnectionError as exc:
+        return ProxyCheckResult(reachable=False, error=str(exc), findings=findings)
+
+    try:
+        # get_geolocation reads (and may download) the MaxMind database, so keep it
+        # off the event loop.
+        location = await asyncio.to_thread(locate, ip)
+    except LocationUnavailable as exc:
+        logger.warning(f"Could not place {ip}: {exc}")
+        findings.append(
+            Finding(
+                "info",
+                "proxy",
+                "The proxy works, but its address could not be placed on the map. "
+                "Run 'camoufox fetch' to install the location database.",
+            )
+        )
+        return ProxyCheckResult(
+            reachable=True, latency_ms=latency, location=ProxyLocation(ip=ip), findings=findings
+        )
+
+    findings.extend(compare(settings, location))
+    return ProxyCheckResult(
+        reachable=True, latency_ms=latency, location=location, findings=findings
+    )

--- a/tests/browser/test_proxy_alignment.py
+++ b/tests/browser/test_proxy_alignment.py
@@ -1,0 +1,76 @@
+"""A profile must not tell a page where this computer really is.
+
+Setting coordinates turns Camoufox's geoip off — the only way it keeps them —
+and that same branch is what fills the timezone. Without the fill this exercises,
+Firefox falls back to the host machine's own zone, which is the real machine
+showing through.
+
+Run with:  uv run pytest -m browser
+"""
+
+import pytest
+from camoufox import AsyncCamoufox
+
+from camoufox_pm.core import proxy_check
+from camoufox_pm.core.models import BrowserSettings, Profile
+
+CLOCK = "() => Intl.DateTimeFormat().resolvedOptions().timeZone"
+
+
+async def timezone_seen(options, user_data_dir):
+    launch = dict(options)
+    launch["headless"] = True
+    launch["user_data_dir"] = str(user_data_dir)
+    async with AsyncCamoufox(**launch) as browser:
+        page = await browser.new_page()
+        await page.goto("about:blank")
+        return await page.evaluate(CLOCK)
+
+
+@pytest.mark.browser
+@pytest.mark.asyncio
+async def test_coordinates_no_longer_leak_this_computers_timezone(tmp_path):
+    """The fix, against the behaviour it replaces.
+
+    Launches the same profile twice: once with the raw options, which is what
+    used to reach the browser, and once after filling in what geoip would have.
+    """
+    profile = Profile(
+        name="coords",
+        browser_settings=BrowserSettings(os="windows", geolocation={"lat": 35.68, "lon": 139.69}),
+    )
+    raw = profile.to_camoufox_launch_options()
+    assert raw["geoip"] is False, "coordinates are expected to turn geoip off"
+    assert "timezone" not in raw["config"]
+
+    host = await timezone_seen(raw, tmp_path / "raw")
+
+    filled = profile.to_camoufox_launch_options()
+    await proxy_check.fill_what_geoip_would_have(profile.proxy, filled)
+    assert filled["config"].get("timezone"), "the exit address should have supplied a timezone"
+    if filled["config"]["timezone"] == host:
+        pytest.skip("this machine sits in the timezone its own address resolves to")
+
+    spoofed = await timezone_seen(filled, tmp_path / "filled")
+
+    assert spoofed == filled["config"]["timezone"]
+    assert spoofed != host, "the browser is still reporting this computer's timezone"
+
+
+@pytest.mark.browser
+@pytest.mark.asyncio
+async def test_an_explicit_timezone_is_never_overwritten(tmp_path):
+    """The user's own answer wins over anything the address suggests."""
+    profile = Profile(
+        name="explicit",
+        browser_settings=BrowserSettings(
+            os="windows",
+            timezone="Pacific/Auckland",
+            geolocation={"lat": -36.85, "lon": 174.76},
+        ),
+    )
+    options = profile.to_camoufox_launch_options()
+    await proxy_check.fill_what_geoip_would_have(profile.proxy, options)
+
+    assert options["config"]["timezone"] == "Pacific/Auckland"
+    assert await timezone_seen(options, tmp_path / "explicit") == "Pacific/Auckland"

--- a/tests/integration/test_api_profiles.py
+++ b/tests/integration/test_api_profiles.py
@@ -88,7 +88,8 @@ async def test_create_keeps_generated_values_for_omitted_fields(client):
     """Omitting an optional field must leave the generated fingerprint intact.
 
     The web form omits blanks on create; sending nulls instead produced profiles
-    with no timezone and no geolocation.
+    with no hardware and no screen. Geography is the deliberate exception — it is
+    left unset so it follows the proxy — so it is asserted absent here.
     """
     created = await client.post(
         "/api/profiles",
@@ -102,8 +103,10 @@ async def test_create_keeps_generated_values_for_omitted_fields(client):
     settings = created.json()["browser_settings"]
 
     assert settings["os"] == "windows"
-    assert settings["timezone"], "timezone should have been generated"
+    assert settings["screen"], "screen should have been generated"
     assert settings["hardware_concurrency"], "hardware_concurrency should have been generated"
+    assert settings["timezone"] is None, "a generated profile takes its timezone from the proxy"
+    assert settings["geolocation"] is None, "coordinates would turn the IP lookup off"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_api_proxy_check.py
+++ b/tests/integration/test_api_proxy_check.py
@@ -1,0 +1,157 @@
+"""The proxy check over HTTP, with the network stubbed.
+
+The rules themselves are covered in tests/unit/test_proxy_check.py; these tests
+are about the endpoints — that a saved profile is compared against its own
+settings, that an unsaved one can be checked while it is still being typed, and
+that a dead proxy is reported rather than raised.
+"""
+
+import pytest
+
+from camoufox_pm.core import proxy_check
+
+TOKYO = proxy_check.ProxyLocation(
+    ip="203.0.113.7",
+    country="JP",
+    timezone="Asia/Tokyo",
+    latitude=35.6895,
+    longitude=139.6917,
+)
+
+
+@pytest.fixture
+def exit_in_tokyo(monkeypatch):
+    """Every check comes out in Tokyo, without touching the network."""
+
+    async def resolve(proxy, timeout=proxy_check.DEFAULT_TIMEOUT):
+        return TOKYO.ip, 42
+
+    monkeypatch.setattr(proxy_check, "resolve_exit_ip", resolve)
+    monkeypatch.setattr(proxy_check, "locate", lambda ip: TOKYO)
+
+
+@pytest.fixture
+def dead_proxy(monkeypatch):
+    async def resolve(proxy, timeout=proxy_check.DEFAULT_TIMEOUT):
+        raise ConnectionError("The proxy refused the connection.")
+
+    monkeypatch.setattr(proxy_check, "resolve_exit_ip", resolve)
+
+
+@pytest.mark.asyncio
+async def test_a_saved_profile_is_compared_against_its_own_timezone(client, exit_in_tokyo):
+    created = await client.post(
+        "/api/profiles",
+        json={"name": "berlin-on-tokyo", "browser_settings": {"timezone": "Europe/Berlin"}},
+    )
+    profile_id = created.json()["id"]
+
+    checked = await client.post(f"/api/profiles/{profile_id}/check-proxy")
+
+    assert checked.status_code == 200
+    body = checked.json()
+    assert body["reachable"] is True
+    assert body["latency_ms"] == 42
+    assert body["location"]["country"] == "JP"
+    assert [f["level"] for f in body["findings"]] == ["warning"]
+    assert "Europe/Berlin" in body["findings"][0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_a_profile_that_agrees_with_its_proxy_reports_nothing(client, exit_in_tokyo):
+    created = await client.post(
+        "/api/profiles",
+        json={"name": "tokyo", "browser_settings": {"timezone": "Asia/Tokyo"}},
+    )
+
+    checked = await client.post(f"/api/profiles/{created.json()['id']}/check-proxy")
+
+    assert checked.json()["findings"] == []
+
+
+@pytest.mark.asyncio
+async def test_checking_a_missing_profile_is_404(client, exit_in_tokyo):
+    assert (await client.post("/api/profiles/nope/check-proxy")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_an_unsaved_proxy_can_be_checked(client, exit_in_tokyo):
+    """The form needs an answer before the profile exists."""
+    checked = await client.post(
+        "/api/proxy/check",
+        json={
+            "proxy_config": {"type": "http", "server": "proxy.example.com:8080"},
+            "browser_settings": {"timezone": "Europe/Berlin"},
+        },
+    )
+
+    assert checked.status_code == 200
+    assert [f["level"] for f in checked.json()["findings"]] == ["warning"]
+
+
+@pytest.mark.asyncio
+async def test_socks_credentials_are_reported_as_a_launch_failure(client, exit_in_tokyo):
+    checked = await client.post(
+        "/api/proxy/check",
+        json={
+            "proxy_config": {
+                "type": "socks5",
+                "server": "h:1080",
+                "username": "u",
+                "password": "p",
+            },
+            "browser_settings": {"timezone": "Asia/Tokyo"},
+        },
+    )
+
+    assert [f["level"] for f in checked.json()["findings"]] == ["error"]
+
+
+@pytest.mark.asyncio
+async def test_a_dead_proxy_is_reported_not_raised(client, dead_proxy):
+    checked = await client.post(
+        "/api/proxy/check",
+        json={"proxy_config": {"type": "http", "server": "127.0.0.1:9"}},
+    )
+
+    assert checked.status_code == 200
+    body = checked.json()
+    assert body["reachable"] is False
+    assert body["error"] == "The proxy refused the connection."
+    assert body["location"] is None
+
+
+@pytest.mark.asyncio
+async def test_an_invalid_proxy_is_422(client):
+    checked = await client.post(
+        "/api/proxy/check",
+        json={"proxy_config": {"type": "carrier-pigeon", "server": "h:1"}},
+    )
+
+    assert checked.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_a_working_proxy_the_database_cannot_place(client, monkeypatch):
+    """A proxy that answers is still worth reporting when it cannot be located."""
+
+    async def resolve(proxy, timeout=proxy_check.DEFAULT_TIMEOUT):
+        return "203.0.113.7", 11
+
+    def unplaceable(ip):
+        raise proxy_check.LocationUnavailable("no database")
+
+    monkeypatch.setattr(proxy_check, "resolve_exit_ip", resolve)
+    monkeypatch.setattr(proxy_check, "locate", unplaceable)
+
+    body = (await client.post("/api/proxy/check", json={})).json()
+
+    assert body["reachable"] is True
+    assert body["location"] == {
+        "ip": "203.0.113.7",
+        "country": None,
+        "timezone": None,
+        "latitude": None,
+        "longitude": None,
+    }
+    assert [f["level"] for f in body["findings"]] == ["info"]

--- a/tests/unit/test_fingerprint_generator.py
+++ b/tests/unit/test_fingerprint_generator.py
@@ -1,8 +1,8 @@
 """Tests for the fingerprint generator.
 
-The generator sets only high-level constraints (os, screen, region-derived
-locale/timezone/geolocation). Camoufox owns the user-agent and WebGL, so those
-are never hand-crafted here.
+The generator sets only high-level constraints: the machine (os, screen,
+hardware) always, and geography only when a region is asked for. Camoufox owns
+the user-agent and WebGL, so those are never hand-crafted here.
 """
 
 import pytest
@@ -34,3 +34,36 @@ async def test_geolocation_set_for_region():
     bs = await gen.generate_fingerprint({"os": "linux", "region": "germany"})
     assert bs.geolocation is not None
     assert "lat" in bs.geolocation and "lon" in bs.geolocation
+
+
+@pytest.mark.asyncio
+async def test_a_profile_with_no_region_has_no_geography():
+    """A new profile is a machine, not a place.
+
+    Generating a timezone and coordinates gave every profile a random country
+    that contradicted whatever proxy it was later given — and coordinates turn
+    Camoufox's IP lookup off entirely, so nothing followed the proxy at all.
+    """
+    gen = FingerprintGenerator()
+
+    bs = await gen.generate_fingerprint({"os": "windows"})
+
+    assert bs.timezone is None
+    assert bs.geolocation is None
+    assert bs.languages == ["en-US", "en"]
+    # The machine is still generated.
+    assert bs.screen in gen.os_screen_combinations["windows"]
+    assert bs.hardware_concurrency
+
+
+@pytest.mark.asyncio
+async def test_rotating_a_fingerprint_does_not_move_the_profile():
+    """Rotation changes the hardware; it must not hand the profile a country."""
+    gen = FingerprintGenerator()
+    current = await gen.generate_fingerprint({"os": "macos", "region": "germany"})
+
+    rotated = await gen.rotate_fingerprint(current)
+
+    assert rotated.os == "macos"
+    assert rotated.timezone is None
+    assert rotated.geolocation is None

--- a/tests/unit/test_proxy_check.py
+++ b/tests/unit/test_proxy_check.py
@@ -1,0 +1,146 @@
+"""What a page could notice between a profile and the address its proxy exits from.
+
+compare() is pure, so every rule is tested here without a proxy or a network.
+"""
+
+import pytest
+
+from camoufox_pm.core.models import BrowserSettings, ProxyConfig, ProxyType
+from camoufox_pm.core.proxy_check import ProxyLocation, compare, preflight, proxy_url
+
+TOKYO = ProxyLocation(
+    ip="203.0.113.7",
+    country="JP",
+    timezone="Asia/Tokyo",
+    latitude=35.6895,
+    longitude=139.6917,
+)
+BERLIN = ProxyLocation(
+    ip="198.51.100.4",
+    country="DE",
+    timezone="Europe/Berlin",
+    latitude=52.52,
+    longitude=13.405,
+)
+
+
+def levels(findings, field):
+    return [f.level for f in findings if f.field == field]
+
+
+def test_a_timezone_on_the_other_side_of_the_world_is_a_warning():
+    """The mismatch this exists to catch: a Berlin clock on a Japanese address."""
+    findings = compare(BrowserSettings(timezone="Europe/Berlin"), TOKYO)
+
+    assert levels(findings, "timezone") == ["warning"]
+    message = next(f.message for f in findings if f.field == "timezone")
+    assert "Europe/Berlin" in message and "Asia/Tokyo" in message and "JP" in message
+
+
+def test_a_matching_timezone_says_nothing():
+    assert compare(BrowserSettings(timezone="Asia/Tokyo"), TOKYO) == []
+
+
+def test_a_different_zone_on_the_same_clock_is_only_a_note():
+    """Berlin and Paris never disagree on the hour, so no page can see a contradiction.
+
+    The zone name still names another country, which is worth mentioning but not
+    worth flagging as a mismatch — over-warning trains people to ignore warnings.
+    """
+    findings = compare(BrowserSettings(timezone="Europe/Paris"), BERLIN)
+
+    assert levels(findings, "timezone") == ["info"]
+
+
+def test_no_timezone_means_it_follows_the_proxy():
+    findings = compare(BrowserSettings(timezone=None), TOKYO)
+
+    assert levels(findings, "timezone") == ["info"]
+    assert "follows the proxy" in findings[0].message
+
+
+def test_coordinates_without_a_timezone_still_follow_the_proxy():
+    """Coordinates turn Camoufox's geoip off, which used to leave the timezone
+    unset and let Firefox report the host machine's own zone. The launch path now
+    fills it from the same exit address, so this is no longer a mismatch."""
+    settings = BrowserSettings(timezone=None, geolocation={"lat": 35.68, "lon": 139.69})
+
+    assert levels(compare(settings, TOKYO), "timezone") == ["info"]
+
+
+def test_coordinates_far_from_the_exit_are_a_warning():
+    settings = BrowserSettings(timezone="Asia/Tokyo", geolocation={"lat": 52.52, "lon": 13.405})
+
+    findings = compare(settings, TOKYO)
+
+    assert levels(findings, "geolocation") == ["warning"]
+    assert "km from where the proxy exits" in findings[-1].message
+
+
+def test_coordinates_in_the_next_city_are_only_a_note():
+    """Osaka is 400 km from Tokyo: the same country, and within one story."""
+    settings = BrowserSettings(timezone="Asia/Tokyo", geolocation={"lat": 34.69, "lon": 135.50})
+
+    findings = compare(settings, TOKYO)
+
+    assert levels(findings, "geolocation") == ["info"]
+
+
+def test_coordinates_in_the_same_city_say_nothing_extra():
+    settings = BrowserSettings(timezone="Asia/Tokyo", geolocation={"lat": 35.70, "lon": 139.70})
+
+    assert compare(settings, TOKYO) == []
+
+
+def test_an_unplaceable_exit_address_still_compares_what_it_can():
+    """A working proxy the database cannot place must not produce false mismatches."""
+    findings = compare(BrowserSettings(timezone="Europe/Berlin"), ProxyLocation(ip="203.0.113.7"))
+
+    assert findings == []
+
+
+def test_an_unknown_timezone_name_is_treated_as_a_contradiction():
+    """A name zoneinfo cannot resolve cannot be shown to agree, so it does not get
+    the benefit of the doubt."""
+    findings = compare(BrowserSettings(timezone="Mars/Olympus"), TOKYO)
+
+    assert levels(findings, "timezone") == ["warning"]
+
+
+@pytest.mark.parametrize("kind", [ProxyType.SOCKS4, ProxyType.SOCKS5])
+def test_socks_with_credentials_is_reported_before_any_request(kind):
+    """Firefox refuses to authenticate to a SOCKS proxy, so the launch fails.
+
+    Better to say so on the check button than to let the user find out when the
+    browser will not start.
+    """
+    findings = preflight(ProxyConfig(type=kind, server="h:1080", username="u", password="p"))
+
+    assert [f.level for f in findings] == ["error"]
+    assert "fail to launch" in findings[0].message
+
+
+def test_socks_without_credentials_is_fine():
+    assert preflight(ProxyConfig(type=ProxyType.SOCKS5, server="h:1080")) == []
+
+
+def test_http_with_credentials_is_fine():
+    assert preflight(ProxyConfig(type=ProxyType.HTTP, server="h:8080", username="u")) == []
+
+
+@pytest.mark.parametrize(
+    ("proxy", "expected"),
+    [
+        (ProxyConfig(type=ProxyType.HTTP, server="h:8080"), "http://h:8080"),
+        (
+            ProxyConfig(type=ProxyType.SOCKS5, server="h:1080", username="u", password="p"),
+            "socks5://u:p@h:1080",
+        ),
+        (
+            ProxyConfig(type=ProxyType.HTTPS, server="h:443", username="u"),
+            "https://u@h:443",
+        ),
+    ],
+)
+def test_proxy_url_carries_credentials(proxy, expected):
+    assert proxy_url(proxy) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -404,6 +404,7 @@ dependencies = [
     { name = "camoufox", extra = ["geoip"] },
     { name = "cryptography" },
     { name = "fastapi" },
+    { name = "httpx", extra = ["socks"] },
     { name = "loguru" },
     { name = "openpyxl" },
     { name = "playwright" },
@@ -429,7 +430,6 @@ desktop = [
     { name = "pywebview" },
 ]
 dev = [
-    { name = "httpx" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -443,7 +443,7 @@ requires-dist = [
     { name = "camoufox", extras = ["geoip"], specifier = ">=0.5.4" },
     { name = "cryptography", specifier = ">=44.0" },
     { name = "fastapi", specifier = ">=0.115" },
-    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.28" },
+    { name = "httpx", extras = ["socks"], specifier = ">=0.28" },
     { name = "loguru", specifier = ">=0.7" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13" },
     { name = "openpyxl", specifier = ">=3.1" },
@@ -1267,6 +1267,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+socks = [
+    { name = "socksio" },
 ]
 
 [[package]]
@@ -3079,6 +3084,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
+name = "socksio"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/5c/48a7d9495be3d1c651198fd99dbb6ce190e2274d0f28b9051307bdec6b85/socksio-1.0.0.tar.gz", hash = "sha256:f88beb3da5b5c38b9890469de67d0cb0f9d494b78b106ca1845f96c10b91c4ac", size = 19055, upload-time = "2020-04-17T15:50:34.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/c3/6eeb6034408dac0fa653d126c9204ade96b819c936e136c5e8a6897eee9c/socksio-1.0.0-py3-none-any.whl", hash = "sha256:95dc1f15f9b34e8d7b16f06d74b8ccf48f609af32ab33c608d08761c5dcbb1f3", size = 12763, upload-time = "2020-04-17T15:50:31.878Z" },
 ]
 
 [[package]]

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -8,6 +8,7 @@ import {
   ChevronRight,
   Copy,
   Download,
+  Globe,
   MoreHorizontal,
   PackageOpen,
   Pencil,
@@ -282,6 +283,33 @@ export default function ProfilesPage() {
       loadProfiles()
     } catch (err) {
       toast('error', 'Could not clone profile', String(err))
+    }
+  }
+
+  /**
+   * A proxy that answers is only half the question: the toast also carries the
+   * first thing a page could notice between the exit address and the profile,
+   * because a healthy proxy in the wrong country is still a giveaway.
+   */
+  async function checkProxy(profile: Profile) {
+    toast('info', 'Checking the proxy…', profile.name)
+    try {
+      const result = await profilesAPI.checkProxy(profile.id)
+      if (!result.reachable) {
+        toast('error', `${profile.name}: proxy unreachable`, result.error ?? undefined)
+        return
+      }
+      const where = [result.location?.country, result.location?.timezone]
+        .filter(Boolean)
+        .join(' · ')
+      const problem = result.findings.find((finding) => finding.level !== 'info')
+      const summary = `${result.location?.ip}${where ? ` — ${where}` : ''}${
+        result.latency_ms !== null ? ` · ${result.latency_ms} ms` : ''
+      }`
+      if (problem) toast('error', `${profile.name}: ${summary}`, problem.message)
+      else toast('ok', `${profile.name}: ${summary}`)
+    } catch (err) {
+      toast('error', 'Could not check the proxy', String(err))
     }
   }
 
@@ -684,6 +712,14 @@ export default function ProfilesPage() {
                               label="Duplicate"
                               onClick={() => {
                                 clone(profile)
+                                closeMenu(profile.id)
+                              }}
+                            />
+                            <MenuItem
+                              icon={<Globe size={13} />}
+                              label="Check proxy"
+                              onClick={() => {
+                                checkProxy(profile)
                                 closeMenu(profile.id)
                               }}
                             />

--- a/web/src/components/profile-form.tsx
+++ b/web/src/components/profile-form.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { AlertTriangle, Loader2, RefreshCw } from 'lucide-react'
+import { AlertTriangle, Check, Info, Loader2, RefreshCw, X } from 'lucide-react'
 
 import { Modal } from '@/components/modal'
 import { useToast } from '@/components/toast'
@@ -12,6 +12,7 @@ import {
   type FingerprintSummary,
   type Group,
   type Profile,
+  type ProxyCheck,
 } from '@/lib/api'
 
 interface FormState {
@@ -102,6 +103,8 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
   const [saving, setSaving] = useState(false)
   const [regenerating, setRegenerating] = useState(false)
   const [refreshingBrowser, setRefreshingBrowser] = useState(false)
+  const [checkingProxy, setCheckingProxy] = useState(false)
+  const [proxyCheck, setProxyCheck] = useState<ProxyCheck | null>(null)
   // The `profile` prop is a snapshot from the list; regenerating or updating the
   // browser returns a new machine, and the panel has to show it without waiting
   // for the dialog to be reopened.
@@ -181,6 +184,28 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
       server: form.proxyServer.trim(),
       username: form.proxyUsername.trim() || undefined,
       password: form.proxyPassword.trim() || undefined,
+    }
+  }
+
+  /**
+   * Checks what is on screen rather than what is stored, so the answer belongs to
+   * the proxy the user is currently typing — the point is to find out before
+   * saving whether it works and whether it agrees with the profile.
+   */
+  async function handleCheckProxy() {
+    setCheckingProxy(true)
+    setProxyCheck(null)
+    try {
+      setProxyCheck(
+        await profilesAPI.checkUnsavedProxy({
+          proxy_config: buildProxy(),
+          browser_settings: buildBrowserSettings(),
+        }),
+      )
+    } catch (error) {
+      toast('error', 'Could not check the proxy', (error as Error).message)
+    } finally {
+      setCheckingProxy(false)
     }
   }
 
@@ -460,6 +485,23 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
                 without them.
               </p>
             )}
+
+          <div className="col-span-2">
+            <button
+              type="button"
+              className="btn"
+              onClick={handleCheckProxy}
+              disabled={checkingProxy}
+            >
+              {checkingProxy ? (
+                <Loader2 size={13} className="animate-spin" />
+              ) : (
+                <RefreshCw size={13} />
+              )}
+              {checkingProxy ? 'Checking…' : 'Check proxy'}
+            </button>
+            <ProxyCheckResult result={proxyCheck} />
+          </div>
         </Section>
 
         {isEdit ? (
@@ -781,5 +823,56 @@ function Section({
       {hint && <p className="mb-2.5 text-ink-faint">{hint}</p>}
       <div className="grid grid-cols-2 gap-3">{children}</div>
     </fieldset>
+  )
+}
+
+
+/**
+ * What the check found: where the proxy actually comes out, and everything a page
+ * could notice between that and the profile. A working proxy is not the whole
+ * answer — a profile whose timezone contradicts its exit address is detectable
+ * however healthy the connection is.
+ */
+function ProxyCheckResult({ result }: { result: ProxyCheck | null }) {
+  if (!result) return null
+
+  if (!result.reachable) {
+    return (
+      <p className="mt-2 flex items-start gap-1.5 text-danger">
+        <X size={13} className="mt-0.5 shrink-0" />
+        <span>{result.error}</span>
+      </p>
+    )
+  }
+
+  const where = result.location
+  const place = [where?.country, where?.timezone].filter(Boolean).join(' · ')
+
+  return (
+    <div className="mt-2 space-y-1.5">
+      <p className="flex items-start gap-1.5 text-ink-muted">
+        <Check size={13} className="mt-0.5 shrink-0 text-ok" />
+        <span>
+          Exits at <span className="font-mono">{where?.ip}</span>
+          {place && <> — {place}</>}
+          {result.latency_ms !== null && <> · {result.latency_ms} ms</>}
+        </span>
+      </p>
+      {result.findings.map((finding, index) => (
+        <p
+          key={index}
+          className={`flex items-start gap-1.5 ${
+            finding.level === 'info' ? 'text-ink-faint' : 'text-danger'
+          }`}
+        >
+          {finding.level === 'info' ? (
+            <Info size={13} className="mt-0.5 shrink-0" />
+          ) : (
+            <AlertTriangle size={13} className="mt-0.5 shrink-0" />
+          )}
+          <span>{finding.message}</span>
+        </p>
+      ))}
+    </div>
   )
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -160,6 +160,28 @@ function toQuery(params: Record<string, unknown>): string {
   return query.toString() ? `?${query.toString()}` : ''
 }
 
+export interface ProxyLocation {
+  ip: string
+  country: string | null
+  timezone: string | null
+  latitude: number | null
+  longitude: number | null
+}
+
+export interface ProxyFinding {
+  level: 'error' | 'warning' | 'info'
+  field: string
+  message: string
+}
+
+export interface ProxyCheck {
+  reachable: boolean
+  error: string | null
+  latency_ms: number | null
+  location: ProxyLocation | null
+  findings: ProxyFinding[]
+}
+
 export const profilesAPI = {
   getProfiles(params: Record<string, unknown> = {}): Promise<ProfilesResponse> {
     return request<ProfilesResponse>(`/api/profiles${toQuery(params)}`)
@@ -201,6 +223,19 @@ export const profilesAPI = {
 
   refreshBrowserVersion(id: string): Promise<Profile> {
     return request<Profile>(`/api/profiles/${id}/refresh-browser`, { method: 'POST' })
+  },
+
+  checkProxy(id: string): Promise<ProxyCheck> {
+    return request<ProxyCheck>(`/api/profiles/${id}/check-proxy`, { method: 'POST' })
+  },
+
+  // The same check for a profile that is still being filled in, so the form can
+  // answer before anything is saved.
+  checkUnsavedProxy(body: {
+    proxy_config: Record<string, unknown> | null
+    browser_settings: Record<string, unknown>
+  }): Promise<ProxyCheck> {
+    return request<ProxyCheck>('/api/proxy/check', { method: 'POST', body: JSON.stringify(body) })
   },
 
   async exportExcel(): Promise<Blob> {


### PR DESCRIPTION
> **Stacked on [#7](https://github.com/polyackiy/camoufox-profile-manager/pull/7).** Merge that one first — this PR targets its branch so the diff shows only this work. GitHub retargets it to `main` automatically once #7 lands.

## Why

Pinning keeps a profile's hardware honest. Geography is the other half, and it is
deliberately not pinned: a profile that reports `Europe/Berlin` while its proxy
comes out in Tokyo contradicts itself in a way any page can measure with two
lines of JavaScript. No amount of fingerprint pinning hides that.

## What

**Check proxy** — in the profile form and in a profile's row menu — reaches the
internet through the proxy and reports the address it comes out at, the country
and timezone that resolves to, and the round trip. Then it lists what a page
could notice:

| Level | Example |
| --- | --- |
| Error | SOCKS with credentials — Firefox refuses to send them, so the profile will not launch |
| Warning | A timezone on a different clock from the exit country; coordinates more than 500 km away |
| Note | A different zone name on the same clock; coordinates in a nearby city |

The form checks **what is on screen**, not what is stored, so a proxy can be
tested — and a mismatch fixed and re-tested — before anything is saved.

`POST /api/profiles/{id}/check-proxy` and `POST /api/proxy/check`. A proxy that
does not answer comes back as `reachable: false` with a readable reason, not a
5xx.

## Two mismatches the product was creating itself

Building the warning turned up the fact that we were manufacturing the thing we
were about to warn about.

**Every generated profile picked a random country.** The generator chose a region
at random and took the timezone, coordinates *and* languages from it — a fresh
profile might claim Shanghai and then be handed a German proxy. Geography is now
left unset so it follows the proxy; an explicit region still pins it.

**Coordinates leaked the host machine's timezone.** Setting coordinates turns
Camoufox's IP lookup off — the only way it keeps them, since with the lookup on it
overwrites the geolocation keys from the exit address. But that same branch is
what fills the timezone and the WebRTC address, so both were left unset and
Firefox fell back to *this computer's* zone. Measured: a profile with Tokyo
coordinates reported `Europe/Moscow`, the host's own. The launch path now fills
those two itself, from the same address and the same database Camoufox would have
used; a failed lookup leaves the launch alone rather than blocking it.

## Verified through a real proxy

Against a local HTTP proxy, in the running app:

- a Berlin profile on a Bulgarian exit → *"This profile reports Europe/Berlin but
  the proxy exits in BG (Europe/Sofia)"*, in the form and as a toast from the row
  menu
- changing the timezone in the form and re-checking → clean, without saving
- authenticated proxy with the right credentials → reachable; with the wrong ones
  → *"The proxy rejected the credentials"*; a dead proxy → *"All connection
  attempts failed"*
- coordinates in Tokyo on that exit → 9,175 km warning

Dropped `suggested_locale` from the response after seeing the same address answer
`de-BG` and then `bg-BG` — Camoufox samples the language for a region, so it is
not a fact about the proxy.

## Tests

- `tests/unit/test_proxy_check.py` — 17 tests over the pure rules: contradictions,
  same-clock notes, distances, unknown zone names, SOCKS credentials, URL building
- `tests/integration/test_api_proxy_check.py` — both endpoints with the network
  stubbed, including a dead proxy, a 404, a 422 and an unplaceable address
- `tests/browser/test_proxy_alignment.py` — the timezone fix in a real browser,
  against the behaviour it replaces
- `tests/unit/test_fingerprint_generator.py` — no region means no geography, and
  rotation does not hand a profile a country

`ruff`, `mypy`, 124 unit/integration and 20 browser tests pass, plus the suite as
CI sees it (`HOME=$(mktemp -d)`, no fetched browser).

Adds `httpx[socks]` as a runtime dependency so SOCKS5 proxies can be checked too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)