### PR TITLE
Validate the exit address, encode proxy credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   a timezone, coordinates and languages from a randomly chosen region, so a fresh
   profile might claim Shanghai and then be given a German proxy — the manager was
   manufacturing the contradiction it exists to avoid. Geography is now left unset
-  and follows the proxy; a region can still be asked for explicitly.
+  and follows the proxy; a region can still be asked for explicitly. Existing
+  profiles keep the values they were given — a stored fingerprint is not rewritten
+  under a live account — so check one and clear the two fields if they disagree.
 - **Coordinates no longer leak the host machine's timezone.** Setting coordinates
   turns Camoufox's IP lookup off, which is the only way it keeps them — and that
   same branch is what fills the timezone and the WebRTC address. Both were left

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,3 +39,7 @@ reproduce. We aim to acknowledge reports within a few days.
   authentication (set `CPM_API_KEY`) and a TLS-terminating reverse proxy.
 - Set `CPM_CORS_ORIGINS` to the specific origins you trust; do not use a wildcard
   together with credentials.
+- The proxy check connects to whatever host a request names and reports whether it
+  answered and how fast. On an instance reachable beyond localhost without
+  `CPM_API_KEY`, that is an unauthenticated way to probe hosts and ports the
+  server can reach but the caller cannot.

--- a/docs/profile-settings.md
+++ b/docs/profile-settings.md
@@ -115,6 +115,11 @@ those two itself, from the same address and the same database Camoufox would hav
 used. Without that, Firefox falls back to *this computer's* timezone: measured,
 a profile with Tokyo coordinates reported `Europe/Moscow`, the host's own zone.
 
