### PR TITLE
Stabilise the REST API for 1.0 behind /api/v1, with a written contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **A stability contract for the REST API**, written down in `docs/api.md`:
+  what 1.0 freezes (paths, field names, status codes, the error shape), what
+  stays deliberately unstable (the `fingerprint` summary, launch internals),
+  and what is deprecated with the version it goes away in.
+- **`/api/v1` is the canonical API prefix.** The unversioned `/api/...` paths
+  keep working as aliases for existing scripts — same routes, same behaviour —
+  but are left out of the OpenAPI schema so a generated client sees each
+  operation once. They go away in 2.0. The bundled web UI now calls `/api/v1`.
+- **One error shape for every failure.** All non-2xx responses now carry
+  `{"error": {"code", "message", "details"}}` with a stable snake_case `code`;
+  validation failures use it too, so `detail` is no longer sometimes a string
+  and sometimes a list. The top-level `detail` string is kept as a mirror of
+  `error.message` for FastAPI-style clients and is deprecated, removed in 1.0.
+- Every route now declares a stable `operation_id`, a summary and a typed
+  `response_model` — including the browser lifecycle endpoints and `/health`,
+  which returned bare dicts — so a generated client is actually usable.
 - **Check a proxy, and what it says about the profile.** *Check proxy* — in the
   form and in a profile's row menu — reaches the internet through the proxy and
   reports where it comes out, how long it took, and everything a page could
@@ -75,6 +91,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Linux bundles on demand. Signing, installers, and auto-update are documented
   follow-ups (see `docs/accessibility-roadmap.md`).
 
+### Deprecated
+- The flattened `browser_*` fields on `PUT /api/v1/profiles/{id}` — send the
+  same keys inside `browser_settings`. Removed in 1.0.
+- `browser_session_id` in the launch response: a random value no endpoint ever
+  accepted. The launch response now carries `process_id` at the top level.
+  Removed in 1.0.
+- Top-level `detail` in error responses — read `error.message`. Removed in 1.0.
+- The unversioned `/api/...` paths — use `/api/v1/...`. Removed in 2.0.
+
 ### Documentation
 - Rewrote the README around what the product actually is now — profiles that keep
   one machine — and replaced the install instructions, which still described a
@@ -90,6 +115,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   the suite as CI sees it, which is the mistake that broke a CI run.
 
 ### Changed
+- `/health` answers `503` when the database is unreachable instead of a
+  healthy-looking `200`, so load balancers and container healthchecks see the
+  failure without parsing the body.
+- Cloning a profile with bad input returns `400`; it was previously reported as
+  `404` even when the source profile existed.
 - The interface was rebuilt as a control panel: a single accent colour marks the
   primary action and a running browser, so a running profile is the only thing
   that draws the eye. Hairline rules replace nested cards, machine values are

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,9 +2,14 @@
 
 The API is the same one the web UI uses. A running instance serves interactive
 documentation at **`/docs`** (Swagger) and **`/redoc`**, generated from the code —
