### PR TITLE
Make a profile's OS setting and old geography reconcilable, not silently wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,31 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Every route now declares a stable `operation_id`, a summary and a typed
   `response_model` — including the browser lifecycle endpoints and `/health`,
   which returned bare dicts — so a generated client is actually usable.
+- **A profile that disagrees with itself now says so, and offers the fix.** Two
+  cases, both of which a profile could previously carry silently:
+  - **The OS setting and the pinned machine.** The pin is what a page sees, so
+    changing the `os` dropdown on a pinned profile changed nothing observable and
+    warned about nothing — the setting just quietly stopped meaning anything. The
+    profile response now reports `pinned_os`, `settings_os` and `os_mismatch`,
+    the save is logged, the form says so under the dropdown, and the Machine
+    panel offers both honest ways out: *Keep this machine* puts the setting back
+    and changes no fingerprint value at all, or a new machine is pinned for the
+    OS that was chosen — new screen, GPU, cores, fonts and seeds, which for a
+    warmed-up account is a real cost. `POST /api/profiles/{id}/reconcile-os`,
+    which refuses when the two already agree.
+  - **Geography from before it followed the proxy.** Profiles created when every
+    new one was given a randomly chosen region still carry that timezone and
+    those coordinates, so an old profile can claim Shanghai on a German proxy and
+    only find out if someone presses *Check proxy*. They are still not migrated
+    behind the user's back, but both fields can now be cleared in one action —
+    from the profile form, or as a bulk action on a selection in the profiles
+    list — after which Camoufox derives the timezone, the coordinates and the
+    WebRTC address from the exit address, as it does for a profile created today.
+    Languages and locale are left alone; they are identity, not geography.
+    `POST /api/profiles/clear-geography`. No heuristic guesses which values were
+    deliberate: nothing recorded it, and the only distinguishable signal is
+    exactly what a deliberate choice of that city would look like, so the action
+    is offered wherever geography is set and explained rather than inferred.
 - **Check a proxy, and what it says about the profile.** *Check proxy* — in the
   form and in a profile's row menu — reaches the internet through the proxy and
   reports where it comes out, how long it took, and everything a page could

--- a/docs/api.md
+++ b/docs/api.md
@@ -192,6 +192,33 @@ profile response says when. Returns `400` if the profile has no pin yet.
 The response's `fingerprint` summary carries `browser_major`, `installed_major`
 and `browser_outdated` so a client does not have to parse the user agent.
 