+Profiles created before this behaviour keep the timezone and coordinates they
+were given, and those were picked from a random region. They are not migrated —
+changing a stored fingerprint under a live account is worse than leaving it — so
+check such a profile and clear the two fields if they disagree with its proxy.
+
 ### Checking a proxy
 
 *Check proxy* in the profile form (and in a profile's row menu) reaches the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,6 +25,11 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
 
 ## Next
 
+- Reconcile a profile's OS setting with its pinned machine. A refresh now follows
+  the pin rather than the setting, so the two can disagree silently; nothing
+  offers to bring them back into step.
+- Offer to clear the geography of profiles created before it followed the proxy,
+  instead of only reporting the mismatch when the proxy is checked.
 - Authentication for multi-user or hosted deployments, beyond the optional API key.
 - Task scheduling and automated fingerprint rotation.
 - Windows App-Bound Encryption support for the Chrome-migration module.

--- a/src/camoufox_pm/api/models/profiles.py
+++ b/src/camoufox_pm/api/models/profiles.py
@@ -7,7 +7,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 from camoufox_pm.core.models import Profile, ProfileStatus
-from camoufox_pm.core.proxy_check import ProxyCheckResult
+from camoufox_pm.core.proxy_check import Level, ProxyCheckResult
 
 
 class ProfileCreateRequest(BaseModel):
@@ -248,7 +248,7 @@ class ProxyLocationResponse(BaseModel):
 class ProxyFindingResponse(BaseModel):
     """One thing worth telling the user about this proxy and this profile."""
 
-    level: str = Field(..., description="error, warning or info")
+    level: Level = Field(..., description="error, warning or info")
     field: str = Field(..., description="The setting the finding is about")
     message: str
 

--- a/src/camoufox_pm/core/fingerprint_store.py
+++ b/src/camoufox_pm/core/fingerprint_store.py
@@ -233,15 +233,19 @@ def installed_major() -> int | None:
         return None
 
 
-def is_outdated(fingerprint: dict[str, Any] | None) -> bool:
+def is_outdated(fingerprint: dict[str, Any] | None, installed: int | None = None) -> bool:
     """Whether a pin claims an older browser than the one now installed.
 
     A pinned fingerprint never ages on its own, so a profile kept for months
     keeps advertising the version it was created with. Real machines update, and
     a browser several releases behind is itself unusual enough to notice.
+
+    ``installed`` lets a caller that already knows the version pass it in.
+    Reading it costs a config file, and a profile list would otherwise pay for
+    that once per profile per field.
     """
     pinned = browser_major(fingerprint)
-    current = installed_major()
+    current = installed_major() if installed is None else installed
     return pinned is not None and current is not None and pinned < current
 
 
@@ -341,6 +345,7 @@ def summarize(fingerprint: dict[str, Any] | None) -> dict[str, Any] | None:
     width = fingerprint.get("screen.width")
     height = fingerprint.get("screen.height")
     fonts = fingerprint.get("fonts")
+    installed = installed_major()
     return {
         "user_agent": fingerprint.get("navigator.userAgent"),
         "platform": fingerprint.get("navigator.platform"),
@@ -351,6 +356,6 @@ def summarize(fingerprint: dict[str, Any] | None) -> dict[str, Any] | None:
         "property_count": len(fingerprint),
         # So the UI can offer an update without re-deriving this itself.
         "browser_major": browser_major(fingerprint),
-        "installed_major": installed_major(),
-        "browser_outdated": is_outdated(fingerprint),
+        "installed_major": installed,
+        "browser_outdated": is_outdated(fingerprint, installed),
     }

--- a/src/camoufox_pm/core/models.py
+++ b/src/camoufox_pm/core/models.py
@@ -150,10 +150,9 @@ class BrowserSettings(BaseModel):
             config["navigator.hardwareConcurrency"] = self.hardware_concurrency
         if self.max_touch_points:
             config["navigator.maxTouchPoints"] = self.max_touch_points
-        # webrtc_local_ips is intentionally not emitted. Camoufox does have a
-        # webrtc:localipv4 key, but setting it replaces the mDNS candidate a real
-        # Firefox sends with a literal address — and Camoufox's own default there
-        # is the bogon 240.0.0.2. Leaving it alone keeps the real behaviour.
+        # webrtc_local_ips is intentionally not emitted. The webrtc:localipv4 key
+        # does exist, but setting it replaces the mDNS candidate a real Firefox
+        # sends with a literal address. Leaving it alone keeps the real behaviour.
         if self.webrtc_public_ip:
             config["webrtc:ipv4"] = self.webrtc_public_ip
         return config

--- a/src/camoufox_pm/core/proxy_check.py
+++ b/src/camoufox_pm/core/proxy_check.py
@@ -1,10 +1,16 @@
 """Does what a profile claims match where its proxy actually comes out?
 
 A pinned fingerprint keeps a profile's hardware honest. The parts deliberately
-left dynamic — timezone, coordinates, locale — follow the proxy only as long as
-the profile does not override them. A profile that reports ``Europe/Berlin``
-while its proxy exits in Tokyo contradicts itself in a way any page can measure
-with two lines of JavaScript, and no amount of fingerprint pinning hides it.
+left dynamic — timezone, coordinates, the WebRTC address — follow the proxy only
+as long as the profile does not override them. A profile that reports
+``Europe/Berlin`` while its proxy exits in Tokyo contradicts itself in a way any
+page can measure with two lines of JavaScript, and no amount of fingerprint
+pinning hides it.
+
+Languages are not in that list. Camoufox applies ``handle_locales`` after its IP
+lookup and overwrites ``locale:*`` unconditionally, so a profile's languages
+always win — by design here, since an English-language browser is unremarkable
+from any country and warning about one would fire on nearly every profile.
 
 This module resolves where a proxy really comes out and compares that with what
 the profile would tell a page.
@@ -18,20 +24,26 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from math import asin, cos, radians, sin, sqrt
-from typing import Literal
+from typing import Any, Literal
+from urllib.parse import quote
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import httpx
+from camoufox.ip import valid_ipv4, valid_ipv6
 from loguru import logger
 
 from .models import BrowserSettings, ProxyConfig, ProxyType
 
 Level = Literal["error", "warning", "info"]
 
-# The same endpoints Camoufox asks for the exit address, so a check sees what the
-# browser will see. We make the request ourselves rather than calling
+# Three of the endpoints Camoufox asks for the exit address, so a check sees the
+# address the browser will. We make the request ourselves rather than calling
 # camoufox.ip.public_ip: that answer is cached for the life of the process, and a
 # check button has to see the proxy as it is now, not as it was an hour ago.
+#
+# One deliberate difference: Camoufox does not verify TLS here and we do, so a
+# proxy that intercepts TLS fails this check while still working at launch. That
+# is worth being told about rather than papering over.
 IP_ENDPOINTS = (
     "https://api.ipify.org",
     "https://checkip.amazonaws.com",
@@ -45,6 +57,10 @@ NEARBY_KM = 100.0
 FAR_KM = 500.0
 
 DEFAULT_TIMEOUT = 10.0
+
+# The launch path is not a person waiting for an answer, so it gets Camoufox's own
+# 5 seconds: a tarpitting proxy must not hold a browser open indefinitely.
+LAUNCH_TIMEOUT = 5.0
 
 
 class LocationUnavailable(RuntimeError):
@@ -81,12 +97,18 @@ class ProxyCheckResult:
 
 
 def proxy_url(proxy: ProxyConfig) -> str:
-    """The proxy as a URL, with credentials if it has them."""
+    """The proxy as a URL, with credentials if it has them.
+
+    Credentials are percent-encoded. Provider-issued passwords routinely contain
+    "@" or ":", and interpolating one raw makes the parser split the URL in the
+    wrong place — which would silently fail the check *and* the lookup that
+    keeps a launch from falling back to this computer's timezone.
+    """
     credentials = ""
     if proxy.username:
-        credentials = proxy.username
+        credentials = quote(proxy.username, safe="")
         if proxy.password:
-            credentials += f":{proxy.password}"
+            credentials += f":{quote(proxy.password, safe='')}"
         credentials += "@"
     return f"{proxy.type.value}://{credentials}{proxy.server}"
 
@@ -222,12 +244,16 @@ def compare(settings: BrowserSettings, location: ProxyLocation) -> list[Finding]
 async def resolve_exit_ip(
     proxy: ProxyConfig | None, timeout: float = DEFAULT_TIMEOUT
 ) -> tuple[str, int]:
-    """Ask, through the proxy, what address the internet sees. Returns (ip, ms)."""
+    """Ask, through the proxy, what address the internet sees. Returns (ip, ms).
+
+    An endpoint that answers with something other than an address is treated as a
+    failure and the next one is tried, as Camoufox does. A captive portal or a
+    rate-limit page can answer 200 with HTML, and that string must never reach a
+    fingerprint key.
+    """
     url = proxy_url(proxy) if proxy else None
     last_error: Exception | None = None
 
-    # TLS is verified. A proxy that intercepts it fails the check with an SSL error,
-    # which is worth knowing rather than papering over.
     async with httpx.AsyncClient(proxy=url, timeout=timeout) as client:
         for endpoint in IP_ENDPOINTS:
             started = time.monotonic()
@@ -238,7 +264,12 @@ async def resolve_exit_ip(
                 last_error = exc
                 logger.debug(f"Proxy check via {endpoint} failed: {exc}")
                 continue
-            return response.text.strip(), int((time.monotonic() - started) * 1000)
+            answer = response.text.strip()
+            if not valid_ipv4(answer) and not valid_ipv6(answer):
+                last_error = ValueError(f"{endpoint} answered with something else")
+                logger.debug(f"Proxy check via {endpoint} returned {answer[:60]!r}")
+                continue
+            return answer, int((time.monotonic() - started) * 1000)
 
     raise ConnectionError(_readable(last_error))
 
@@ -270,7 +301,7 @@ def _readable(error: Exception | None) -> str:
     return f"Could not reach the internet through the proxy: {error}"
 
 
-async def fill_what_geoip_would_have(proxy: ProxyConfig | None, options: dict) -> None:
+async def fill_what_geoip_would_have(proxy: ProxyConfig | None, options: dict[str, Any]) -> None:
     """Supply the IP-derived values Camoufox skips when geoip is off.
 
     Setting coordinates turns geoip off, because that is the only way Camoufox
@@ -281,27 +312,36 @@ async def fill_what_geoip_would_have(proxy: ProxyConfig | None, options: dict) -
     Europe/Moscow, the host's own zone. That is worse than any mismatch, because
     it is the real machine showing through.
 
-    So we do that part ourselves, from the same exit address and the same
-    database Camoufox would have used. A lookup that fails leaves the launch
-    alone rather than blocking it.
+    This reproduces that branch — the address, the timezone and the IPv6 pref that
+    goes with a spoofed v4 candidate — from the same endpoints and the same
+    database Camoufox would have used. It deliberately does not touch the
+    coordinates, which are the reason geoip is off in the first place. A lookup
+    that fails leaves the launch alone rather than blocking it.
     """
     if options.get("geoip"):
         return
 
     config = options.setdefault("config", {})
     needs_timezone = "timezone" not in config
-    needs_webrtc = "webrtc:ipv4" not in config and not options.get("block_webrtc")
+    has_webrtc = "webrtc:ipv4" in config or "webrtc:ipv6" in config
+    needs_webrtc = not has_webrtc and not options.get("block_webrtc")
     if not needs_timezone and not needs_webrtc:
         return
 
     try:
-        ip, _ = await resolve_exit_ip(proxy)
+        ip, _ = await resolve_exit_ip(proxy, timeout=LAUNCH_TIMEOUT)
     except ConnectionError as exc:
         logger.warning(f"Could not find the exit address, leaving the launch alone: {exc}")
         return
 
     if needs_webrtc:
-        config["webrtc:ipv4"] = ip
+        if valid_ipv4(ip):
+            config["webrtc:ipv4"] = ip
+            # Camoufox pairs the v4 spoof with this pref, so a page cannot reach
+            # around the spoofed candidate over IPv6.
+            options.setdefault("firefox_user_prefs", {})["network.dns.disableIPv6"] = True
+        else:
+            config["webrtc:ipv6"] = ip
     if not needs_timezone:
         return
 

--- a/tests/browser/test_fingerprint_stability.py
+++ b/tests/browser/test_fingerprint_stability.py
@@ -47,13 +47,20 @@ async def test_unpinned_profiles_look_like_new_hardware(tmp_path):
 
     If this ever starts passing as "stable", Camoufox changed its behaviour and
     the pinning below may no longer be needed.
+
+    Three launches, not two: Camoufox draws from a finite catalogue of machines,
+    so two consecutive draws can coincide by chance and did once here. Three
+    identical draws would mean it is not drawing at all.
     """
     profile = Profile(name="drift", browser_settings=BrowserSettings(os="windows"))
 
-    first = await observe(profile.to_camoufox_launch_options(), tmp_path / "drift")
-    second = await observe(profile.to_camoufox_launch_options(), tmp_path / "drift")
+    seen = [
+        await observe(profile.to_camoufox_launch_options(), tmp_path / "drift") for _ in range(3)
+    ]
 
-    assert first != second, "expected an unpinned profile to drift between launches"
+    assert any(other != seen[0] for other in seen[1:]), (
+        f"expected an unpinned profile to drift between launches, got {seen[0]}"
+    )
 
 
 @pytest.mark.browser

--- a/tests/unit/test_proxy_check.py
+++ b/tests/unit/test_proxy_check.py
@@ -3,8 +3,10 @@
 compare() is pure, so every rule is tested here without a proxy or a network.
 """
 
+import httpx
 import pytest
 
+from camoufox_pm.core import proxy_check
 from camoufox_pm.core.models import BrowserSettings, ProxyConfig, ProxyType
 from camoufox_pm.core.proxy_check import ProxyLocation, compare, preflight, proxy_url
 
@@ -140,7 +142,159 @@ def test_http_with_credentials_is_fine():
             ProxyConfig(type=ProxyType.HTTPS, server="h:443", username="u"),
             "https://u@h:443",
         ),
+        # Provider-issued passwords routinely contain these. Interpolated raw,
+        # the parser splits on the last "@" and both the host and the
+        # credentials come out wrong.
+        (
+            ProxyConfig(type=ProxyType.HTTP, server="h:8080", username="u@x", password="p@ss:w/d"),
+            "http://u%40x:p%40ss%3Aw%2Fd@h:8080",
+        ),
     ],
 )
 def test_proxy_url_carries_credentials(proxy, expected):
     assert proxy_url(proxy) == expected
+
+
+class FakeResponse:
+    def __init__(self, text: str, status: int = 200):
+        self.text = text
+        self.status_code = status
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("boom", request=None, response=self)  # type: ignore[arg-type]
+
+
+class FakeClient:
+    """Answers each endpoint in turn from a scripted list."""
+
+    def __init__(self, answers):
+        self.answers = list(answers)
+        self.asked: list[str] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url):
+        self.asked.append(url)
+        answer = self.answers.pop(0)
+        if isinstance(answer, Exception):
+            raise answer
+        return FakeResponse(answer)
+
+
+@pytest.fixture
+def answers(monkeypatch):
+    """Script the exit-address endpoints. Returns the client so it can be inspected."""
+    holder = {}
+
+    def install(*scripted):
+        client = FakeClient(scripted)
+        monkeypatch.setattr(proxy_check.httpx, "AsyncClient", lambda **kwargs: client)
+        holder["client"] = client
+        return client
+
+    return install
+
+
+@pytest.mark.asyncio
+async def test_an_endpoint_that_answers_with_a_page_is_skipped(answers):
+    """A captive portal or a rate-limit page can answer 200 with HTML.
+
+    That string must never be taken for an address: it would end up in
+    webrtc:ipv4 and be a far louder tell than the one this module exists to fix.
+    """
+    client = answers("<html>Sign in to continue</html>", "203.0.113.7")
+
+    ip, _ = await proxy_check.resolve_exit_ip(None)
+
+    assert ip == "203.0.113.7"
+    assert len(client.asked) == 2, "expected the bad answer to fall through to the next endpoint"
+
+
+@pytest.mark.asyncio
+async def test_no_endpoint_gives_an_address(answers):
+    answers("nonsense", "also nonsense", "still nonsense")
+
+    with pytest.raises(ConnectionError):
+        await proxy_check.resolve_exit_ip(None)
+
+
+@pytest.mark.asyncio
+async def test_the_ipv6_answer_goes_into_the_ipv6_key(answers):
+    """Camoufox routes a v6 exit address to webrtc:ipv6, and so must this."""
+    answers("2001:db8::1")
+    options = {"geoip": False, "config": {"timezone": "Asia/Tokyo"}}
+
+    await proxy_check.fill_what_geoip_would_have(None, options)
+
+    assert options["config"]["webrtc:ipv6"] == "2001:db8::1"
+    assert "webrtc:ipv4" not in options["config"]
+    assert "firefox_user_prefs" not in options
+
+
+@pytest.mark.asyncio
+async def test_a_spoofed_v4_candidate_brings_its_pref(answers):
+    """Camoufox sets this alongside webrtc:ipv4 so a page cannot reach around the
+    spoofed candidate over IPv6."""
+    answers("203.0.113.7")
+    options = {"geoip": False, "config": {"timezone": "Asia/Tokyo"}}
+
+    await proxy_check.fill_what_geoip_would_have(None, options)
+
+    assert options["config"]["webrtc:ipv4"] == "203.0.113.7"
+    assert options["firefox_user_prefs"]["network.dns.disableIPv6"] is True
+
+
+@pytest.mark.asyncio
+async def test_the_pref_joins_any_others_already_set(answers):
+    """stable_canvas puts its own pref here; filling must not replace it."""
+    answers("203.0.113.7")
+    options = {
+        "geoip": False,
+        "config": {"timezone": "Asia/Tokyo"},
+        "firefox_user_prefs": {"privacy.baselineFingerprintingProtection": False},
+    }
+
+    await proxy_check.fill_what_geoip_would_have(None, options)
+
+    assert options["firefox_user_prefs"] == {
+        "privacy.baselineFingerprintingProtection": False,
+        "network.dns.disableIPv6": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_nothing_is_asked_when_geoip_will_do_it(answers):
+    client = answers("203.0.113.7")
+
+    await proxy_check.fill_what_geoip_would_have(None, {"geoip": True, "config": {}})
+
+    assert client.asked == []
+
+
+@pytest.mark.asyncio
+async def test_a_blocked_webrtc_profile_is_left_alone(answers):
+    """webrtc_mode "none" removes RTCPeerConnection; spoofing an address is moot."""
+    answers("203.0.113.7")
+    options = {"geoip": False, "block_webrtc": True, "config": {"timezone": "Asia/Tokyo"}}
+
+    await proxy_check.fill_what_geoip_would_have(None, options)
+
+    assert "webrtc:ipv4" not in options["config"]
+
+
+@pytest.mark.asyncio
+async def test_an_unreachable_proxy_does_not_block_the_launch(monkeypatch):
+    async def refuse(proxy, timeout=proxy_check.DEFAULT_TIMEOUT):
+        raise ConnectionError("nope")
+
+    monkeypatch.setattr(proxy_check, "resolve_exit_ip", refuse)
+    options = {"geoip": False, "config": {}}
+
+    await proxy_check.fill_what_geoip_would_have(None, options)
+
+    assert options["config"] == {}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -28,6 +28,9 @@
 
   --color-danger: #f2555a;
   --color-danger-shade: #3a1418;
+  /* Detectable-but-not-fatal. Distinct from --color-signal, which means "this is
+     the primary action" or "this profile is running" and nothing else. */
+  --color-warn: #d8a13a;
   --color-ok: #3fb950;
 
   --font-sans: var(--font-plex-sans), ui-sans-serif, system-ui, sans-serif;

--- a/web/src/components/profile-form.tsx
+++ b/web/src/components/profile-form.tsx
@@ -832,6 +832,9 @@ function Section({
  * could notice between that and the profile. A working proxy is not the whole
  * answer — a profile whose timezone contradicts its exit address is detectable
  * however healthy the connection is.
+ *
+ * Three levels, three treatments: red for something that stops the browser
+ * launching, amber for something a page can detect, grey for a note.
  */
 function ProxyCheckResult({ result }: { result: ProxyCheck | null }) {
   if (!result) return null
@@ -862,7 +865,11 @@ function ProxyCheckResult({ result }: { result: ProxyCheck | null }) {
         <p
           key={index}
           className={`flex items-start gap-1.5 ${
-            finding.level === 'info' ? 'text-ink-faint' : 'text-danger'
+            finding.level === 'error'
+              ? 'text-danger'
+              : finding.level === 'warning'
+                ? 'text-warn'
+                : 'text-ink-faint'
           }`}
         >
           {finding.level === 'info' ? (


### PR DESCRIPTION
Acting on a code review of the two branches merged in #7 and #8. Every claim below was checked against the installed Camoufox 152 or reproduced before being fixed.

## Critical

**The exit address went into the fingerprint unchecked.** `resolve_exit_ip` returned `response.text.strip()` verbatim and the launch path wrote it to `webrtc:ipv4`. A captive portal or a rate-limit page answers `200` with HTML, and that string would have become a fingerprint value — a far louder tell than the host-timezone leak the code exists to remove. An IPv6 answer went into the v4 key for the same reason, though Camoufox routes it to `webrtc:ipv6`.

Now validated with Camoufox's own `valid_ipv4`/`valid_ipv6`: a non-address falls through to the next endpoint, and a v6 address goes to the v6 key.

## Important

**Proxy credentials were interpolated raw.** Provider-issued passwords routinely contain `@` or `:`. Verified: httpx rejects `http://u@x:p@ss:w/d@host:8080` outright with `Invalid port: 'w'`. That broke the check button and, worse, the launch-path lookup — which silently reinstated the leak this feature had just fixed. Percent-encoded now, and verified end to end against a local proxy with exactly that password.

- A spoofed v4 candidate now brings `network.dns.disableIPv6`, which Camoufox sets alongside it (`utils.py:747`) so a page cannot reach around the spoof over IPv6.
- The launch path takes Camoufox's own 5 s timeout rather than 10, so a tarpitting proxy cannot hold a browser open across three endpoints.
- `summarize()` read the installed version twice per profile; `is_outdated()` now accepts it.
- **The module claimed locale follows the proxy. It never does** — `handle_locales` runs after the IP lookup and does an unconditional `config.update`, so the profile's languages always win. Docstring corrected. Languages are deliberately *not* compared against the exit country: an English-language browser is unremarkable from anywhere, so that finding would fire on nearly every profile and train people to ignore the panel.
- **Existing profiles are not migrated** and still carry the old random-region geography. The changelog implied otherwise; it and `docs/profile-settings.md` now say so, and rewriting a stored fingerprint under a live account is explicitly rejected as the alternative.

## Minor

- The comment asserting Camoufox defaults `webrtc:localipv4` to the bogon `240.0.0.2` is gone — that string appears nowhere in the shipped build. The verifiable half (the key exists; setting it replaces Firefox's mDNS candidate) stays.
- Warnings get their own colour instead of being drawn identically to errors, so the three documented levels are three visible ones.
- `IP_ENDPOINTS` no longer claims parity with Camoufox: it is 3 of its 6 and we verify TLS where it does not, which is a deliberate difference worth stating.
- `ProxyFindingResponse.level` keeps the `Level` literal, so the OpenAPI schema and the TS union come from one source; `fill_what_geoip_would_have` takes `dict[str, Any]`.
- `SECURITY.md` notes that the check connects to any host it is given, which is a probe on an instance exposed without `CPM_API_KEY`.
- `docs/roadmap.md` restores the item about reconciling a drifted OS setting. The refresh *ignores* the setting; it does not reconcile it, so deleting that line was wrong.

## Tests

Nine new unit tests, including a scripted endpoint that answers with a page, an IPv6 exit, the pref joining `stable_canvas`'s, a blocked-WebRTC profile and an unreachable proxy. Credential encoding is a new case in the URL table.

`test_unpinned_profiles_look_like_new_hardware` flaked once during this run: Camoufox draws from a finite catalogue, so two consecutive draws can coincide. It takes three launches now and asserts they are not all identical.

`ruff`, `mypy`, 133 unit/integration tests, 20 browser tests, and the suite as CI sees it (`HOME=$(mktemp -d)`, no fetched browser).

## Not changed

The reviewer noted `WebRTCMode.REAL`/`FORWARD` are still effectively ignored. That is pre-existing and matches what Camoufox does with geoip on; it belongs in its own change rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)