-that is the authoritative schema. This page is the guided tour.
+that is the authoritative schema. This page is the guided tour, and the
+[stability contract](#stability-contract) below is what we promise to keep.
 
-Base URL: `http://127.0.0.1:8000` by default.
+Base URL: `http://127.0.0.1:8000` by default. Endpoints live under **`/api/v1`**.
+
+The unversioned `/api/...` paths from before 0.2 keep working as aliases — same
+routes, same behaviour — but are left out of the OpenAPI schema so a generated
+client sees each operation once. New code should use `/api/v1`.
 
 ## Authentication
 
@@ -12,7 +17,7 @@ None by default, because the app binds to loopback. Set `CPM_API_KEY` and every
 request must carry it:
 
 ```bash
-curl -H "X-API-Key: $CPM_API_KEY" http://localhost:8000/api/profiles
+curl -H "X-API-Key: $CPM_API_KEY" http://localhost:8000/api/v1/profiles
 ```
 
 The key is compared in constant time. The web UI sends it too — paste it into the
@@ -24,28 +29,95 @@ anybody who can reach the port can read your profiles, including proxy passwords
 ## Conventions
 
 - Request and response bodies are JSON, except file upload and download.
-- Errors return `{"detail": "..."}` with a meaningful status: `400` for a bad
-  request, `404` for a missing profile, `409` for a state conflict (exporting a
-  running profile), `422` for values that fail validation, `500` otherwise.
+- Resource endpoints return the resource itself. Action and system endpoints
+  that have no resource to return use the envelope
+  `{"success": bool, "message": str, "data": ...}`.
 - **A field you send is authoritative, including `null`, which clears it. A field
-  you omit is left alone.** This matters most on `PUT /api/profiles/{id}`: send
-  `{"proxy_config": null}` to detach a proxy; omit the key to leave it.
+  you omit is left alone.** This matters most on `PUT /api/v1/profiles/{id}`:
+  send `{"proxy_config": null}` to detach a proxy; omit the key to leave it.
+- Statuses: `400` for a bad request, `401` for a missing or wrong API key,
+  `404` for a missing resource, `409` for a state conflict (exporting a running
+  profile), `422` for values that fail validation, `500` otherwise.
+
+### Errors
+
+Every non-2xx response has one shape:
+
+```json
+{
+  "error": {
+    "code": "not_found",
+    "message": "Profile with ID x1 not found",
+    "details": null
+  },
+  "detail": "Profile with ID x1 not found"
+}
+```
+
+- `error.code` is a stable snake_case token: `bad_request`, `unauthorized`,
+  `not_found`, `conflict`, `validation_error`, `internal_error`.
+- `error.message` is always a single human-readable string — including for
+  validation failures, which used to arrive as a list.
+- `error.details` carries the structured specifics when there are any; for
+  validation failures it is pydantic's error list, each entry with `loc`,
+  `msg` and `type`.
+- `detail` mirrors `error.message` for clients written against FastAPI's
+  default shape. It is deprecated and goes away in 1.0; read `error.message`.
+
+## Stability contract
+
+`1.0` freezes, for the whole `1.x` line:
+
+- the `/api/v1` paths, methods and status codes documented here;
+- the names and types of every documented request and response field —
+  fields are only ever *added*, never renamed or removed;
+- the error shape above and its `error.code` values;
+- the pagination shape on `GET /api/v1/profiles`.
+
+New endpoints, new optional parameters and new response fields are **not**
+breaking changes and can appear in any release. Anything that would break the
+above waits for a `/api/v2`, at which point `/api/v1` keeps working.
+
+Deliberately **outside** the contract, at 1.0 and after:
+
+- the contents of the `fingerprint` summary on a profile — its values come from
+  Camoufox's fingerprint catalogue and change when Camoufox does;
+- `camoufox_options` in the launch response — launch internals, exposed for
+  debugging;
+- the entries of `actions` in profile statistics;
+- the preset fields beyond `id` and `os` — they describe whatever Camoufox's
+  captured devices carry.
+
+### Deprecated, removed in 1.0
+
+Everything here works throughout `0.1.x` and is marked deprecated in the
+OpenAPI schema:
+
+| Deprecated                                        | Use instead                          |
+| ------------------------------------------------- | ------------------------------------ |
+| Flattened `browser_*` fields on profile update    | the same keys in `browser_settings`  |
+| `browser_session_id` in the launch response       | `profile_id` (it addresses the browser); the id was a random value nothing accepted |
+| Top-level `detail` in error responses             | `error.message`                      |
+
+The unversioned `/api/...` aliases outlive 1.0 — scripts against them keep
+working for the whole `1.x` line — and are removed in 2.0.
 
 ## Profiles
 
 ### List
 
 ```http
-GET /api/profiles?page=1&per_page=25&status=active&group=<id>&search=shop
+GET /api/v1/profiles?page=1&per_page=25&status=active&group=<id>&search=shop
 ```
 
 Returns `{profiles, total, page, per_page, has_next, has_prev}`. `search` matches
-the name.
+the name. This is the only paginated collection: groups and browsers stay small,
+so those lists are returned whole.
 
 ### Create
 
 ```http
-POST /api/profiles
+POST /api/v1/profiles
 ```
 
 ```json
@@ -76,10 +148,10 @@ Only `name` is required. Everything under `browser_settings` that you leave out 
 generated as a consistent fingerprint.
 
 `fingerprint_preset` pins the profile to a real device from
-`GET /api/fingerprints/presets`; the preset then defines the hardware, so values
-it owns are not also generated. This needs the browser installed and returns
-`400` if it is not, rather than creating a profile with a different machine than
-the one asked for.
+`GET /api/v1/fingerprints/presets`; the preset then defines the hardware, so
+values it owns are not also generated. This needs the browser installed and
+returns `400` if it is not, rather than creating a profile with a different
+machine than the one asked for.
 
 Responds `201` with the profile, including a `fingerprint` summary once one is
 pinned.
@@ -87,29 +159,29 @@ pinned.
 ### Read, update, delete
 
 ```http
-GET    /api/profiles/{id}
-PUT    /api/profiles/{id}
-DELETE /api/profiles/{id}
+GET    /api/v1/profiles/{id}
+PUT    /api/v1/profiles/{id}
+DELETE /api/v1/profiles/{id}
 ```
 
 `PUT` takes the same shape as create. `browser_settings` is **merged** over what
 is stored, so sending one field does not reset the rest of the fingerprint. The
 older flattened form (`browser_os`, `browser_timezone`, …) still works and is
-merged the same way.
+merged the same way, but is deprecated — it goes away in 1.0.
 
 ### Other actions
 
 ```http
-POST /api/profiles/{id}/clone              {"new_name": "..."}
-POST /api/profiles/{id}/reset-fingerprint
-GET  /api/profiles/{id}/stats
+POST /api/v1/profiles/{id}/clone              {"new_name": "..."}
+POST /api/v1/profiles/{id}/reset-fingerprint
+GET  /api/v1/profiles/{id}/stats
 ```
 
 `reset-fingerprint` generates new settings **and drops the pinned machine**, so
 the next launch assigns fresh hardware.
 
 ```http
-POST /api/profiles/{id}/refresh-browser
+POST /api/v1/profiles/{id}/refresh-browser
 ```
 
 Moves the pinned machine onto the installed browser version, changing only the
@@ -123,8 +195,8 @@ and `browser_outdated` so a client does not have to parse the user agent.
 ## Checking a proxy
 
 ```http
-POST /api/profiles/{id}/check-proxy
-POST /api/proxy/check      {"proxy_config": {...}, "browser_settings": {...}}
+POST /api/v1/profiles/{id}/check-proxy
+POST /api/v1/proxy/check      {"proxy_config": {...}, "browser_settings": {...}}
 ```
 
 Both reach the internet through the proxy and return the same shape: `reachable`,
@@ -140,22 +212,26 @@ profile form uses so a proxy can be checked before the profile exists; omit
 ## Running browsers
 
 ```http
-POST /api/profiles/{id}/launch    {"headless": false, "window_size": "1280x720"}
-POST /api/profiles/{id}/close
-GET  /api/browsers/active
-POST /api/browsers/close-all
+POST /api/v1/profiles/{id}/launch    {"headless": false, "window_size": "1280x720"}
+POST /api/v1/profiles/{id}/close
+GET  /api/v1/browsers/active
+POST /api/v1/browsers/close-all
 ```
+
+Launch responds with `status` (`launched`, or `already_running` if the profile's
+browser is already up), a `message` and the `process_id`. Closing a browser that
+is not running is a no-op reported as `status: "not_running"`, not an error.
 
 The first launch of a profile resolves its fingerprint and stores it; every
 launch after replays it. Closing the browser window yourself is detected and the
-session is cleaned up, so `/api/browsers/active` reflects reality without polling
-the process table.
+session is cleaned up, so `/api/v1/browsers/active` reflects reality without
+polling the process table.
 
 ## Moving a profile
 
 ```http
-GET  /api/profiles/{id}/export      → application/zip
-POST /api/profiles/import           multipart: file=<archive.zip>[&name=...]
+GET  /api/v1/profiles/{id}/export      → application/zip
+POST /api/v1/profiles/import           multipart: file=<archive.zip>[&name=...]
 ```
 
 The archive carries the profile, its pinned fingerprint and its browser data
@@ -170,7 +246,7 @@ can be restored next to the profile it came from.
 ## Device presets
 
 ```http
-GET /api/fingerprints/presets?os=windows
+GET /api/v1/fingerprints/presets?os=windows
 ```
 
 The fingerprints Camoufox captured from real machines, as
@@ -182,11 +258,11 @@ The catalogue reads without the browser installed; pinning one does not.
 ## Groups
 
 ```http
-GET    /api/groups
-POST   /api/groups            {"name": "Client A", "description": "..."}
-GET    /api/groups/{id}
-PUT    /api/groups/{id}
-DELETE /api/groups/{id}
+GET    /api/v1/groups
+POST   /api/v1/groups            {"name": "Client A", "description": "..."}
+GET    /api/v1/groups/{id}
+PUT    /api/v1/groups/{id}
+DELETE /api/v1/groups/{id}
 ```
 
 Deleting a group keeps its profiles; they become ungrouped.
@@ -194,8 +270,8 @@ Deleting a group keeps its profiles; they become ungrouped.
 ## Bulk editing
 
 ```http
-GET  /api/profiles/export/excel     → .xlsx
-POST /api/profiles/import/excel     multipart: file=<sheet.xlsx>
+GET  /api/v1/profiles/export/excel     → .xlsx
+POST /api/v1/profiles/import/excel     multipart: file=<sheet.xlsx>
 ```
 
 Import always creates new profiles rather than updating existing ones. The export
@@ -204,35 +280,39 @@ contains proxy passwords in clear text. See [excel.md](excel.md).
 ## System
 
 ```http
-GET  /health                             liveness and database state
-GET  /api/system/status                  counts, load, memory, disk, uptime
-GET  /api/system/info                    name, version, uptime
-GET  /api/system/config                  effective configuration, no secret values
-GET  /api/system/profiles/diagnostic     profiles whose storage looks wrong
-POST /api/system/profiles/cleanup        remove orphaned profile directories
-POST /api/system/restart                 close all browsers, ready for a restart
+GET  /health                                liveness and database state
+GET  /api/v1/system/status                  counts, load, memory, disk, uptime
+GET  /api/v1/system/info                    name, version, uptime
+GET  /api/v1/system/config                  effective configuration, no secret values
+GET  /api/v1/system/profiles/diagnostic     profiles whose storage looks wrong
+POST /api/v1/system/profiles/cleanup        remove orphaned profile directories
+POST /api/v1/system/restart                 close all browsers, ready for a restart
 ```
 
-`/api/system/config` reports whether encryption and the API key are on, the bind
-address, the database path and whether the browser is installed — it never
+`/health` is deliberately unversioned, so probes survive API versions. An
+unhealthy instance answers with the same body under a `503`, so a load balancer
+or container healthcheck sees the failure without parsing anything.
+
+`/api/v1/system/config` reports whether encryption and the API key are on, the
+bind address, the database path and whether the browser is installed — it never
 returns the values of secrets. It backs the Settings screen.
 
-`/api/system/restart` does **not** restart the process; it closes every browser so
-you can restart it cleanly yourself.
+`/api/v1/system/restart` does **not** restart the process; it closes every
+browser so you can restart it cleanly yourself.
 
 ## Example: create a profile and run it
 
 ```bash
 API=http://localhost:8000
 
-ID=$(curl -s -X POST $API/api/profiles \
+ID=$(curl -s -X POST $API/api/v1/profiles \
       -H 'Content-Type: application/json' \
       -d '{"name":"demo","browser_settings":{"os":"windows"}}' \
       | python3 -c 'import sys,json; print(json.load(sys.stdin)["id"])')
 
-curl -s -X POST $API/api/profiles/$ID/launch \
+curl -s -X POST $API/api/v1/profiles/$ID/launch \
      -H 'Content-Type: application/json' -d '{"headless":false}'
 
-curl -s $API/api/browsers/active
-curl -s -X POST $API/api/profiles/$ID/close
+curl -s $API/api/v1/browsers/active
+curl -s -X POST $API/api/v1/profiles/$ID/close
 ```

--- a/docs/excel.md
+++ b/docs/excel.md
@@ -8,7 +8,7 @@ spreadsheet carries settings only.
 ## Export
 
 - **Web UI:** the download icon in the toolbar on the Profiles page.
-- **API:** `GET /api/profiles/export/excel`
+- **API:** `GET /api/v1/profiles/export/excel`
 
 Each row is a profile. The header row carries help text and key columns have
 dropdown validation, so the file doubles as a template.
@@ -20,7 +20,7 @@ dropdown validation, so the file doubles as a template.
 ## Import
 
 - **Web UI:** the upload icon in the toolbar.
-- **API:** `POST /api/profiles/import/excel` (multipart file upload)
+- **API:** `POST /api/v1/profiles/import/excel` (multipart file upload)
 
 Import **always creates new profiles** with fresh IDs — it never updates existing
 ones. That keeps IDs unique and avoids overwriting a profile by accident. The

--- a/docs/profile-settings.md
+++ b/docs/profile-settings.md
@@ -85,7 +85,7 @@ A pin never ages by itself. A profile created on Firefox 152 still claims 152 a
 year later, and a browser several releases behind is itself unusual — real
 machines update.
 
-*Update* in the Machine panel (or `POST /api/profiles/{id}/refresh-browser`)
+*Update* in the Machine panel (or `POST /api/v1/profiles/{id}/refresh-browser`)
 moves the pin onto the installed browser and changes **only** the browser
 version. Screen, GPU, cores, fonts and the noise seeds stay exactly as they were,
 which is what a real computer looks like after a browser update. The button
@@ -145,7 +145,7 @@ genuinely exists.
 
 Pick one when creating a profile (the form lists them by screen, CPU count and
 GPU) and the profile is pinned to that device immediately. `GET
-/api/fingerprints/presets` returns the catalogue; ids look like `windows:42` and
+/api/v1/fingerprints/presets` returns the catalogue; ids look like `windows:42` and
 are only a selector — the resolved fingerprint is stored, so a Camoufox update
 that reshuffles the catalogue cannot move an existing profile.
 
@@ -155,8 +155,8 @@ still win.
 
 ## Moving a profile
 
-`GET /api/profiles/{id}/export` packs the profile record, its pinned fingerprint
-and its browser data directory into a single zip; `POST /api/profiles/import`
+`GET /api/v1/profiles/{id}/export` packs the profile record, its pinned fingerprint
+and its browser data directory into a single zip; `POST /api/v1/profiles/import`
 restores it under a new id. In the UI: *Export…* in a profile's row menu, and the
 import button in the toolbar.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,10 +17,13 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
   the profile's timezone and coordinates agree with it.
 - The web UI covers the product: creating profiles, groups, and a settings screen
   reporting how the instance is configured.
+- The REST API is stabilised for `1.0`: `/api/v1` paths (the unversioned ones
+  stay as aliases), one error shape everywhere, typed responses on every route,
+  and a written stability contract in [api.md](api.md) saying what freezes and
+  what deliberately does not.
 
 ## Now (0.1.x)
 
-- Stabilise the REST API before `1.0`.
 - Fill remaining gaps in test coverage.
 
 ## Next

--- a/src/camoufox_pm/api/errors.py
+++ b/src/camoufox_pm/api/errors.py
@@ -1,0 +1,96 @@
+"""One error shape for the whole API.
+
+Every non-2xx response carries the same body:
+
+    {"error": {"code": "...", "message": "...", "details": [...] | null},
+     "detail": "..."}
+
+``error`` is the contract; ``detail`` mirrors ``error.message`` for clients
+written against FastAPI's default shape and goes away in 1.0. Handlers here
+catch both plain ``HTTPException`` (routes, the auth guard, 405s from Starlette)
+and request validation, so a validation failure is no longer the one error that
+looked different.
+"""
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+# Codes are keyed by status so a plain HTTPException still yields a stable,
+# machine-readable code without every raise site naming one.
+DEFAULT_CODES = {
+    400: "bad_request",
+    401: "unauthorized",
+    404: "not_found",
+    405: "method_not_allowed",
+    409: "conflict",
+    413: "payload_too_large",
+    422: "validation_error",
+    500: "internal_error",
+    503: "unavailable",
+}
+
+
+class ApiError(HTTPException):
+    """An ``HTTPException`` that names its error code and structured details."""
+
+    def __init__(
+        self,
+        status_code: int,
+        message: str,
+        code: str | None = None,
+        details: Sequence[Any] | None = None,
+    ) -> None:
+        super().__init__(status_code=status_code, detail=message)
+        self.code = code or DEFAULT_CODES.get(status_code, "error")
+        self.details = details
+
+
+def _payload(code: str, message: str, details: Sequence[Any] | None = None) -> dict[str, Any]:
+    return {
+        "error": {"code": code, "message": message, "details": jsonable_encoder(details)},
+        "detail": message,
+    }
+
+
+def install_error_handlers(app: FastAPI) -> None:
+    """Route every error FastAPI can produce through the one shape."""
+
+    @app.exception_handler(StarletteHTTPException)
+    async def _http_exception(request: Request, exc: StarletteHTTPException) -> JSONResponse:
+        code = getattr(exc, "code", None) or DEFAULT_CODES.get(exc.status_code, "error")
+        details = getattr(exc, "details", None)
+        message = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=_payload(code, message, details),
+            headers=getattr(exc, "headers", None),
+        )
+
+    @app.exception_handler(RequestValidationError)
+    async def _validation_error(request: Request, exc: RequestValidationError) -> JSONResponse:
+        return JSONResponse(
+            status_code=422,
+            content=_payload("validation_error", validation_message(exc.errors()), exc.errors()),
+        )
+
+
+def validation_message(errors: Sequence[Mapping[str, Any]]) -> str:
+    """Flatten pydantic's error list into one readable sentence.
+
+    The structured list still travels in ``error.details``; this is so ``detail``
+    and ``error.message`` stay strings even for validation failures.
+    """
+    parts = []
+    for error in errors[:3]:
+        location = ".".join(str(piece) for piece in error.get("loc", ()))
+        message = error.get("msg", "invalid value")
+        parts.append(f"{location}: {message}" if location else message)
+    if len(errors) > 3:
+        parts.append(f"and {len(errors) - 3} more")
+    return "Validation failed — " + "; ".join(parts)

--- a/src/camoufox_pm/api/models/__init__.py
+++ b/src/camoufox_pm/api/models/__init__.py
@@ -19,7 +19,6 @@ from .profiles import (
 from .system import (
     ApiResponse,
     ErrorResponse,
-    PaginationResponse,
     SystemStatusResponse,
 )
 
@@ -39,5 +38,4 @@ __all__ = [
     "SystemStatusResponse",
     "ApiResponse",
     "ErrorResponse",
-    "PaginationResponse",
 ]

--- a/src/camoufox_pm/api/models/profiles.py
+++ b/src/camoufox_pm/api/models/profiles.py
@@ -25,7 +25,7 @@ class ProfileCreateRequest(BaseModel):
         None,
         description=(
             "Pin the profile to a captured real device, using an id from "
-            "GET /api/fingerprints/presets. Omit to generate a fingerprint instead."
+            "GET /api/v1/fingerprints/presets. Omit to generate a fingerprint instead."
         ),
     )
 
@@ -62,34 +62,48 @@ class ProfileUpdateRequest(BaseModel):
     proxy_config: dict[str, Any] | None = Field(None)
     notes: str | None = Field(None, max_length=1000)
 
-    # Individual browser settings
-    browser_os: str | None = Field(None, description="Operating system (windows, macos, linux)")
-    browser_screen: str | None = Field(None, description="Screen resolution (1920x1080)")
-    browser_user_agent: str | None = Field(None, description="User-Agent string")
-    browser_languages: list[str] | None = Field(None, description="Browser languages")
-    browser_timezone: str | None = Field(None, description="Timezone")
-    browser_locale: str | None = Field(None, description="Locale (en_US, ru_RU)")
-    browser_webrtc_mode: str | None = Field(
-        None, description="WebRTC mode (forward, replace, real, none)"
+    # The legacy flattened form of browser_settings. Kept for 0.1.x clients;
+    # removed in 1.0. Send the same keys inside browser_settings instead.
+    browser_os: str | None = Field(
+        None, description="Operating system (windows, macos, linux)", deprecated=True
     )
-    browser_canvas_noise: bool | None = Field(None, description="Canvas noise")
+    browser_screen: str | None = Field(
+        None, description="Screen resolution (1920x1080)", deprecated=True
+    )
+    browser_user_agent: str | None = Field(None, description="User-Agent string", deprecated=True)
+    browser_languages: list[str] | None = Field(
+        None, description="Browser languages", deprecated=True
+    )
+    browser_timezone: str | None = Field(None, description="Timezone", deprecated=True)
+    browser_locale: str | None = Field(None, description="Locale (en_US, ru_RU)", deprecated=True)
+    browser_webrtc_mode: str | None = Field(
+        None, description="WebRTC mode (forward, replace, real, none)", deprecated=True
+    )
+    browser_canvas_noise: bool | None = Field(None, description="Canvas noise", deprecated=True)
     browser_stable_canvas: bool | None = Field(
         None,
         description=(
             "Keep the canvas reproducible across launches. Costs cross-site "
             "unlinkability: the canvas becomes identical on every site."
         ),
+        deprecated=True,
     )
-    browser_webgl_noise: bool | None = Field(None, description="WebGL noise")
-    browser_audio_noise: bool | None = Field(None, description="Audio noise")
-    browser_hardware_concurrency: int | None = Field(None, ge=1, le=32, description="CPU cores")
-    browser_device_memory: int | None = Field(None, ge=1, le=128, description="Device memory (GB)")
-    browser_max_touch_points: int | None = Field(None, ge=0, le=10, description="Max touch points")
+    browser_webgl_noise: bool | None = Field(None, description="WebGL noise", deprecated=True)
+    browser_audio_noise: bool | None = Field(None, description="Audio noise", deprecated=True)
+    browser_hardware_concurrency: int | None = Field(
+        None, ge=1, le=32, description="CPU cores", deprecated=True
+    )
+    browser_device_memory: int | None = Field(
+        None, ge=1, le=128, description="Device memory (GB)", deprecated=True
+    )
+    browser_max_touch_points: int | None = Field(
+        None, ge=0, le=10, description="Max touch points", deprecated=True
+    )
     browser_window_width: int | None = Field(
-        None, ge=800, le=3840, description="Browser window width"
+        None, ge=800, le=3840, description="Browser window width", deprecated=True
     )
     browser_window_height: int | None = Field(
-        None, ge=600, le=2160, description="Browser window height"
+        None, ge=600, le=2160, description="Browser window height", deprecated=True
     )
 
     model_config = ConfigDict(
@@ -97,11 +111,13 @@ class ProfileUpdateRequest(BaseModel):
             "example": {
                 "status": "inactive",
                 "notes": "Updated notes",
-                "browser_os": "windows",
-                "browser_screen": "1920x1080",
-                "browser_webrtc_mode": "replace",
-                "browser_canvas_noise": True,
-                "browser_webgl_noise": True,
+                "browser_settings": {
+                    "os": "windows",
+                    "screen": "1920x1080",
+                    "webrtc_mode": "replace",
+                    "canvas_noise": True,
+                    "webgl_noise": True,
+                },
             }
         }
     )
@@ -123,7 +139,14 @@ class ProfileResponse(BaseModel):
     last_used: datetime | None
     # A short description of the pinned machine, not the stored config itself:
     # that is ~40 properties and tens of kilobytes, which nothing here needs.
-    fingerprint: dict[str, Any] | None = None
+    fingerprint: dict[str, Any] | None = Field(
+        None,
+        description=(
+            "Summary of the pinned machine, null until the first launch. Its values "
+            "come from Camoufox and may gain keys as Camoufox changes; not frozen "
+            "by the API contract."
+        ),
+    )
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -169,7 +192,9 @@ class ProfileStatsResponse(BaseModel):
     total_duration_minutes: int
     last_session: datetime | None
     success_rate: float
-    actions: list[dict[str, Any]]
+    actions: list[dict[str, Any]] = Field(
+        ..., description="Recent usage log entries; shape not covered by the API contract"
+    )
 
 
 class ProfileCloneRequest(BaseModel):
@@ -209,10 +234,53 @@ class ProfileLaunchResponse(BaseModel):
     """Response returned when a browser is launched."""
 
     profile_id: str
-    browser_session_id: str
-    status: str
+    browser_session_id: str = Field(
+        ...,
+        description=(
+            "A random value that never identified anything; no endpoint accepts it. "
+            "Use profile_id to address the running browser."
+        ),
+        deprecated=True,
+    )
+    status: str = Field(..., description="launched or already_running")
     message: str
-    camoufox_options: dict[str, Any]
+    process_id: int | None = Field(None, description="OS process id of the browser, if known")
+    camoufox_options: dict[str, Any] = Field(
+        ...,
+        description="Launch internals passed to Camoufox; shape not covered by the API contract",
+    )
+
+
+class BrowserCloseResponse(BaseModel):
+    """Response returned when a browser is asked to close."""
+
+    status: str = Field(..., description="closed or not_running")
+    profile_id: str
+    message: str
+
+
+class ActiveBrowserInfo(BaseModel):
+    """One running browser."""
+
+    profile_id: str
+    process_id: int | None
+    started_at: datetime
+
+
+class ActiveBrowsersResponse(BaseModel):
+    """The browsers currently running."""
+
+    active_browsers: list[ActiveBrowserInfo]
+    count: int
+
+
+class BrowsersCloseAllResponse(BaseModel):
+    """Response returned when every browser is asked to close."""
+
+    status: str
+    closed_count: int
+    errors: list[str]
+    message: str
 
 
 class ProxyCheckRequest(BaseModel):

--- a/src/camoufox_pm/api/models/system.py
+++ b/src/camoufox_pm/api/models/system.py
@@ -8,41 +8,54 @@ T = TypeVar("T")
 
 
 class ApiResponse(BaseModel, Generic[T]):
-    """Generic API response."""
+    """Envelope for action endpoints that do not return a resource."""
 
     success: bool = Field(True, description="Whether the operation succeeded")
     message: str = Field("", description="Message")
     data: T | None = Field(None, description="Response payload")
 
 
-class ErrorResponse(BaseModel):
-    """Error response."""
+class ErrorDetail(BaseModel):
+    """The machine-readable part of every error response."""
 
-    success: bool = Field(False)
-    error: str = Field(..., description="Error code")
-    message: str = Field(..., description="Error description")
-    details: dict[str, Any] | None = Field(None, description="Additional details")
+    code: str = Field(..., description="Stable error code (snake_case)")
+    message: str = Field(..., description="Human-readable description")
+    details: list[Any] | None = Field(
+        None, description="Structured specifics; set for validation errors"
+    )
+
+
+class ErrorResponse(BaseModel):
+    """The one shape every non-2xx response uses."""
+
+    error: ErrorDetail
+    detail: str = Field(
+        ...,
+        description="Mirror of error.message for FastAPI-style clients",
+        deprecated=True,
+    )
 
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
-                "success": False,
-                "error": "PROFILE_NOT_FOUND",
-                "message": "Profile not found",
-                "details": {"profile_id": "invalid_id"},
+                "error": {
+                    "code": "not_found",
+                    "message": "Profile with ID x1 not found",
+                    "details": None,
+                },
+                "detail": "Profile with ID x1 not found",
             }
         }
     )
 
 