+```http
+POST /api/profiles/{id}/reconcile-os     {"keep_machine": true}
+```
+
+Brings a profile's `os` setting and its pinned machine back into agreement. The
+summary reports the disagreement as `pinned_os`, `settings_os` and `os_mismatch`.
+
+- `keep_machine: true` sets `os` to what the pin reports and changes **no**
+  fingerprint value.
+- `keep_machine: false` pins a machine resolved for the `os` setting instead —
+  new screen, GPU, cores, fonts and noise seeds, and `browser_settings.screen` is
+  updated to match.
+
+`400` when the profile has no pin, when the pin's OS cannot be read, or when the
+two already agree — regenerating hardware is irreversible for an account, so a
+stale client cannot trigger it by accident.
+
+```http
+POST /api/profiles/clear-geography    {"profile_ids": ["a1b2c3d4", ...]}
+```
+
+Unsets `timezone` and `geolocation` on each profile named, so Camoufox derives
+both — and the WebRTC address — from where that profile's proxy comes out, as a
+profile created today does. Languages and `locale` are not touched. Returns
+`cleared`, `unchanged` (already followed the proxy) and `not_found`, so a bulk
+call reports itself; `422` for an empty list.
+
 ## Checking a proxy
 
 ```http

--- a/docs/profile-settings.md
+++ b/docs/profile-settings.md
@@ -96,6 +96,25 @@ The user agent is resolved for the OS **the pin describes**, taken from its
 someone changed the dropdown after the machine was pinned, and following the
 setting would put a macOS browser on Windows hardware.
 
+### When the OS setting and the machine disagree
+
+The pin is what a page sees, so changing the `os` dropdown on a pinned profile
+changes nothing observable — the setting simply stops meaning anything. That is
+allowed (it is often the first step towards regenerating, and refusing it would
+break bulk edits), but it is no longer silent: the profile response reports
+`fingerprint.pinned_os`, `fingerprint.settings_os` and `fingerprint.os_mismatch`,
+the server logs a warning on the save, the form says so under the dropdown, and
+the Machine panel shows a banner offering the two ways out.
+
+| | What it does | What it costs |
+| --- | --- | --- |
+| **Keep this machine** | Puts the OS setting back to what the pin reports | Nothing — no fingerprint value changes |
+| **New \<OS\> machine** | Pins a fresh machine resolved for the OS setting | New screen, GPU, cores, fonts and noise seeds; a warmed-up account is now on different hardware |
+
+Neither is preselected, and `POST /api/profiles/{id}/reconcile-os` refuses when
+the two already agree, so a stale screen cannot replace the hardware of a healthy
+profile.
+
 ## Where the profile appears to be
 
 A pinned machine keeps the hardware honest. Geography is the other half, and it
@@ -116,9 +135,34 @@ used. Without that, Firefox falls back to *this computer's* timezone: measured,
 a profile with Tokyo coordinates reported `Europe/Moscow`, the host's own zone.
 
 Profiles created before this behaviour keep the timezone and coordinates they
-were given, and those were picked from a random region. They are not migrated —
-changing a stored fingerprint under a live account is worse than leaving it — so
-check such a profile and clear the two fields if they disagree with its proxy.
+were given, and those were picked from a random region. They are still not
+migrated automatically — changing a stored fingerprint under a live account is
+worse than leaving it — but the change is offered:
+
+- **In the profile form**, under Geolocation, whenever the saved profile states a
+  timezone or coordinates: *Clear both, follow the proxy*.
+- **In the profiles list**, as a bulk action on the current selection. The button
+  counts how many of the selected profiles actually state a location, so it says
+  what it will really change.
+- **`POST /api/profiles/clear-geography`** with `{"profile_ids": [...]}`, which
+  is what both use.
+
+**There is no attempt to guess which values were chosen on purpose.** Nothing
+recorded it, and the only distinguishable signal — values matching the old
+generator's region table — is exactly what someone who deliberately picked that
+city would have produced. So the action is offered wherever geography is set,
+explained, and never applied on its own.
+
+Only the timezone and the coordinates are cleared. Languages and `locale` are
+left alone: Camoufox applies languages after its IP lookup regardless, an
+English-language browser is unremarkable from any country, and changing them
+would alter the profile's identity rather than free it to follow the proxy.
+
+Clearing the coordinates is the part that matters beyond tidiness. Their presence
+forces `geoip=False`, and that same branch is what fills the timezone and the
+WebRTC address, so a profile carrying a random region derives none of the three
+from its proxy. With both cleared, `geoip` is back on and all three follow the
+exit address.
 
 ### Checking a proxy
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,6 +15,10 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
   created with.
 - A proxy can be checked from the UI: where it comes out, how fast, and whether
   the profile's timezone and coordinates agree with it.
+- A profile that contradicts itself says so and can be fixed: an OS setting that
+  disagrees with the pinned machine is reported with both ways out, and a profile
+  carrying geography from before it followed the proxy can have it cleared, one
+  profile or a whole selection at a time.
 - The web UI covers the product: creating profiles, groups, and a settings screen
   reporting how the instance is configured.
 - The REST API is stabilised for `1.0`: `/api/v1` paths (the unversioned ones
@@ -32,11 +36,6 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
 
 ## Next
 
-- Reconcile a profile's OS setting with its pinned machine. A refresh now follows
-  the pin rather than the setting, so the two can disagree silently; nothing
-  offers to bring them back into step.
-- Offer to clear the geography of profiles created before it followed the proxy,
-  instead of only reporting the mismatch when the proxy is checked.
 - Authentication for multi-user or hosted deployments, beyond the optional API key.
 - Task scheduling and automated fingerprint rotation.
 - Windows App-Bound Encryption support for the Chrome-migration module.

--- a/src/camoufox_pm/api/models/profiles.py
+++ b/src/camoufox_pm/api/models/profiles.py
@@ -169,7 +169,10 @@ class ProfileResponse(BaseModel):
             created_at=profile.created_at,
             updated_at=profile.updated_at,
             last_used=profile.last_used,
-            fingerprint=fingerprint_store.summarize(profile.fingerprint),
+            fingerprint=fingerprint_store.summarize(
+                profile.fingerprint,
+                profile.browser_settings.os if profile.browser_settings else None,
+            ),
         )
 
 
@@ -301,6 +304,37 @@ class ProxyCheckRequest(BaseModel):
             }
         }
     )
+
+
+class ReconcileOsRequest(BaseModel):
+    """Which of the two things a profile says about its OS should win."""
+
+    keep_machine: bool = Field(
+        ...,
+        description=(
+            "True: put the OS setting back to what the pinned machine reports, changing "
+            "no fingerprint. False: pin a new machine for the OS setting instead — new "
+            "screen, GPU, cores, fonts and noise seeds."
+        ),
+    )
+
+    model_config = ConfigDict(json_schema_extra={"example": {"keep_machine": True}})
+
+
+class ClearGeographyRequest(BaseModel):
+    """Profiles whose stored timezone and coordinates should follow the proxy again."""
+
+    profile_ids: list[str] = Field(..., min_length=1, description="Profile IDs to clear")
+
+    model_config = ConfigDict(json_schema_extra={"example": {"profile_ids": ["a1b2c3d4"]}})
+
+
+class ClearGeographyResponse(BaseModel):
+    """What the request did to each profile it named."""
+
+    cleared: list[str] = Field(..., description="Had a timezone or coordinates; both are now unset")
+    unchanged: list[str] = Field(..., description="Already followed the proxy")
+    not_found: list[str] = Field(..., description="No such profile")
 
 
 class ProxyLocationResponse(BaseModel):

--- a/src/camoufox_pm/api/routes/profiles.py
+++ b/src/camoufox_pm/api/routes/profiles.py
@@ -22,6 +22,8 @@ from camoufox_pm.api.models.profiles import (
     ActiveBrowsersResponse,
     BrowserCloseResponse,
     BrowsersCloseAllResponse,
+    ClearGeographyRequest,
+    ClearGeographyResponse,
     ProfileCloneRequest,
     ProfileCreateRequest,
     ProfileLaunchRequest,
@@ -32,6 +34,7 @@ from camoufox_pm.api.models.profiles import (
     ProfileUpdateRequest,
     ProxyCheckRequest,
     ProxyCheckResponse,
+    ReconcileOsRequest,
 )
 from camoufox_pm.api.models.system import ApiResponse, ExcelImportData
 from camoufox_pm.core import proxy_check
@@ -467,6 +470,54 @@ async def refresh_browser_version(profile_id: str):
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
         logger.error(f"Failed to refresh the browser version for {profile_id}: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post(
+    "/profiles/{profile_id}/reconcile-os",
+    response_model=ProfileResponse,
+    summary="Reconcile the OS setting with the pinned machine",
+    description=(
+        "A profile's OS setting and its pinned machine can disagree, because the pin is "
+        "what a page sees and the setting is only a dropdown. Either put the setting back "
+        "to what the machine reports (no fingerprint change), or pin a new machine for the "
+        "setting — new screen, GPU, cores, fonts and noise seeds."
+    ),
+)
+async def reconcile_profile_os(profile_id: str, request: ReconcileOsRequest):
+    """Bring a profile's OS setting and its pinned machine back into agreement."""
+    try:
+        profile = await get_profile_manager().reconcile_os(profile_id, request.keep_machine)
+        if not profile:
+            raise HTTPException(status_code=404, detail=f"Profile with ID {profile_id} not found")
+        return ProfileResponse.from_profile(profile)
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error(f"Failed to reconcile the OS for {profile_id}: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post(
+    "/profiles/clear-geography",
+    response_model=ClearGeographyResponse,
+    summary="Clear stored timezone and coordinates",
+    description=(
+        "Unset the timezone and coordinates of the named profiles so both follow the "
+        "proxy's exit address again, as a profile created today does. Takes a list "
+        "because profiles created before that behaviour all carry a randomly chosen "
+        "region. Languages and locale are left alone."
+    ),
+)
+async def clear_profiles_geography(request: ClearGeographyRequest):
+    """Make the named profiles derive their location from their proxy again."""
+    try:
+        result = await get_profile_manager().clear_geography(request.profile_ids)
+        return ClearGeographyResponse(**result)
+    except Exception as exc:
+        logger.error(f"Failed to clear geography: {exc}")
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 

--- a/src/camoufox_pm/core/fingerprint_store.py
+++ b/src/camoufox_pm/core/fingerprint_store.py
@@ -333,11 +333,18 @@ def get_preset(preset_id: str) -> dict[str, Any] | None:
     return None
 
 
-def summarize(fingerprint: dict[str, Any] | None) -> dict[str, Any] | None:
+def summarize(
+    fingerprint: dict[str, Any] | None, settings_os: str | None = None
+) -> dict[str, Any] | None:
     """Describe a pinned fingerprint in the few values worth showing a user.
 
     The stored config is ~40 properties and tens of kilobytes; this is what the
     UI displays so someone can confirm the profile really has a fixed machine.
+
+    ``settings_os`` is the profile's own OS setting, reported next to the OS the
+    pin describes so the two can be seen to disagree. While a pin exists the
+    setting has no effect on what a page sees, so a disagreement is silent
+    otherwise.
     """
     if not fingerprint:
         return None
@@ -346,6 +353,7 @@ def summarize(fingerprint: dict[str, Any] | None) -> dict[str, Any] | None:
     height = fingerprint.get("screen.height")
     fonts = fingerprint.get("fonts")
     installed = installed_major()
+    pinned = pinned_os(fingerprint)
     return {
         "user_agent": fingerprint.get("navigator.userAgent"),
         "platform": fingerprint.get("navigator.platform"),
@@ -358,4 +366,7 @@ def summarize(fingerprint: dict[str, Any] | None) -> dict[str, Any] | None:
         "browser_major": browser_major(fingerprint),
         "installed_major": installed,
         "browser_outdated": is_outdated(fingerprint, installed),
+        "pinned_os": pinned,
+        "settings_os": settings_os,
+        "os_mismatch": bool(pinned and settings_os and pinned != settings_os),
     }

--- a/src/camoufox_pm/core/models.py
+++ b/src/camoufox_pm/core/models.py
@@ -131,6 +131,25 @@ class BrowserSettings(BaseModel):
     # Fonts
     fonts: list[str] | None = None
 
+    def has_geography(self) -> bool:
+        """Whether this profile states where it is instead of following its proxy."""
+        return bool(self.timezone or self.geolocation)
+
+    def clear_geography(self) -> bool:
+        """Drop the stated location so the proxy's exit address supplies it again.
+
+        Only the two fields Camoufox derives from that address. Languages and
+        locale are left alone: they are not geography — Camoufox applies them
+        after its IP lookup regardless, and an English browser is unremarkable
+        from any country — so clearing them would change the profile's identity
+        rather than free it to follow the proxy.
+        """
+        if not self.has_geography():
+            return False
+        self.timezone = None
+        self.geolocation = None
+        return True
+
     def to_camoufox_config(self) -> dict[str, Any]:
         """Build Camoufox ``config`` property overrides.
 

--- a/src/camoufox_pm/core/profile_manager.py
+++ b/src/camoufox_pm/core/profile_manager.py
@@ -207,6 +207,20 @@ class ProfileManager:
                         value = BrowserSettings(**value)
                 setattr(profile, key, value)
 
+        # Changing the OS of a pinned profile is not refused: the setting is not
+        # what a page sees while a pin exists, so nothing breaks, and refusing
+        # would block a legitimate edit made on the way to regenerating. But it
+        # does leave the profile saying two things, so it is worth a line in the
+        # log; the profile response reports it as os_mismatch for the UI.
+        if "browser_settings" in updates and profile.fingerprint:
+            pinned_os = fingerprint_store.pinned_os(profile.fingerprint)
+            if pinned_os and pinned_os != profile.browser_settings.os:
+                logger.warning(
+                    f"Profile {profile_id} is now set to {profile.browser_settings.os} "
+                    f"while its pinned machine is {pinned_os}; the setting has no effect "
+                    "until the machine is regenerated"
+                )
+
         profile.updated_at = datetime.now()
 
         # Persist the update
@@ -582,6 +596,106 @@ class ProfileManager:
         )
         logger.info(f"Profile {profile_id} browser version refreshed: {before} -> {after}")
         return profile
+
+    async def reconcile_os(self, profile_id: str, keep_machine: bool) -> Profile | None:
+        """Put a profile's OS setting and its pinned machine back in agreement.
+
+        The two can drift apart because a pin describes the machine forever while
+        the setting is a dropdown: change it after the first launch and nothing
+        objects, because the pin is what a page actually sees. There are only two
+        honest ways out and they cost very different amounts.
+
+        ``keep_machine`` puts the setting back to the OS the pin describes and
+        touches nothing else — the profile is the computer it has always been.
+        Otherwise the setting wins and a new machine is pinned for it: new screen,
+        GPU, cores, fonts and noise seeds. For a warmed-up account that is a real
+        cost, which is why it is never the automatic answer.
+        """
+        profile = await self.get_profile(profile_id)
+        if not profile:
+            return None
+        if not profile.fingerprint:
+            raise ValueError("This profile has no pinned machine yet, so nothing can disagree.")
+
+        pinned_os = fingerprint_store.pinned_os(profile.fingerprint)
+        if not pinned_os:
+            raise ValueError("Cannot tell which operating system this profile's machine describes.")
+        if pinned_os == profile.browser_settings.os:
+            # Regenerating hardware is irreversible for an account, so refuse
+            # rather than let a stale UI fire this at a profile that agrees.
+            raise ValueError(f"This profile is already set to {pinned_os}.")
+
+        was = profile.browser_settings.os
+        if keep_machine:
+            profile.browser_settings.os = pinned_os
+        else:
+            resolved = fingerprint_store.resolve(profile.to_camoufox_launch_options())
+            if not resolved:
+                raise ValueError(
+                    "Could not resolve a machine for this operating system. "
+                    "Check that Camoufox is installed ('camoufox fetch')."
+                )
+            profile.fingerprint = resolved
+            # The stored screen described the machine that has just been replaced.
+            width, height = resolved.get("screen.width"), resolved.get("screen.height")
+            if width and height:
+                profile.browser_settings.screen = f"{width}x{height}"
+
+        profile.updated_at = datetime.now()
+        await self.storage.update_profile(profile)
+        await self.storage.log_usage(
+            UsageStats(
+                profile_id=profile_id,
+                action="reconcile_os",
+                details={
+                    "kept": "machine" if keep_machine else "setting",
+                    "from": was,
+                    "to": profile.browser_settings.os,
+                },
+            )
+        )
+        logger.info(
+            f"Profile {profile_id} reconciled to {profile.browser_settings.os} "
+            f"by keeping the {'machine' if keep_machine else 'setting'}"
+        )
+        return profile
+
+    async def clear_geography(self, profile_ids: list[str]) -> dict[str, list[str]]:
+        """Drop the stored timezone and coordinates so the proxy supplies both.
+
+        Until recently every new profile was given the timezone and coordinates of
+        a randomly chosen region, so an old profile can claim Shanghai and be
+        handed a German proxy. Those profiles were deliberately not migrated —
+        rewriting a stored fingerprint under a live account is worse than leaving
+        it — so this is the offer instead: the same change, made deliberately.
+
+        Clearing the coordinates is the part that matters beyond tidiness. Their
+        presence turns Camoufox's IP lookup off, and that lookup is also what
+        fills the timezone and the WebRTC address; without them the profile is
+        back to deriving all three from where its proxy comes out, exactly as a
+        profile created today does.
+        """
+        cleared: list[str] = []
+        unchanged: list[str] = []
+        not_found: list[str] = []
+
+        for profile_id in profile_ids:
+            profile = await self.get_profile(profile_id)
+            if not profile:
+                not_found.append(profile_id)
+                continue
+            if not profile.browser_settings.clear_geography():
+                unchanged.append(profile_id)
+                continue
+            profile.updated_at = datetime.now()
+            await self.storage.update_profile(profile)
+            await self.storage.log_usage(
+                UsageStats(profile_id=profile_id, action="clear_geography", details={})
+            )
+            cleared.append(profile_id)
+
+        logger.info(f"Cleared the geography of {len(cleared)} of {len(profile_ids)} profiles")
+        return {"cleared": cleared, "unchanged": unchanged, "not_found": not_found}
 
     # -- Portability --------------------------------------------------------
 

--- a/tests/integration/test_api_profiles.py
+++ b/tests/integration/test_api_profiles.py
@@ -475,6 +475,185 @@ async def test_refresh_browser_version_keeps_the_machine(client, monkeypatch):
     assert stored.fingerprint["fonts:spacing_seed"] == 777
 
 
+WINDOWS_PIN = {
+    "navigator.userAgent": STALE_UA,
+    "navigator.platform": "Win32",
+    "navigator.oscpu": "Windows NT 10.0; Win64; x64",
+    "navigator.hardwareConcurrency": 12,
+    "screen.width": 2560,
+    "screen.height": 1440,
+    "webGl:renderer": "ANGLE (NVIDIA, GeForce GTX 980)",
+    "canvas:seed": 424242,
+}
+
+
+async def _pinned_windows_profile_set_to(client, os_name: str) -> str:
+    """A profile whose pin says Windows while its setting says something else."""
+    from camoufox_pm.api.dependencies import get_profile_manager
+
+    created = await client.post("/api/profiles", json={"name": f"drifted-{os_name}"})
+    profile_id = created.json()["id"]
+    manager = get_profile_manager()
+    profile = await manager.get_profile(profile_id)
+    profile.fingerprint = dict(WINDOWS_PIN)
+    profile.browser_settings.os = os_name
+    await manager.storage.update_profile(profile)
+    return profile_id
+
+
+@pytest.mark.asyncio
+async def test_a_setting_that_disagrees_with_the_pin_is_reported(client):
+    """Changing the OS of a pinned profile is allowed, but must not stay silent."""
+    profile_id = await _pinned_windows_profile_set_to(client, "windows")
+
+    updated = await client.put(f"/api/profiles/{profile_id}", json={"browser_os": "macos"})
+    assert updated.status_code == 200
+    summary = updated.json()["fingerprint"]
+    assert summary["settings_os"] == "macos"
+    assert summary["pinned_os"] == "windows"
+    assert summary["os_mismatch"] is True
+
+
+@pytest.mark.asyncio
+async def test_keeping_the_machine_moves_the_setting_and_nothing_else(client):
+    """The cheap way out: the profile is the computer it has always been."""
+    from camoufox_pm.api.dependencies import get_profile_manager
+
+    profile_id = await _pinned_windows_profile_set_to(client, "macos")
+
+    response = await client.post(
+        f"/api/profiles/{profile_id}/reconcile-os", json={"keep_machine": True}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["browser_settings"]["os"] == "windows"
+    assert body["fingerprint"]["os_mismatch"] is False
+
+    stored = await get_profile_manager().get_profile(profile_id)
+    assert stored.fingerprint == WINDOWS_PIN, "no fingerprint may change on this path"
+
+
+@pytest.mark.asyncio
+async def test_keeping_the_setting_pins_a_machine_for_it(client, monkeypatch):
+    """The expensive way out: new hardware, resolved for the OS that was chosen."""
+    from camoufox_pm.api.dependencies import get_profile_manager
+
+    asked_for: dict = {}
+
+    def fake_resolve(options, preset=None):
+        asked_for.update(options)
+        return {
+            "navigator.userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:199.0)",
+            "navigator.platform": "MacIntel",
+            "navigator.hardwareConcurrency": 8,
+            "screen.width": 1440,
+            "screen.height": 900,
+            "canvas:seed": 111,
+        }
+
+    monkeypatch.setattr(fingerprint_store, "resolve", fake_resolve)
+    profile_id = await _pinned_windows_profile_set_to(client, "macos")
+
+    response = await client.post(
+        f"/api/profiles/{profile_id}/reconcile-os", json={"keep_machine": False}
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert asked_for["os"] == "macos", "the new machine must be resolved for the chosen OS"
+    assert body["fingerprint"]["pinned_os"] == "macos"
+    assert body["fingerprint"]["os_mismatch"] is False
+    # The stored screen described the machine that has just been replaced.
+    assert body["browser_settings"]["screen"] == "1440x900"
+
+    stored = await get_profile_manager().get_profile(profile_id)
+    assert stored.fingerprint["canvas:seed"] == 111, "this path is meant to change the hardware"
+
+
+@pytest.mark.asyncio
+async def test_reconciling_a_profile_that_already_agrees_is_refused(client):
+    """Otherwise a stale UI could replace the hardware of a healthy profile."""
+    profile_id = await _pinned_windows_profile_set_to(client, "windows")
+    response = await client.post(
+        f"/api/profiles/{profile_id}/reconcile-os", json={"keep_machine": False}
+    )
+    assert response.status_code == 400
+    assert "already set to windows" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_reconciling_needs_a_pin_and_a_profile(client):
+    created = await client.post("/api/profiles", json={"name": "unpinned"})
+    unpinned = await client.post(
+        f"/api/profiles/{created.json()['id']}/reconcile-os", json={"keep_machine": True}
+    )
+    assert unpinned.status_code == 400
+    assert "no pinned machine" in unpinned.json()["detail"]
+
+    missing = await client.post(
+        "/api/profiles/does-not-exist/reconcile-os", json={"keep_machine": True}
+    )
+    assert missing.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_clear_geography_hands_the_location_back_to_the_proxy(client):
+    """A profile from before geography followed the proxy can be freed to do so."""
+    from camoufox_pm.api.dependencies import get_profile_manager
+
+    old = await client.post(
+        "/api/profiles",
+        json={
+            "name": "shanghai",
+            "browser_settings": {
+                "timezone": "Asia/Shanghai",
+                "geolocation": {"lat": 31.23, "lon": 121.47},
+                "languages": ["zh-CN", "zh"],
+            },
+        },
+    )
+    profile_id = old.json()["id"]
+
+    response = await client.post(
+        "/api/profiles/clear-geography", json={"profile_ids": [profile_id]}
+    )
+    assert response.status_code == 200
+    assert response.json() == {"cleared": [profile_id], "unchanged": [], "not_found": []}
+
+    settings = (await client.get(f"/api/profiles/{profile_id}")).json()["browser_settings"]
+    assert settings["timezone"] is None
+    assert settings["geolocation"] is None
+    assert settings["languages"] == ["zh-CN", "zh"], "languages are identity, not geography"
+
+    profile = await get_profile_manager().get_profile(profile_id)
+    options = profile.to_camoufox_launch_options()
+    assert options["geoip"] is True, "the whole point: Camoufox derives it from the exit address"
+
+
+@pytest.mark.asyncio
+async def test_clear_geography_reports_each_profile_it_was_given(client):
+    """A selection is the unit here, so partial answers have to be readable."""
+    with_geo = await client.post(
+        "/api/profiles", json={"name": "berlin", "browser_settings": {"timezone": "Europe/Berlin"}}
+    )
+    without = await client.post("/api/profiles", json={"name": "follows-the-proxy"})
+
+    response = await client.post(
+        "/api/profiles/clear-geography",
+        json={"profile_ids": [with_geo.json()["id"], without.json()["id"], "nope"]},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["cleared"] == [with_geo.json()["id"]]
+    assert body["unchanged"] == [without.json()["id"]]
+    assert body["not_found"] == ["nope"]
+
+
+@pytest.mark.asyncio
+async def test_clear_geography_needs_at_least_one_profile(client):
+    response = await client.post("/api/profiles/clear-geography", json={"profile_ids": []})
+    assert response.status_code == 422
+
+
 @pytest.mark.asyncio
 async def test_refresh_browser_version_needs_a_pin_first(client):
     """Refreshing an unpinned profile would silently invent a machine."""

--- a/tests/unit/test_camoufox_options.py
+++ b/tests/unit/test_camoufox_options.py
@@ -96,6 +96,43 @@ def test_launch_options_geoip_auto_unless_explicit_coords():
     assert with_coords["geoip"] is False
 
 
+def test_clearing_geography_hands_the_location_back_to_the_proxy():
+    """The point of clearing is the geoip flip, not the tidier record.
+
+    Coordinates force ``geoip=False``, and that same branch is what Camoufox uses
+    to fill the timezone and the WebRTC address from the exit address. A profile
+    carrying a randomly chosen region therefore derives none of the three.
+    """
+    settings = BrowserSettings(timezone="Asia/Shanghai", geolocation={"lat": 31.2, "lon": 121.5})
+    assert settings.has_geography() is True
+    before = Profile(name="old", browser_settings=settings).to_camoufox_launch_options()
+    assert before["geoip"] is False
+    assert before["config"]["timezone"] == "Asia/Shanghai"
+
+    assert settings.clear_geography() is True
+    after = Profile(name="old", browser_settings=settings).to_camoufox_launch_options()
+    assert after["geoip"] is True
+    assert "timezone" not in after["config"]
+    assert "geolocation:latitude" not in after["config"]
+
+
+def test_clearing_geography_leaves_the_language_alone():
+    """Languages are identity, not geography; Camoufox applies them either way."""
+    settings = BrowserSettings(
+        timezone="Asia/Shanghai", languages=["zh-CN", "zh"], locale="zh_CN", os="macos"
+    )
+    settings.clear_geography()
+    assert settings.languages == ["zh-CN", "zh"]
+    assert settings.locale == "zh_CN"
+    assert settings.os == "macos"
+
+
+def test_clearing_geography_reports_when_there_was_none():
+    settings = BrowserSettings()
+    assert settings.has_geography() is False
+    assert settings.clear_geography() is False
+
+
 def test_launch_options_include_proxy():
     p = Profile(
         name="t",

--- a/tests/unit/test_fingerprint_store.py
+++ b/tests/unit/test_fingerprint_store.py
@@ -214,6 +214,34 @@ def test_pinned_os_is_read_from_the_pin_not_the_settings():
     assert fingerprint_store.pinned_os(None) is None
 
 
+def test_summary_reports_a_setting_that_disagrees_with_the_pin():
+    """The dropdown can be changed long after the pin was made, and silently.
+
+    While a pin exists it is what a page sees, so a profile set to macOS on
+    Windows hardware behaves exactly as before — the setting simply stops meaning
+    anything, with nothing to say so.
+    """
+    pin = {"navigator.platform": "Win32", "navigator.userAgent": UA_NEW}
+
+    agreeing = fingerprint_store.summarize(pin, "windows")
+    assert agreeing["pinned_os"] == "windows"
+    assert agreeing["settings_os"] == "windows"
+    assert agreeing["os_mismatch"] is False
+
+    disagreeing = fingerprint_store.summarize(pin, "macos")
+    assert disagreeing["pinned_os"] == "windows"
+    assert disagreeing["settings_os"] == "macos"
+    assert disagreeing["os_mismatch"] is True
+
+
+def test_summary_claims_no_mismatch_when_either_side_is_unknown():
+    """Half an answer must not be reported as a contradiction."""
+    assert fingerprint_store.summarize({"screen.width": 800}, "macos")["os_mismatch"] is False
+    assert (
+        fingerprint_store.summarize({"navigator.platform": "Win32"}, None)["os_mismatch"] is False
+    )
+
+
 def test_get_preset_rejects_malformed_ids():
     """Only a plain run of ASCII digits names a preset.
 

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -30,6 +30,7 @@ import {
   formatLastUsed,
   formatProxyString,
   groupsAPI,
+  hasGeography,
   OS_LABELS,
   profilesAPI,
   type Group,
@@ -176,6 +177,12 @@ export default function ProfilesPage() {
       }
     })
   }, [profiles, search, statusFilter, sortKey, sortDir, groupNames])
+
+  // Offering the bulk clear when nothing selected would change is just noise.
+  const selectedWithGeography = useMemo(
+    () => profiles.filter((profile) => selected.has(profile.id) && hasGeography(profile)).length,
+    [profiles, selected],
+  )
 
   const totalPages = Math.max(1, Math.ceil(visible.length / perPage))
   // Deleting the last rows of a page must not strand the user on an empty one.
@@ -346,6 +353,30 @@ export default function ProfilesPage() {
     })
   }
 
+  /**
+   * The profiles this exists for were all created the same way — with the
+   * timezone and coordinates of a randomly chosen region — so the useful unit is
+   * a selection, not one profile at a time. Only those that actually state a
+   * location are named, so the confirmation says what will really change.
+   */
+  function askClearGeography() {
+    const ids = profiles.filter((p) => selected.has(p.id) && hasGeography(p)).map((p) => p.id)
+    setConfirm({
+      title: `Clear geography of ${ids.length} profile${ids.length === 1 ? '' : 's'}`,
+      body:
+        'The stored timezone and coordinates are unset, so Camoufox derives both — and the ' +
+        'WebRTC address — from where each profile\'s proxy comes out, as a profile created ' +
+        'today does. Languages and the pinned machine are untouched.',
+      label: 'Clear',
+      run: async () => {
+        const result = await profilesAPI.clearGeography(ids)
+        toast('ok', `Cleared ${result.cleared.length} profile${result.cleared.length === 1 ? '' : 's'}`)
+        setSelected(new Set())
+        loadProfiles()
+      },
+    })
+  }
+
   function askCloseAll() {
     setConfirm({
       title: 'Close all browsers',
@@ -496,6 +527,12 @@ export default function ProfilesPage() {
       {selected.size > 0 && (
         <div className="flex items-center gap-3 border-b border-line bg-raised px-5 py-2">
           <span>{selected.size} selected</span>
+          {selectedWithGeography > 0 && (
+            <button className="btn btn-default h-7" onClick={askClearGeography}>
+              <Globe size={13} />
+              Clear geography ({selectedWithGeography})
+            </button>
+          )}
           <button className="btn btn-danger h-7" onClick={askBulkDelete}>
             <Trash2 size={13} />
             Delete

--- a/web/src/components/profile-form.tsx
+++ b/web/src/components/profile-form.tsx
@@ -6,6 +6,8 @@ import { AlertTriangle, Check, Info, Loader2, RefreshCw, X } from 'lucide-react'
 import { Modal } from '@/components/modal'
 import { useToast } from '@/components/toast'
 import {
+  hasGeography,
+  OS_LABELS,
   presetsAPI,
   profilesAPI,
   type DevicePreset,
@@ -109,6 +111,11 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
   // browser returns a new machine, and the panel has to show it without waiting
   // for the dialog to be reopened.
   const [machine, setMachine] = useState<FingerprintSummary | null | undefined>(undefined)
+  const [reconciling, setReconciling] = useState(false)
+  // Whether the *saved* profile states where it is. The form fields alone cannot
+  // answer that once the user has started typing in them.
+  const [storedGeography, setStoredGeography] = useState(false)
+  const [clearingGeography, setClearingGeography] = useState(false)
   const [presets, setPresets] = useState<DevicePreset[]>([])
   const [presetId, setPresetId] = useState('')
   const toast = useToast()
@@ -117,6 +124,7 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
     if (open) {
       setForm(profile ? fromProfile(profile) : EMPTY)
       setMachine(profile?.fingerprint)
+      setStoredGeography(profile ? hasGeography(profile) : false)
       setPresetId('')
     }
   }, [open, profile])
@@ -273,6 +281,52 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
     }
   }
 
+  /**
+   * Keeping the machine only moves the dropdown; keeping the setting replaces the
+   * hardware, so the two are reported very differently even though one call does
+   * both. The form's own OS field follows, or it would still show the value the
+   * user has just resolved away from.
+   */
+  async function handleReconcileOs(keepMachine: boolean) {
+    if (!profile) return
+    setReconciling(true)
+    try {
+      const updated = await profilesAPI.reconcileOs(profile.id, keepMachine)
+      setMachine(updated.fingerprint)
+      set('os', updated.browser_settings.os)
+      toast(
+        'ok',
+        keepMachine
+          ? `Set back to ${OS_LABELS[updated.browser_settings.os] ?? updated.browser_settings.os}`
+          : 'New machine pinned',
+        keepMachine
+          ? 'The machine is untouched.'
+          : `${updated.fingerprint?.screen} · ${updated.fingerprint?.hardware_concurrency} cores. The old hardware is gone.`,
+      )
+      onSaved()
+    } catch (err) {
+      toast('error', 'Could not reconcile the operating system', String(err))
+    } finally {
+      setReconciling(false)
+    }
+  }
+
+  async function handleClearGeography() {
+    if (!profile) return
+    setClearingGeography(true)
+    try {
+      await profilesAPI.clearGeography([profile.id])
+      setForm((current) => ({ ...current, timezone: '', geoMode: 'auto', latitude: '', longitude: '' }))
+      setStoredGeography(false)
+      toast('ok', 'Timezone and coordinates cleared', 'Both now follow the proxy.')
+      onSaved()
+    } catch (err) {
+      toast('error', 'Could not clear the geography', String(err))
+    } finally {
+      setClearingGeography(false)
+    }
+  }
+
   async function handleRegenerate() {
     if (!profile) return
     setRegenerating(true)
@@ -373,10 +427,15 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
               <option value="macos">macOS</option>
               <option value="linux">Linux</option>
             </select>
+            {/* Once a machine is pinned this setting is not what a page sees, so
+                the honest warning is stronger than "the rest stays as it was". */}
             {isEdit && form.os !== (profile.browser_settings?.os ?? 'windows') && (
               <p className="mt-1.5 text-ink-faint">
-                Screen size, locale and fonts stay as they were. Use Regenerate fingerprint for a
-                set that matches the new OS.
+                {machine?.pinned_os
+                  ? `Saving this changes nothing a page can see: the pinned machine reports ${
+                      OS_LABELS[machine.pinned_os] ?? machine.pinned_os
+                    } and keeps doing so. The Machine panel then offers both ways out.`
+                  : 'Screen size, locale and fonts stay as they were. Use Regenerate fingerprint for a set that matches the new OS.'}
               </p>
             )}
           </div>
@@ -509,6 +568,8 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
             fingerprint={machine}
             onRefreshBrowser={handleRefreshBrowser}
             refreshing={refreshingBrowser}
+            onReconcileOs={handleReconcileOs}
+            reconciling={reconciling}
           />
         ) : (
           <fieldset>
@@ -694,6 +755,36 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
               </div>
             </div>
           )}
+
+          {/* Until recently every new profile was given the timezone and
+              coordinates of a randomly chosen region, so an old one can claim
+              Shanghai on a German proxy. Nothing recorded which values were
+              chosen and which were rolled, so this is offered whenever both are
+              set rather than guessed at. */}
+          {isEdit && storedGeography && (
+            <div className="col-span-2 rounded-md border border-line bg-raised p-2.5">
+              <p className="text-ink">
+                This profile states where it is instead of taking it from its proxy.
+              </p>
+              <p className="mt-0.5 text-ink-faint">
+                A profile created today leaves both unset, so Camoufox derives the timezone, the
+                coordinates and the WebRTC address from the exit address. Profiles created earlier
+                were given a randomly chosen region, and nothing records which values were a
+                choice — so clear them if this one was not.
+              </p>
+              <div className="mt-2 flex justify-end">
+                <button
+                  type="button"
+                  className="btn btn-default"
+                  onClick={handleClearGeography}
+                  disabled={clearingGeography}
+                >
+                  {clearingGeography && <Loader2 size={13} className="animate-spin" />}
+                  Clear both, follow the proxy
+                </button>
+              </div>
+            </div>
+          )}
         </Section>
       </form>
     </Modal>
@@ -727,10 +818,14 @@ function PinnedMachine({
   fingerprint,
   onRefreshBrowser,
   refreshing,
+  onReconcileOs,
+  reconciling,
 }: {
   fingerprint?: FingerprintSummary | null
   onRefreshBrowser: () => void
   refreshing: boolean
+  onReconcileOs: (keepMachine: boolean) => void
+  reconciling: boolean
 }) {
   if (!fingerprint) {
     return (
@@ -802,8 +897,56 @@ function PinnedMachine({
           </button>
         </div>
       )}
+
+      {/* The OS dropdown can be changed long after the machine was pinned, and
+          nothing stops it — the pin is what a page sees, so the setting simply
+          stops meaning anything. The two ways out cost very different amounts,
+          so neither is preselected. */}
+      {fingerprint.os_mismatch && (
+        <div className="mt-2 rounded-md border border-line bg-raised p-2.5">
+          <div className="flex items-start gap-2.5">
+            <AlertTriangle size={14} className="mt-0.5 shrink-0 text-warn" />
+            <div>
+              <p className="text-ink">
+                This profile is set to {osLabel(fingerprint.settings_os)}, but its pinned machine is
+                a {osLabel(fingerprint.pinned_os)} one — and the machine is what every page sees.
+              </p>
+              <p className="mt-0.5 text-ink-faint">
+                Keeping the machine puts the setting back to {osLabel(fingerprint.pinned_os)} and
+                changes no fingerprint at all. Pinning a{' '}
+                {osLabel(fingerprint.settings_os)} machine instead gives this profile different
+                hardware — screen, GPU, cores, fonts and canvas — which any account already warmed
+                up on the old one will notice.
+              </p>
+            </div>
+          </div>
+          <div className="mt-2 flex justify-end gap-2">
+            <button
+              type="button"
+              className="btn btn-default"
+              onClick={() => onReconcileOs(true)}
+              disabled={reconciling}
+            >
+              {reconciling && <Loader2 size={13} className="animate-spin" />}
+              Keep this machine
+            </button>
+            <button
+              type="button"
+              className="btn btn-default"
+              onClick={() => onReconcileOs(false)}
+              disabled={reconciling}
+            >
+              New {osLabel(fingerprint.settings_os)} machine
+            </button>
+          </div>
+        </div>
+      )}
     </fieldset>
   )
+}
+
+function osLabel(os?: string | null): string {
+  return (os && OS_LABELS[os]) || os || 'unknown'
 }
 
 function Section({

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -59,6 +59,12 @@ export interface FingerprintSummary {
   installed_major?: number | null
   /** The pin claims an older browser than the one installed. */
   browser_outdated?: boolean
+  /** The OS the pinned machine itself reports. */
+  pinned_os?: string | null
+  /** The OS the profile's settings ask for. */
+  settings_os?: string | null
+  /** The setting names one operating system and the pinned machine another. */
+  os_mismatch?: boolean
 }
 
 export interface Profile {
@@ -224,6 +230,23 @@ export const profilesAPI = {
     return request<Profile>(`${API_PREFIX}/profiles/${id}/refresh-browser`, { method: 'POST' })
   },
 
+  /** keepMachine: move the OS setting to the pin. Otherwise: pin new hardware for the setting. */
+  reconcileOs(id: string, keepMachine: boolean): Promise<Profile> {
+    return request<Profile>(`/api/profiles/${id}/reconcile-os`, {
+      method: 'POST',
+      body: JSON.stringify({ keep_machine: keepMachine }),
+    })
+  },
+
+  // Takes a list because the profiles this exists for — created when every one
+  // was given a random region — are all of them at once.
+  clearGeography(ids: string[]): Promise<ClearGeographyResult> {
+    return request<ClearGeographyResult>('/api/profiles/clear-geography', {
+      method: 'POST',
+      body: JSON.stringify({ profile_ids: ids }),
+    })
+  },
+
   checkProxy(id: string): Promise<ProxyCheck> {
     return request<ProxyCheck>(`${API_PREFIX}/profiles/${id}/check-proxy`, { method: 'POST' })
   },
@@ -283,6 +306,12 @@ export const profilesAPI = {
     })
     return response.json() as Promise<ImportResult>
   },
+}
+
+export interface ClearGeographyResult {
+  cleared: string[]
+  unchanged: string[]
+  not_found: string[]
 }
 
 export interface ImportResult {
@@ -363,6 +392,12 @@ export const systemAPI = {
 }
 
 // --- Display helpers ---------------------------------------------------------
+
+/** Whether a profile states where it is instead of letting its proxy say. */
+export function hasGeography(profile: Profile): boolean {
+  const bs = profile.browser_settings ?? {}
+  return Boolean(bs.timezone || bs.geolocation)
+}
 
 export function formatProxyString(proxy?: ProxyConfig | null): string {
   if (!proxy || !proxy.server) return ''

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -232,7 +232,7 @@ export const profilesAPI = {
 
   /** keepMachine: move the OS setting to the pin. Otherwise: pin new hardware for the setting. */
   reconcileOs(id: string, keepMachine: boolean): Promise<Profile> {
-    return request<Profile>(`/api/profiles/${id}/reconcile-os`, {
+    return request<Profile>(`${API_PREFIX}/profiles/${id}/reconcile-os`, {
       method: 'POST',
       body: JSON.stringify({ keep_machine: keepMachine }),
     })
@@ -241,7 +241,7 @@ export const profilesAPI = {
   // Takes a list because the profiles this exists for — created when every one
   // was given a random region — are all of them at once.
   clearGeography(ids: string[]): Promise<ClearGeographyResult> {
-    return request<ClearGeographyResult>('/api/profiles/clear-geography', {
+    return request<ClearGeographyResult>(`${API_PREFIX}/profiles/clear-geography`, {
       method: 'POST',
       body: JSON.stringify({ profile_ids: ids }),
     })


### PR DESCRIPTION
Closes two roadmap "Next" items, both about a profile that quietly contradicts itself.

## 1. OS setting vs. pinned machine

Changing the OS dropdown on a pinned profile did nothing observable and warned about nothing — the setting silently stopped meaning anything, because a page only ever sees the pinned machine. `summarize()` now reports `pinned_os` / `settings_os` / `os_mismatch` (the same shape as the existing `browser_outdated`), and the Machine panel reuses that banner with two honestly-worded ways out via `POST /api/profiles/{id}/reconcile-os {"keep_machine": bool}`:

- **Keep this machine** — set the OS setting back to what the pin says; no fingerprint changes.
- **New \<OS\> machine** — regenerate the pin for the chosen OS; new hardware, which for a warmed-up account is a real cost.

Refuses (400) when there is no pin, the pin's OS is unreadable, or **the two already agree** — regenerating hardware is irreversible, so a stale screen must not fire it. Saving a changed `os` warns (inline note + `logger.warning` + the banner) but does not block: `PUT /profiles/{id}` is also the Excel-import path, and changing `os` is often step one toward regenerating anyway.

## 2. Clearing old geography

Older profiles carry a timezone and coordinates from when the generator rolled a **random region** per profile — a Shanghai clock behind a German proxy — and only found out if someone pressed *Check proxy*. `POST /api/profiles/clear-geography {"profile_ids": [...]}` unsets `timezone` and `geolocation`, so they follow the proxy like a new profile's. In the form as a panel under Geolocation (when the saved profile states a location) and in the list's selection toolbar, labelled with how many of the selected profiles actually state one.

Three judgement calls, each argued in the report and docs:

- **No "chosen vs. rolled" heuristic.** The old generator is fully readable, so a match is computable — but it is exactly what a deliberate Berlin profile looks like. So the action is offered wherever geography is set, with the uncertainty stated in the copy, rather than guessed at.
- **A plain action, not a warning.** The OS case is a provable contradiction (`Win32` vs. macOS). Geography is only contradictory relative to a proxy — which *Check proxy* already tests — so claiming it is wrong without checking would be a guess.
- **Only timezone and coordinates, not languages.** Coordinates are the load-bearing half: they force `geoip=False`, and clearing both puts `geoip` back on so timezone, coordinates and WebRTC all follow the exit address again. Languages stay — Camoufox applies them after its IP lookup regardless, and an English browser is unremarkable anywhere.

## Verified in the running app (real Camoufox binary)

- `drifted-os` pinned to a Windows preset, then `PUT browser_os=macos` → `os_mismatch: true`, warning logged, banner rendered. **Keep this machine** → back to Windows, fingerprint screen untouched. **New macOS machine** → `MacIntel`, Apple M1, 10 cores, `os_mismatch: false`. Both refusals returned their 400s.
- `old-shanghai` (Asia/Shanghai, zh-CN) with a German proxy → **Clear both** blanked the timezone, flipped Geolocation to "From the proxy IP", kept `zh-CN`. Bulk button read **Clear geography (1)** across a 5-profile selection where only one still stated a location.

## Gates — verified independently in a fresh worktree

```
ruff / format / mypy   clean (29→28 files; two pre-existing annotation-unchecked notes on database.py, unrelated)
pytest -m "not browser"   146 passed, 20 deselected  (+13: unit for the mismatch reporting and the geoip flip, integration for both reconcile paths, the refusals, and the three clear outcomes)
tsc / next lint / next build   clean
```

## Merge order

Branched before the API-1.0 PR. Its new routes are added to the profiles router, so they inherit the dual `/api` + `/api/v1` mount automatically once rebased; `web/src/lib/api.ts` will need the `API_PREFIX` constant reconciled. I will rebase this onto main after API-1.0 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)