-class PaginationResponse(BaseModel):
-    """Pagination metadata."""
+class HealthResponse(BaseModel):
+    """Liveness report; unhealthy instances answer with it under a 503."""
 
-    page: int = Field(1, ge=1, description="Page number")
-    per_page: int = Field(10, ge=1, le=100, description="Items per page")
-    total: int = Field(0, ge=0, description="Total number of items")
-    has_next: bool = Field(False, description="Whether a next page exists")
-    has_prev: bool = Field(False, description="Whether a previous page exists")
+    status: str = Field(..., description="healthy or unhealthy")
+    api_version: str
+    database: str = Field(..., description="connected or disconnected")
+    profiles_count: int
 
 
 class SystemStatusResponse(BaseModel):
@@ -56,6 +69,57 @@ class SystemStatusResponse(BaseModel):
     memory_usage: float = Field(..., description="Memory usage in %")
     disk_usage: float = Field(..., description="Disk usage in %")
     uptime_seconds: int = Field(..., description="Uptime in seconds")
+
+
+class SystemInfoData(BaseModel):
+    """Payload of the system info endpoint."""
+
+    name: str
+    version: str
+    description: str
+    uptime_seconds: int
+
+
+class SystemConfigData(BaseModel):
+    """Effective configuration; secrets are reported only as set/unset."""
+
+    version: str
+    host: str
+    port: int
+    database_path: str
+    api_key_set: bool
+    encryption_enabled: bool
+    cors_origins: list[str]
+    camoufox_available: bool
+    uptime_seconds: int
+
+
+class DevicePreset(BaseModel):
+    """A fingerprint captured from a real machine, from Camoufox's catalogue."""
+
+    id: str = Field(..., description="Preset id, '<os>:<index>'")
+    os: str
+    screen: str | None = None
+    hardware_concurrency: int | None = None
+    gpu: str | None = None
+    vendor: str | None = None
+    user_agent: str | None = None
+
+
+class PresetListData(BaseModel):
+    """Payload of the preset catalogue endpoint."""
+
+    presets: list[DevicePreset]
+    total: int
+
+
+class ExcelImportData(BaseModel):
+    """Payload of the Excel import endpoint."""
+
+    created_count: int
+    updated_count: int
+    error_count: int
+    errors: list[str]
 
 
 class ProfileDiagnosticResponse(BaseModel):

--- a/src/camoufox_pm/api/routes/groups.py
+++ b/src/camoufox_pm/api/routes/groups.py
@@ -18,8 +18,9 @@ router = APIRouter()
 @router.get(
     "/groups",
     response_model=GroupListResponse,
-    summary="List groups",
-    description="List all profile groups",
+    operation_id="list_groups",
+    summary="List groups.",
+    description="List all profile groups. Groups are few, so the list is not paginated.",
 )
 async def list_groups():
     """List all groups."""
@@ -46,8 +47,9 @@ async def list_groups():
     "/groups",
     response_model=GroupResponse,
     status_code=status.HTTP_201_CREATED,
-    summary="Create a group",
-    description="Create a new profile group",
+    operation_id="create_group",
+    summary="Create a group.",
+    description="Create a new profile group.",
 )
 async def create_group(request: GroupCreateRequest):
     """Create a new group."""
@@ -74,8 +76,9 @@ async def create_group(request: GroupCreateRequest):
 @router.get(
     "/groups/{group_id}",
     response_model=GroupResponse,
-    summary="Get a group",
-    description="Get information about a group",
+    operation_id="get_group",
+    summary="Get a group.",
+    description="Get information about a group.",
 )
 async def get_group(group_id: str):
     """Get a group by ID."""
@@ -101,8 +104,9 @@ async def get_group(group_id: str):
 @router.put(
     "/groups/{group_id}",
     response_model=GroupResponse,
-    summary="Update a group",
-    description="Update a group's data",
+    operation_id="update_group",
+    summary="Update a group.",
+    description="Update a group's data.",
 )
 async def update_group(group_id: str, request: GroupUpdateRequest):
     """Update a group."""
@@ -134,9 +138,10 @@ async def update_group(group_id: str, request: GroupUpdateRequest):
 
 @router.delete(
     "/groups/{group_id}",
-    response_model=ApiResponse,
-    summary="Delete a group",
-    description="Delete a group (its profiles become ungrouped)",
+    response_model=ApiResponse[None],
+    operation_id="delete_group",
+    summary="Delete a group.",
+    description="Delete a group; its profiles become ungrouped.",
 )
 async def delete_group(group_id: str):
     """Delete a group."""

--- a/src/camoufox_pm/api/routes/profiles.py
+++ b/src/camoufox_pm/api/routes/profiles.py
@@ -17,7 +17,11 @@ from pydantic import ValidationError
 from starlette.background import BackgroundTask
 
 from camoufox_pm.api.dependencies import get_profile_manager
+from camoufox_pm.api.errors import ApiError, validation_message
 from camoufox_pm.api.models.profiles import (
+    ActiveBrowsersResponse,
+    BrowserCloseResponse,
+    BrowsersCloseAllResponse,
     ProfileCloneRequest,
     ProfileCreateRequest,
     ProfileLaunchRequest,
@@ -29,19 +33,40 @@ from camoufox_pm.api.models.profiles import (
     ProxyCheckRequest,
     ProxyCheckResponse,
 )
-from camoufox_pm.api.models.system import ApiResponse
+from camoufox_pm.api.models.system import ApiResponse, ExcelImportData
 from camoufox_pm.core import proxy_check
 from camoufox_pm.core.excel_manager import ExcelManager
 from camoufox_pm.core.models import BrowserSettings, ProfileStatus, ProxyConfig
 
 router = APIRouter()
 
+# Maps the deprecated flattened update fields onto their browser_settings keys.
+_FLATTENED_BROWSER_FIELDS = {
+    "browser_os": "os",
+    "browser_screen": "screen",
+    "browser_user_agent": "user_agent",
+    "browser_languages": "languages",
+    "browser_timezone": "timezone",
+    "browser_locale": "locale",
+    "browser_webrtc_mode": "webrtc_mode",
+    "browser_canvas_noise": "canvas_noise",
+    "browser_stable_canvas": "stable_canvas",
+    "browser_webgl_noise": "webgl_noise",
+    "browser_audio_noise": "audio_noise",
+    "browser_hardware_concurrency": "hardware_concurrency",
+    "browser_device_memory": "device_memory",
+    "browser_max_touch_points": "max_touch_points",
+    "browser_window_width": "window_width",
+    "browser_window_height": "window_height",
+}
+
 
 @router.get(
     "/profiles",
     response_model=ProfileListResponse,
-    summary="List profiles",
-    description="List all profiles with filtering and pagination",
+    operation_id="list_profiles",
+    summary="List profiles.",
+    description="List all profiles with filtering and pagination.",
 )
 async def list_profiles(
     page: int = Query(1, ge=1, description="Page number"),
@@ -95,8 +120,9 @@ async def list_profiles(
     "/profiles",
     response_model=ProfileResponse,
     status_code=status.HTTP_201_CREATED,
-    summary="Create a profile",
-    description="Create a new profile with an auto-generated fingerprint",
+    operation_id="create_profile",
+    summary="Create a profile.",
+    description="Create a new profile with an auto-generated fingerprint.",
 )
 async def create_profile(request: ProfileCreateRequest):
     """Create a new profile."""
@@ -128,8 +154,9 @@ async def create_profile(request: ProfileCreateRequest):
 @router.get(
     "/profiles/{profile_id}",
     response_model=ProfileResponse,
-    summary="Get a profile",
-    description="Get detailed information about a profile",
+    operation_id="get_profile",
+    summary="Get a profile.",
+    description="Get detailed information about a profile.",
 )
 async def get_profile(profile_id: str):
     """Get a profile by ID."""
@@ -152,8 +179,13 @@ async def get_profile(profile_id: str):
 @router.put(
     "/profiles/{profile_id}",
     response_model=ProfileResponse,
-    summary="Update a profile",
-    description="Update a profile's data",
+    operation_id="update_profile",
+    summary="Update a profile.",
+    description=(
+        "Update a profile's data. A field that is sent is authoritative, including "
+        "an explicit null, which clears it; a field that is omitted is left alone. "
+        "browser_settings is merged over the stored settings."
+    ),
 )
 async def update_profile(profile_id: str, request: ProfileUpdateRequest):
     """Update a profile."""
@@ -164,59 +196,32 @@ async def update_profile(profile_id: str, request: ProfileUpdateRequest):
         # which clears it. A field it omitted is left untouched. Testing for
         # "is not None" instead would make clearing a proxy, a group or the
         # notes silently do nothing while still reporting success.
-        sent = request.model_fields_set
+        # Read through model_dump: attribute access on the deprecated flattened
+        # fields would raise DeprecationWarning from inside our own route.
+        sent = request.model_dump(exclude_unset=True)
 
         updates: dict[str, Any] = {}
-        if request.name is not None:
-            updates["name"] = request.name
+        if sent.get("name") is not None:
+            updates["name"] = sent["name"]
         if "group" in sent:
-            updates["group"] = request.group
-        if request.status is not None:
-            updates["status"] = request.status
+            updates["group"] = sent["group"]
+        if sent.get("status") is not None:
+            updates["status"] = sent["status"]
         if "proxy_config" in sent:
-            updates["proxy_config"] = request.proxy_config
+            updates["proxy_config"] = sent["proxy_config"]
         if "notes" in sent:
-            updates["notes"] = request.notes
+            updates["notes"] = sent["notes"]
 
-        # Browser settings arrive either as a nested object or as flattened
-        # browser_* fields. Both are collected here and merged over the stored
-        # settings, so a client that sends only the fields it edits cannot wipe
-        # the rest of the generated fingerprint.
+        # Browser settings arrive either as a nested object or as the deprecated
+        # flattened browser_* fields. Both are collected here and merged over the
+        # stored settings, so a client that sends only the fields it edits cannot
+        # wipe the rest of the generated fingerprint.
         browser_updates: dict[str, Any] = {}
-        if request.browser_settings is not None:
-            browser_updates.update(request.browser_settings)
-        if request.browser_os is not None:
-            browser_updates["os"] = request.browser_os
-        if request.browser_screen is not None:
-            browser_updates["screen"] = request.browser_screen
-        if request.browser_user_agent is not None:
-            browser_updates["user_agent"] = request.browser_user_agent
-        if request.browser_languages is not None:
-            browser_updates["languages"] = request.browser_languages
-        if request.browser_timezone is not None:
-            browser_updates["timezone"] = request.browser_timezone
-        if request.browser_locale is not None:
-            browser_updates["locale"] = request.browser_locale
-        if request.browser_webrtc_mode is not None:
-            browser_updates["webrtc_mode"] = request.browser_webrtc_mode
-        if request.browser_canvas_noise is not None:
-            browser_updates["canvas_noise"] = request.browser_canvas_noise
-        if request.browser_stable_canvas is not None:
-            browser_updates["stable_canvas"] = request.browser_stable_canvas
-        if request.browser_webgl_noise is not None:
-            browser_updates["webgl_noise"] = request.browser_webgl_noise
-        if request.browser_audio_noise is not None:
-            browser_updates["audio_noise"] = request.browser_audio_noise
-        if request.browser_hardware_concurrency is not None:
-            browser_updates["hardware_concurrency"] = request.browser_hardware_concurrency
-        if request.browser_device_memory is not None:
-            browser_updates["device_memory"] = request.browser_device_memory
-        if request.browser_max_touch_points is not None:
-            browser_updates["max_touch_points"] = request.browser_max_touch_points
-        if request.browser_window_width is not None:
-            browser_updates["window_width"] = request.browser_window_width
-        if request.browser_window_height is not None:
-            browser_updates["window_height"] = request.browser_window_height
+        if sent.get("browser_settings") is not None:
+            browser_updates.update(sent["browser_settings"])
+        for field, key in _FLATTENED_BROWSER_FIELDS.items():
+            if sent.get(field) is not None:
+                browser_updates[key] = sent[field]
 
         if browser_updates:
             current_profile = await profile_manager.get_profile(profile_id)
@@ -244,7 +249,7 @@ async def update_profile(profile_id: str, request: ProfileUpdateRequest):
         # fail when it is turned into a BrowserSettings. That is the client's
         # mistake, not a server fault.
         logger.warning(f"Rejected invalid update for profile {profile_id}: {e}")
-        raise HTTPException(status_code=422, detail=e.errors()) from e
+        raise ApiError(422, validation_message(e.errors()), details=e.errors()) from e
     except Exception as e:
         logger.error(f"Failed to update profile {profile_id}: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -252,9 +257,10 @@ async def update_profile(profile_id: str, request: ProfileUpdateRequest):
 
 @router.delete(
     "/profiles/{profile_id}",
-    response_model=ApiResponse,
-    summary="Delete a profile",
-    description="Delete a profile and all associated data",
+    response_model=ApiResponse[None],
+    operation_id="delete_profile",
+    summary="Delete a profile.",
+    description="Delete a profile and all associated data.",
 )
 async def delete_profile(profile_id: str):
     """Delete a profile."""
@@ -281,8 +287,9 @@ async def delete_profile(profile_id: str):
 @router.post(
     "/profiles/{profile_id}/launch",
     response_model=ProfileLaunchResponse,
-    summary="Launch browser",
-    description="Launch Camoufox with the profile's settings",
+    operation_id="launch_profile",
+    summary="Launch a browser.",
+    description="Launch Camoufox with the profile's settings.",
 )
 async def launch_profile(profile_id: str, request: ProfileLaunchRequest):
     """Launch a browser with a profile."""
@@ -304,6 +311,7 @@ async def launch_profile(profile_id: str, request: ProfileLaunchRequest):
             browser_session_id=str(uuid.uuid4()),
             status=browser_session.get("status", "launched"),
             message=browser_session.get("message", "Browser launched successfully"),
+            process_id=browser_session.get("process_id"),
             camoufox_options={
                 "process_id": browser_session.get("process_id"),
                 "status": browser_session.get("status"),
@@ -322,8 +330,9 @@ async def launch_profile(profile_id: str, request: ProfileLaunchRequest):
     "/profiles/{profile_id}/clone",
     response_model=ProfileResponse,
     status_code=status.HTTP_201_CREATED,
-    summary="Clone a profile",
-    description="Create a copy of a profile with a new fingerprint",
+    operation_id="clone_profile",
+    summary="Clone a profile.",
+    description="Create a copy of a profile with a new fingerprint.",
 )
 async def clone_profile(profile_id: str, request: ProfileCloneRequest):
     """Clone a profile."""
@@ -341,8 +350,12 @@ async def clone_profile(profile_id: str, request: ProfileCloneRequest):
 
         return ProfileResponse.from_profile(cloned_profile)
 
+    except HTTPException:
+        raise
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
+        # A missing source returns None above; a ValueError here is bad input
+        # (pydantic's ValidationError subclasses it), not a missing profile.
+        raise HTTPException(status_code=400, detail=str(e)) from e
     except Exception as e:
         logger.error(f"Failed to clone profile {profile_id}: {e}")
         raise HTTPException(status_code=500, detail=str(e)) from e
@@ -351,7 +364,8 @@ async def clone_profile(profile_id: str, request: ProfileCloneRequest):
 @router.post(
     "/profiles/{profile_id}/check-proxy",
     response_model=ProxyCheckResponse,
-    summary="Check a profile's proxy",
+    operation_id="check_profile_proxy",
+    summary="Check a profile's proxy.",
     description=(
         "Reach the internet through the profile's proxy, report where it comes out, "
         "and list everything a page could notice between that and the profile's settings."
@@ -370,7 +384,8 @@ async def check_profile_proxy(profile_id: str):
 @router.post(
     "/proxy/check",
     response_model=ProxyCheckResponse,
-    summary="Check a proxy",
+    operation_id="check_proxy",
+    summary="Check an unsaved proxy.",
     description=(
         "The same check for a proxy that has not been saved yet, so a profile can be "
         "checked while it is still being filled in."
@@ -382,7 +397,7 @@ async def check_proxy(request: ProxyCheckRequest):
         proxy = ProxyConfig(**request.proxy_config) if request.proxy_config else None
         settings = BrowserSettings(**(request.browser_settings or {}))
     except ValidationError as e:
-        raise HTTPException(status_code=422, detail=e.errors()) from e
+        raise ApiError(422, validation_message(e.errors()), details=e.errors()) from e
 
     result = await proxy_check.check(proxy, settings)
     return ProxyCheckResponse.from_result(result)
@@ -391,8 +406,9 @@ async def check_proxy(request: ProxyCheckRequest):
 @router.get(
     "/profiles/{profile_id}/stats",
     response_model=ProfileStatsResponse,
-    summary="Get profile statistics",
-    description="Get usage statistics for a profile",
+    operation_id="get_profile_stats",
+    summary="Get profile statistics.",
+    description="Get usage statistics for a profile.",
 )
 async def get_profile_stats(profile_id: str):
     """Get usage statistics for a profile."""
@@ -426,7 +442,8 @@ async def get_profile_stats(profile_id: str):
 @router.post(
     "/profiles/{profile_id}/refresh-browser",
     response_model=ProfileResponse,
-    summary="Refresh the browser version",
+    operation_id="refresh_browser_version",
+    summary="Refresh the pinned browser version.",
     description=(
         "Move the profile's pinned machine onto the installed browser version, "
         "keeping its hardware. A pin never ages on its own, and a browser several "
@@ -452,11 +469,14 @@ async def refresh_browser_version(profile_id: str):
 
 @router.get(
     "/profiles/{profile_id}/export",
-    summary="Export a profile",
+    operation_id="export_profile",
+    summary="Export a profile.",
     description=(
         "Download the profile and its browser data (cookies, storage, history) as a "
         "single archive. Contains the proxy password and live session cookies."
     ),
+    response_class=FileResponse,
+    responses={200: {"content": {"application/zip": {}}, "description": "The profile archive"}},
 )
 async def export_profile(profile_id: str):
     """Stream a profile archive."""
@@ -495,8 +515,9 @@ async def export_profile(profile_id: str):
     "/profiles/import",
     response_model=ProfileResponse,
     status_code=status.HTTP_201_CREATED,
-    summary="Import a profile",
-    description="Create a profile from an archive produced by the export endpoint",
+    operation_id="import_profile",
+    summary="Import a profile.",
+    description="Create a profile from an archive produced by the export endpoint.",
 )
 async def import_profile(file: UploadFile = File(...), name: str | None = None):
     """Restore a profile from an uploaded archive."""
@@ -522,8 +543,9 @@ async def import_profile(file: UploadFile = File(...), name: str | None = None):
 @router.post(
     "/profiles/{profile_id}/reset-fingerprint",
     response_model=ProfileResponse,
-    summary="Reset fingerprint",
-    description="Fully regenerate the browser fingerprint for a profile",
+    operation_id="reset_profile_fingerprint",
+    summary="Reset the fingerprint.",
+    description="Fully regenerate the browser fingerprint for a profile.",
 )
 async def reset_profile_fingerprint(profile_id: str):
     """Reset and regenerate a profile's fingerprint."""
@@ -553,8 +575,16 @@ async def reset_profile_fingerprint(profile_id: str):
 
 @router.get(
     "/profiles/export/excel",
-    summary="Export profiles to Excel",
-    description="Export all profiles to an Excel file for bulk editing",
+    operation_id="export_profiles_to_excel",
+    summary="Export profiles to Excel.",
+    description="Export all profiles to an Excel file for bulk editing.",
+    response_class=Response,
+    responses={
+        200: {
+            "content": {"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": {}},
+            "description": "The Excel workbook",
+        }
+    },
 )
 async def export_profiles_to_excel():
     """Export all profiles to an Excel file."""
@@ -580,9 +610,10 @@ async def export_profiles_to_excel():
 
 @router.post(
     "/profiles/import/excel",
-    response_model=ApiResponse,
-    summary="Import profiles from Excel",
-    description="Import profiles from an Excel file, creating new ones",
+    response_model=ApiResponse[ExcelImportData],
+    operation_id="import_profiles_from_excel",
+    summary="Import profiles from Excel.",
+    description="Import profiles from an Excel file, creating new ones.",
 )
 async def import_profiles_from_excel(file: UploadFile = File(...)):
     """Import profiles from an Excel file."""
@@ -612,12 +643,12 @@ async def import_profiles_from_excel(file: UploadFile = File(...)):
         return ApiResponse(
             success=result["success"],
             message=result["summary"],
-            data={
-                "created_count": result["created_count"],
-                "updated_count": result["updated_count"],
-                "error_count": result["error_count"],
-                "errors": result["errors"],
-            },
+            data=ExcelImportData(
+                created_count=result["created_count"],
+                updated_count=result["updated_count"],
+                error_count=result["error_count"],
+                errors=result["errors"],
+            ),
         )
 
     except HTTPException:
@@ -629,8 +660,10 @@ async def import_profiles_from_excel(file: UploadFile = File(...)):
 
 @router.post(
     "/profiles/{profile_id}/close",
-    summary="Close browser",
-    description="Force-close the browser for a profile",
+    response_model=BrowserCloseResponse,
+    operation_id="close_profile_browser",
+    summary="Close a profile's browser.",
+    description="Force-close the browser for a profile. Closing one that is not running is a no-op.",
 )
 async def close_profile_browser(profile_id: str):
     """Close the browser for a profile."""
@@ -647,7 +680,11 @@ async def close_profile_browser(profile_id: str):
 
 
 @router.get(
-    "/browsers/active", summary="List active browsers", description="List all active browsers"
+    "/browsers/active",
+    response_model=ActiveBrowsersResponse,
+    operation_id="get_active_browsers",
+    summary="List active browsers.",
+    description="List all running browsers.",
 )
 async def get_active_browsers():
     """List active browsers."""
@@ -664,8 +701,10 @@ async def get_active_browsers():
 
 @router.post(
     "/browsers/close-all",
-    summary="Close all browsers",
-    description="Force-close all active browsers",
+    response_model=BrowsersCloseAllResponse,
+    operation_id="close_all_browsers",
+    summary="Close all browsers.",
+    description="Force-close all active browsers.",
 )
 async def close_all_browsers():
     """Close all active browsers."""

--- a/src/camoufox_pm/api/routes/system.py
+++ b/src/camoufox_pm/api/routes/system.py
@@ -11,8 +11,12 @@ from camoufox_pm import __version__
 from camoufox_pm.api.dependencies import get_profile_manager
 from camoufox_pm.api.models.system import (
     ApiResponse,
+    DevicePreset,
+    PresetListData,
     ProfileCleanupResponse,
     ProfileDiagnosticResponse,
+    SystemConfigData,
+    SystemInfoData,
     SystemStatusResponse,
 )
 from camoufox_pm.config import get_settings
@@ -29,8 +33,9 @@ startup_time = time.time()
 @router.get(
     "/system/status",
     response_model=SystemStatusResponse,
-    summary="Get system status",
-    description="Get an overview of the system state",
+    operation_id="get_system_status",
+    summary="Get the system status.",
+    description="Get an overview of the system state.",
 )
 async def get_system_status():
     """Return an overview of the system state."""
@@ -59,8 +64,9 @@ async def get_system_status():
 @router.get(
     "/system/profiles/diagnostic",
     response_model=ProfileDiagnosticResponse,
-    summary="Diagnose profiles",
-    description="Check profile storage health and find issues",
+    operation_id="diagnose_profiles",
+    summary="Diagnose profile storage.",
+    description="Check profile storage health and find issues.",
 )
 async def diagnostic_profiles():
     """Diagnose profile storage health."""
@@ -89,8 +95,9 @@ async def diagnostic_profiles():
 @router.post(
     "/system/profiles/cleanup",
     response_model=ProfileCleanupResponse,
-    summary="Clean up orphaned profiles",
-    description="Remove profile directories that are not present in the database",
+    operation_id="cleanup_orphaned_profiles",
+    summary="Clean up orphaned profiles.",
+    description="Remove profile directories that are not present in the database.",
 )
 async def cleanup_orphaned_profiles(dry_run: bool = False):
     """Clean up orphaned profile directories."""
@@ -129,9 +136,10 @@ async def cleanup_orphaned_profiles(dry_run: bool = False):
 
 @router.post(
     "/system/restart",
-    response_model=ApiResponse,
-    summary="Restart",
-    description="Close all browsers as part of a safe restart",
+    response_model=ApiResponse[None],
+    operation_id="restart_system",
+    summary="Prepare for a restart.",
+    description="Close all browsers as part of a safe restart. Does not restart the process itself.",
 )
 async def restart_system():
     """Close all browsers in preparation for a restart."""
@@ -149,8 +157,9 @@ async def restart_system():
 
 @router.get(
     "/fingerprints/presets",
-    response_model=ApiResponse,
-    summary="List real device presets",
+    response_model=ApiResponse[PresetListData],
+    operation_id="list_fingerprint_presets",
+    summary="List real device presets.",
     description=(
         "Fingerprints captured from real machines, bundled with Camoufox. A profile "
         "created from one is pinned to that device instead of a generated fingerprint."
@@ -164,14 +173,17 @@ async def list_fingerprint_presets(
     return ApiResponse(
         success=True,
         message=f"{len(presets)} presets available",
-        data={"presets": presets, "total": len(presets)},
+        data=PresetListData(
+            presets=[DevicePreset(**preset) for preset in presets], total=len(presets)
+        ),
     )
 
 
 @router.get(
     "/system/config",
-    response_model=ApiResponse,
-    summary="Effective configuration",
+    response_model=ApiResponse[SystemConfigData],
+    operation_id="get_system_config",
+    summary="Report the effective configuration.",
     description="Report how this instance is configured. Never returns secret values.",
 )
 async def get_system_config():
@@ -184,35 +196,36 @@ async def get_system_config():
     return ApiResponse(
         success=True,
         message="Effective configuration",
-        data={
-            "version": __version__,
-            "host": settings.host,
-            "port": settings.port,
-            "database_path": str(Path(settings.db_path).resolve()),
-            "api_key_set": bool(settings.api_key),
-            "encryption_enabled": bool(settings.secret_key),
-            "cors_origins": settings.cors_origins,
-            "camoufox_available": CAMOUFOX_AVAILABLE,
-            "uptime_seconds": int(time.time() - startup_time),
-        },
+        data=SystemConfigData(
+            version=__version__,
+            host=settings.host,
+            port=settings.port,
+            database_path=str(Path(settings.db_path).resolve()),
+            api_key_set=bool(settings.api_key),
+            encryption_enabled=bool(settings.secret_key),
+            cors_origins=settings.cors_origins,
+            camoufox_available=CAMOUFOX_AVAILABLE,
+            uptime_seconds=int(time.time() - startup_time),
+        ),
     )
 
 
 @router.get(
     "/system/info",
-    response_model=ApiResponse,
-    summary="System info",
-    description="Basic information about the API",
+    response_model=ApiResponse[SystemInfoData],
+    operation_id="get_system_info",
+    summary="Get basic API information.",
+    description="Basic information about the API.",
 )
 async def get_system_info():
     """Return basic information about the API."""
     return ApiResponse(
         success=True,
         message="Camoufox Profile Manager API",
-        data={
-            "name": "camoufox-profile-manager",
-            "version": __version__,
-            "description": "Antidetect browser profile manager API",
-            "uptime_seconds": int(time.time() - startup_time),
-        },
+        data=SystemInfoData(
+            name="camoufox-profile-manager",
+            version=__version__,
+            description="Antidetect browser profile manager API",
+            uptime_seconds=int(time.time() - startup_time),
+        ),
     )

--- a/src/camoufox_pm/main.py
+++ b/src/camoufox_pm/main.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import RedirectResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from loguru import logger
 
@@ -15,7 +15,9 @@ from camoufox_pm.api.dependencies import (
     set_profile_manager,
     set_storage_manager,
 )
+from camoufox_pm.api.errors import install_error_handlers
 from camoufox_pm.api.middleware.logging import LoggingMiddleware
+from camoufox_pm.api.models.system import ErrorResponse, HealthResponse
 from camoufox_pm.api.routes import groups, profiles, system
 from camoufox_pm.config import get_settings
 from camoufox_pm.core.database import StorageManager
@@ -52,13 +54,18 @@ app = FastAPI(
     description=(
         "Self-hosted, open-source antidetect browser profile manager built on "
         "Camoufox. Manage profiles and groups, generate fingerprints, launch the "
-        "browser, and drive everything over a REST API."
+        "browser, and drive everything over a REST API.\n\n"
+        "Endpoints live under `/api/v1`. The unversioned `/api/...` paths from "
+        "before 0.2 keep working as aliases but are left out of this schema; "
+        "see the stability contract in `docs/api.md`."
     ),
     version=__version__,
     docs_url="/docs",
     redoc_url="/redoc",
     lifespan=lifespan,
+    responses={"4XX": {"model": ErrorResponse}, "5XX": {"model": ErrorResponse}},
 )
+install_error_handlers(app)
 
 app.add_middleware(
     CORSMiddleware,
@@ -73,32 +80,65 @@ app.add_middleware(LoggingMiddleware)
 
 # Optional API-key guard; a no-op when CPM_API_KEY is unset.
 protected = [Depends(require_api_key)]
-app.include_router(profiles.router, prefix="/api", tags=["Profiles"], dependencies=protected)
-app.include_router(groups.router, prefix="/api", tags=["Groups"], dependencies=protected)
-app.include_router(system.router, prefix="/api", tags=["System"], dependencies=protected)
+# /api/v1 is the canonical prefix. The same routers are also served under the
+# pre-0.2 unversioned /api so existing scripts keep working; those copies are
+# left out of the schema so a generated client sees each operation once.
+for _prefix, _in_schema in (("/api/v1", True), ("/api", False)):
+    app.include_router(
+        profiles.router,
+        prefix=_prefix,
+        tags=["Profiles"],
+        dependencies=protected,
+        include_in_schema=_in_schema,
+    )
+    app.include_router(
+        groups.router,
+        prefix=_prefix,
+        tags=["Groups"],
+        dependencies=protected,
+        include_in_schema=_in_schema,
+    )
+    app.include_router(
+        system.router,
+        prefix=_prefix,
+        tags=["System"],
+        dependencies=protected,
+        include_in_schema=_in_schema,
+    )
 
 
-@app.get("/health", tags=["System"])
+@app.get(
+    "/health",
+    tags=["System"],
+    response_model=HealthResponse,
+    operation_id="health_check",
+    summary="Report API and database health.",
+)
 async def health_check():
-    """Report API and database health."""
+    """Report API and database health. Unversioned so probes survive API versions."""
     from camoufox_pm.api.dependencies import get_profile_manager
 
     try:
         profile_mgr = get_profile_manager()
         profiles_list = await profile_mgr.list_profiles()
-        return {
-            "status": "healthy",
-            "api_version": __version__,
-            "database": "connected",
-            "profiles_count": len(profiles_list),
-        }
+        return HealthResponse(
+            status="healthy",
+            api_version=__version__,
+            database="connected",
+            profiles_count=len(profiles_list),
+        )
     except Exception:
-        return {
-            "status": "unhealthy",
-            "api_version": __version__,
-            "database": "disconnected",
-            "profiles_count": 0,
-        }
+        # 503 rather than a healthy-looking 200, so load balancers and container
+        # healthchecks see the failure without parsing the body.
+        return JSONResponse(
+            status_code=503,
+            content=HealthResponse(
+                status="unhealthy",
+                api_version=__version__,
+                database="disconnected",
+                profiles_count=0,
+            ).model_dump(),
+        )
 
 
 def _webui_dir() -> Path | None:

--- a/tests/integration/test_api_contract.py
+++ b/tests/integration/test_api_contract.py
@@ -1,0 +1,112 @@
+"""Integration tests for the 1.0 API contract: versioned paths, one error shape,
+and a schema a client can be generated from.
+
+The older tests in this directory deliberately keep calling the unversioned
+``/api`` paths — they double as regression coverage for the alias.
+"""
+
+import pytest
+
+from camoufox_pm.main import app
+
+
+@pytest.mark.asyncio
+async def test_v1_is_canonical_and_the_legacy_alias_serves_the_same_data(client):
+    created = await client.post("/api/v1/profiles", json={"name": "versioned"})
+    assert created.status_code == 201
+    profile_id = created.json()["id"]
+
+    via_v1 = await client.get(f"/api/v1/profiles/{profile_id}")
+    via_alias = await client.get(f"/api/profiles/{profile_id}")
+    assert via_v1.status_code == via_alias.status_code == 200
+    assert via_v1.json() == via_alias.json()
+
+
+@pytest.mark.asyncio
+async def test_errors_share_one_shape(client):
+    response = await client.get("/api/v1/profiles/does-not-exist")
+    assert response.status_code == 404
+    body = response.json()
+    assert body["error"]["code"] == "not_found"
+    assert isinstance(body["error"]["message"], str)
+    # The legacy mirror, kept until 1.0.
+    assert body["detail"] == body["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_request_validation_errors_use_the_same_shape(client):
+    """FastAPI's own validation errors must not be the one differently-shaped error."""
+    response = await client.post("/api/v1/profiles", json={"name": ""})
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error"]["code"] == "validation_error"
+    assert isinstance(body["detail"], str), "detail used to be a list here"
+    assert isinstance(body["error"]["details"], list)
+    assert body["error"]["details"][0]["loc"]
+
+
+@pytest.mark.asyncio
+async def test_late_validation_errors_use_the_same_shape(client):
+    """browser_settings is free-form on the way in, so it fails after FastAPI."""
+    created = await client.post("/api/v1/profiles", json={"name": "late"})
+    response = await client.put(
+        f"/api/v1/profiles/{created.json()['id']}",
+        json={"browser_settings": {"hardware_concurrency": "many"}},
+    )
+    assert response.status_code == 422
+    body = response.json()
+    assert body["error"]["code"] == "validation_error"
+    assert isinstance(body["detail"], str)
+    assert isinstance(body["error"]["details"], list)
+
+
+@pytest.mark.asyncio
+async def test_auth_failures_use_the_same_shape(client, monkeypatch):
+    from camoufox_pm.config import get_settings
+
+    monkeypatch.setenv("CPM_API_KEY", "top-secret")
+    get_settings.cache_clear()
+    try:
+        response = await client.get("/api/v1/profiles")
+        assert response.status_code == 401
+        assert response.json()["error"]["code"] == "unauthorized"
+    finally:
+        get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_health_reports_unhealthy_as_503(client, monkeypatch):
+    """A healthy-looking 200 would hide the failure from probes that only read
+    the status code."""
+    from camoufox_pm.api import dependencies
+
+    monkeypatch.setattr(dependencies, "_profile_manager", None)
+    response = await client.get("/health")
+    assert response.status_code == 503
+    assert response.json()["status"] == "unhealthy"
+    assert response.json()["database"] == "disconnected"
+
+
+def test_openapi_exposes_only_versioned_paths_with_stable_operation_ids():
+    schema = app.openapi()
+    api_paths = [path for path in schema["paths"] if path.startswith("/api")]
+    assert api_paths, "the API disappeared from its own schema"
+    assert all(path.startswith("/api/v1/") for path in api_paths), (
+        "legacy alias paths must stay out of the schema so a generated client "
+        "sees each operation once"
+    )
+
+    operation_ids = []
+    for path, methods in schema["paths"].items():
+        for method, operation in methods.items():
+            operation_ids.append(operation["operationId"])
+            assert operation.get("summary"), f"{method.upper()} {path} has no summary"
+    assert len(operation_ids) == len(set(operation_ids)), "operation ids must be unique"
+
+
+def test_deprecations_are_marked_in_the_schema():
+    schema = app.openapi()
+    update_request = schema["components"]["schemas"]["ProfileUpdateRequest"]
+    assert update_request["properties"]["browser_os"].get("deprecated") is True
+    launch_response = schema["components"]["schemas"]["ProfileLaunchResponse"]
+    assert launch_response["properties"]["browser_session_id"].get("deprecated") is True

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -635,7 +635,7 @@ export default function ProfilesPage() {
                   </td>
                   <td className="py-2.5 pr-4 text-ink-dim">{formatLastUsed(profile.last_used)}</td>
                   <td className="py-2.5 pr-4 font-mono text-ink-faint">
-                    {formatProxyString(profile.proxy ?? profile.proxy_config) || '—'}
+                    {formatProxyString(profile.proxy_config) || '—'}
                   </td>
 
                   <td className="py-2.5 pr-5">

--- a/web/src/components/profile-form.tsx
+++ b/web/src/components/profile-form.tsx
@@ -61,7 +61,7 @@ const EMPTY: FormState = {
 
 function fromProfile(profile: Profile): FormState {
   const bs = profile.browser_settings ?? {}
-  const proxy = profile.proxy ?? profile.proxy_config ?? {}
+  const proxy = profile.proxy_config ?? {}
   const geo = bs.geolocation
   const lat = geo?.lat ?? geo?.latitude
   const lon = geo?.lon ?? geo?.longitude

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5,6 +5,10 @@
 
 export const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? ''
 
+// Canonical API prefix. The backend still serves the unversioned /api paths as
+// aliases for older scripts; the bundled UI always talks to the current one.
+const API_PREFIX = '/api/v1'
+
 export interface BrowserSettings {
   os: string
   screen: string
@@ -64,7 +68,6 @@ export interface Profile {
   status: string
   browser_settings: BrowserSettings
   proxy_config?: ProxyConfig | null
-  proxy?: ProxyConfig | null
   storage_path?: string | null
   notes?: string | null
   created_at: string
@@ -135,14 +138,10 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
     let detail = response.statusText
     try {
       const body = await response.json()
-      // FastAPI validation errors arrive as a list of objects; flatten them so
-      // the toast shows something readable instead of "[object Object]".
-      const raw = body.detail ?? body.message ?? detail
-      detail = Array.isArray(raw)
-        ? raw.map((item) => item?.msg ?? JSON.stringify(item)).join('; ')
-        : typeof raw === 'string'
-          ? raw
-          : JSON.stringify(raw)
+      // Every API error carries error.message; detail is the legacy mirror,
+      // kept as a fallback for anything not yet on the one error shape.
+      const raw = body.error?.message ?? body.detail ?? body.message ?? detail
+      detail = typeof raw === 'string' ? raw : JSON.stringify(raw)
     } catch {
       // response had no JSON body
     }
@@ -184,49 +183,49 @@ export interface ProxyCheck {
 
 export const profilesAPI = {
   getProfiles(params: Record<string, unknown> = {}): Promise<ProfilesResponse> {
-    return request<ProfilesResponse>(`/api/profiles${toQuery(params)}`)
+    return request<ProfilesResponse>(`${API_PREFIX}/profiles${toQuery(params)}`)
   },
 
   createProfile(data: Record<string, unknown>): Promise<Profile> {
-    return request<Profile>('/api/profiles', { method: 'POST', body: JSON.stringify(data) })
+    return request<Profile>(`${API_PREFIX}/profiles`, { method: 'POST', body: JSON.stringify(data) })
   },
 
   updateProfile(id: string, data: Record<string, unknown>): Promise<Profile> {
-    return request<Profile>(`/api/profiles/${id}`, { method: 'PUT', body: JSON.stringify(data) })
+    return request<Profile>(`${API_PREFIX}/profiles/${id}`, { method: 'PUT', body: JSON.stringify(data) })
   },
 
   deleteProfile(id: string): Promise<void> {
-    return request<void>(`/api/profiles/${id}`, { method: 'DELETE' })
+    return request<void>(`${API_PREFIX}/profiles/${id}`, { method: 'DELETE' })
   },
 
   cloneProfile(id: string, newName: string): Promise<Profile> {
-    return request<Profile>(`/api/profiles/${id}/clone`, {
+    return request<Profile>(`${API_PREFIX}/profiles/${id}/clone`, {
       method: 'POST',
       body: JSON.stringify({ new_name: newName }),
     })
   },
 
   startProfile(id: string): Promise<unknown> {
-    return request<unknown>(`/api/profiles/${id}/launch`, {
+    return request<unknown>(`${API_PREFIX}/profiles/${id}/launch`, {
       method: 'POST',
       body: JSON.stringify({ headless: false }),
     })
   },
 
   closeProfile(id: string): Promise<unknown> {
-    return request<unknown>(`/api/profiles/${id}/close`, { method: 'POST' })
+    return request<unknown>(`${API_PREFIX}/profiles/${id}/close`, { method: 'POST' })
   },
 
   resetFingerprint(id: string): Promise<Profile> {
-    return request<Profile>(`/api/profiles/${id}/reset-fingerprint`, { method: 'POST' })
+    return request<Profile>(`${API_PREFIX}/profiles/${id}/reset-fingerprint`, { method: 'POST' })
   },
 
   refreshBrowserVersion(id: string): Promise<Profile> {
-    return request<Profile>(`/api/profiles/${id}/refresh-browser`, { method: 'POST' })
+    return request<Profile>(`${API_PREFIX}/profiles/${id}/refresh-browser`, { method: 'POST' })
   },
 
   checkProxy(id: string): Promise<ProxyCheck> {
-    return request<ProxyCheck>(`/api/profiles/${id}/check-proxy`, { method: 'POST' })
+    return request<ProxyCheck>(`${API_PREFIX}/profiles/${id}/check-proxy`, { method: 'POST' })
   },
 
   // The same check for a profile that is still being filled in, so the form can
@@ -235,11 +234,11 @@ export const profilesAPI = {
     proxy_config: Record<string, unknown> | null
     browser_settings: Record<string, unknown>
   }): Promise<ProxyCheck> {
-    return request<ProxyCheck>('/api/proxy/check', { method: 'POST', body: JSON.stringify(body) })
+    return request<ProxyCheck>(`${API_PREFIX}/proxy/check`, { method: 'POST', body: JSON.stringify(body) })
   },
 
   async exportExcel(): Promise<Blob> {
-    const response = await fetch(`${API_BASE_URL}/api/profiles/export/excel`, {
+    const response = await fetch(`${API_BASE_URL}${API_PREFIX}/profiles/export/excel`, {
       headers: authHeaders(),
     })
     if (!response.ok) throw new Error(response.statusText)
@@ -247,7 +246,7 @@ export const profilesAPI = {
   },
 
   async exportArchive(id: string): Promise<Blob> {
-    const response = await fetch(`${API_BASE_URL}/api/profiles/${id}/export`, {
+    const response = await fetch(`${API_BASE_URL}${API_PREFIX}/profiles/${id}/export`, {
       headers: authHeaders(),
     })
     if (!response.ok) {
@@ -261,7 +260,7 @@ export const profilesAPI = {
     const body = new FormData()
     body.append('file', file)
     // No Content-Type: the browser has to set the multipart boundary itself.
-    const response = await fetch(`${API_BASE_URL}/api/profiles/import`, {
+    const response = await fetch(`${API_BASE_URL}${API_PREFIX}/profiles/import`, {
       method: 'POST',
       headers: authHeaders(),
       body,
@@ -277,7 +276,7 @@ export const profilesAPI = {
     const body = new FormData()
     body.append('file', file)
     // No Content-Type: the browser has to set the multipart boundary itself.
-    const response = await fetch(`${API_BASE_URL}/api/profiles/import/excel`, {
+    const response = await fetch(`${API_BASE_URL}${API_PREFIX}/profiles/import/excel`, {
       method: 'POST',
       headers: authHeaders(),
       body,
@@ -294,29 +293,29 @@ export interface ImportResult {
 
 export const browsersAPI = {
   active(): Promise<{ active_browsers: { profile_id: string }[]; count: number }> {
-    return request('/api/browsers/active')
+    return request(`${API_PREFIX}/browsers/active`)
   },
 
   closeAll(): Promise<{ closed_count: number; message: string }> {
-    return request('/api/browsers/close-all', { method: 'POST' })
+    return request(`${API_PREFIX}/browsers/close-all`, { method: 'POST' })
   },
 }
 
 export const groupsAPI = {
   list(): Promise<{ groups: Group[]; total: number }> {
-    return request('/api/groups')
+    return request(`${API_PREFIX}/groups`)
   },
 
   create(data: { name: string; description?: string }): Promise<Group> {
-    return request<Group>('/api/groups', { method: 'POST', body: JSON.stringify(data) })
+    return request<Group>(`${API_PREFIX}/groups`, { method: 'POST', body: JSON.stringify(data) })
   },
 
   update(id: string, data: { name?: string; description?: string }): Promise<Group> {
-    return request<Group>(`/api/groups/${id}`, { method: 'PUT', body: JSON.stringify(data) })
+    return request<Group>(`${API_PREFIX}/groups/${id}`, { method: 'PUT', body: JSON.stringify(data) })
   },
 
   remove(id: string): Promise<void> {
-    return request<void>(`/api/groups/${id}`, { method: 'DELETE' })
+    return request<void>(`${API_PREFIX}/groups/${id}`, { method: 'DELETE' })
   },
 }
 
@@ -346,7 +345,7 @@ export interface DevicePreset {
 export const presetsAPI = {
   async list(os?: string): Promise<DevicePreset[]> {
     const body = await request<{ data: { presets: DevicePreset[] } }>(
-      `/api/fingerprints/presets${toQuery({ os })}`,
+      `${API_PREFIX}/fingerprints/presets${toQuery({ os })}`,
     )
     return body.data.presets
   },
@@ -354,11 +353,11 @@ export const presetsAPI = {
 
 export const systemAPI = {
   status(): Promise<SystemStatus> {
-    return request<SystemStatus>('/api/system/status')
+    return request<SystemStatus>(`${API_PREFIX}/system/status`)
   },
 
   async config(): Promise<SystemConfig> {
-    const body = await request<{ data: SystemConfig }>('/api/system/config')
+    const body = await request<{ data: SystemConfig }>(`${API_PREFIX}/system/config`)
     return body.data
   },
 }


### PR DESCRIPTION
Closes the roadmap item "Stabilise the REST API before 1.0." This is a contract decision, written down and enforced, not just a cleanup.

## Decisions (each with its cost)

**Versioned at `/api/v1`; unversioned `/api` kept as a live alias.** The same routers are mounted under both prefixes; the alias copies are `include_in_schema=False`, so a generated client sees each operation once. Cost: the alias is invisible in the schema — deliberate, and documented. Scripts against `/api/...` keep working through all of 1.x; the alias is slated for removal in **2.0**, because silently breaking a self-hosted user's loopback scripts is the worst failure mode here. `/health` stays unversioned so probes outlive API versions.

**One error shape everywhere:** `{"error": {"code", "message", "details"}, "detail": "<string>"}`, via new `api/errors.py` handling `HTTPException` and `RequestValidationError`. Validation errors — the one case whose `detail` used to be a *list* — now flatten to a sentence, with pydantic's structured list preserved in `error.details`. `detail` is kept as a string mirror for FastAPI-style clients, deprecated, gone in 1.0.

**Resource model made consistent:** `proxy_config` is canonical (the API never actually returned `proxy` — the UI's fallback was dead code, removed); the flattened `browser_*` update fields are `deprecated=True` but functional; bare-dict endpoints got real response models (shapes unchanged, schemas now honest).

## Bugs found while auditing

- **`browser_session_id` was `str(uuid.uuid4())` minted per request** — fabricated data identifying nothing, accepted by no endpoint. Deprecated; the real `process_id` is now top-level.
- **Clone mapped `ValueError → 404`**, but pydantic's `ValidationError` subclasses `ValueError`, so bad input could 404 an existing profile. Now 400.
- **`/health` returned 200 while reporting itself unhealthy** — invisible to any probe reading the status code. Now 503 when the database is unreachable.
- Dead `ErrorResponse` / `PaginationResponse` models removed.

## Deprecations (all working through 0.1.x, marked in the schema)

| What | Replacement | Removed in |
|---|---|---|
| Flattened `browser_*` on profile update | same keys in `browser_settings` | 1.0 |
| `browser_session_id` in launch response | top-level `process_id` | 1.0 |
| Top-level `detail` in errors | `error.message` | 1.0 |
| Unversioned `/api/...` | `/api/v1/...` | 2.0 |

The **stability contract** is now a section in `docs/api.md`: what 1.0 freezes (paths, field names/types additively, status codes, error shape, pagination) and what stays explicitly unstable even at 1.0 (the `fingerprint` blob — Camoufox's, not ours — `camoufox_options`, stats `actions`, preset fields beyond `id`/`os`).

## Gates — verified independently in a fresh worktree

```
ruff check / format   clean
mypy                  Success: no issues found in 29 source files
pytest -m "not browser"  141 passed, 20 deselected  (+8 contract tests)
tsc / next lint / next build   clean
```

Live against a running instance (mine, not the agent's): `/api/v1` create + `/api` alias read return identical data; 404 and 422 both emit the one error shape with a string `detail`; `/health` 200; `openapi.json` has **zero** non-v1 `/api` paths and 32 operations with unique operationIds; the rebuilt bundled UI loaded and fetched `/api/v1/...`.

## Note on merge order

This touches the route and model files and `web/src/lib/api.ts`. The `profile-coherence` PR was branched before this and adds routes under the old prefix; it will be rebased onto this and its new routes inherit the dual-prefix mount automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)