### PR TITLE
Fill test-coverage gaps — and the six bugs they turned up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,8 +132,50 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `--port` is no longer misreported as the configured default.
 - Removed the `/ws/monitor` WebSocket route: no client used it, it had no tests,
   and it was mounted without the API-key guard.
+- The parts that had never been exercised are now tested: deleting profile
+  directories, the browser session lifecycle, bulk spreadsheet import, the
+  destructive system endpoints and the command-line launcher. Six bugs came out
+  of writing them, listed below. `ProfileCleanupManager` takes the database path
+  separately from the data directory, and its CLI gained `--db-path`;
+  `create_profile` takes a `status`. What is left uncovered on purpose, and why,
+  is written down in CONTRIBUTING.
+- Removed `ExcelManager._prepare_profile_updates`, which nothing has ever called:
+  import only creates profiles.
 
 ### Fixed
+- **The cleanup endpoint could delete every profile directory on the machine.**
+  `POST /api/system/profiles/cleanup` and the diagnostic beside it built their
+  storage view from hard-coded defaults — `./data` and `./data/profiles.db` —
+  instead of the configured database. With `CPM_DB_PATH` pointing at any other
+  file name, they opened an empty database next to the real one, found nothing to
+  match the directories on disk against, and removed all of them. A profile
+  directory is the account: cookies, storage and saved logins go with it.
+- **A clone was the same machine as the profile it came from.** Cloning copied
+  the pinned fingerprint along with everything else, so the copy reported an
+  identical GPU, screen, core count, fonts and noise seeds — and a pin never
+  changes on its own, so it stayed that way. Two accounts that are provably one
+  computer is the one thing this tool exists to prevent. A clone now starts
+  unpinned and takes its own machine on first launch; asking it not to regenerate
+  the fingerprint still keeps the pin, which is the deliberate case.
+- **A rearranged spreadsheet imported into the wrong fields.** Import located
+  columns by position, so deleting the read-only ID column or dragging one
+  elsewhere — the two things bulk editing invites — shifted every field after it.
+  Nothing objected, because most of them are free text: a sheet with Locale moved
+  ahead of Timezone imported cleanly with those two values swapped, for every row.
+  Columns are now found by their header, and a file without a recognisable header
+  row is refused instead of imported as garbage.
+- **Excel import dropped the Notes and Status columns.** Both were exported, both
+  were read back out of the row, and neither was ever applied, so every imported
+  profile came back active and without its notes. An unrecognised status now
+  fails that row rather than quietly reactivating a profile someone had parked.
+- **Profile statistics were always empty.** `GET /api/profiles/{id}/stats` read
+  keys the manager never returned, so it reported no sessions, no last session
+  and no actions however much the profile had been used.
+- **Cloning an unknown profile answered 500 instead of 404**, reporting the
+  caller's own bad id as a server fault.
+- **A page of profiles could not be taken from the middle of the list.** SQLite
+  will not accept an `OFFSET` without a `LIMIT`, so `list_profiles(offset=...)`
+  on its own had the offset dropped and returned the first page.
 - **A new profile no longer picks a random country.** Every generated profile got
   a timezone, coordinates and languages from a randomly chosen region, so a fresh
   profile might claim Shanghai and then be given a German proxy — the manager was

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,31 @@ uv run python scripts/build_webui.py
   options passed in. When a test guards a premise about Camoufox's behaviour, say
   so — `test_unpinned_profiles_look_like_new_hardware` exists to fail loudly if
   upstream ever changes.
+- **A test should be able to fail.** Coverage is a way of finding untested
+  behaviour, not a target: a test that asserts a getter returns what was set
+  costs time on every run and catches nothing. Name the behaviour in the test
+  name, and when the test exists because something once broke, say in a docstring
+  what broke.
+
+### What is deliberately not covered
+
+Two modules are left untested on purpose, so nobody spends an afternoon
+rediscovering why:
+
+- **`desktop.py`** composes uvicorn and pywebview and has no logic of its own
+  beyond a connect-retry loop. pywebview is an optional extra that CI does not
+  install, so a test would have to stand in for every call it makes and would
+  then only assert that the stand-ins were called in order. The thing that can
+  actually break here — the window opening at all — is not observable without a
+  display.
+- **The FastAPI lifespan in `main.py`** builds the storage and profile manager
+  from the settings on startup. The integration tests inject their own instead,
+  which is what lets each of them have a throwaway database.
+
+The remaining uncovered lines are mostly `except Exception -> 500` handlers,
+which exist for failures that cannot be provoked without breaking SQLite
+underneath the process, and `fingerprint_store.resolve()`, which needs the
+browser binary and is covered by the `browser`-marked tests.
 
 ## Project layout
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,10 +21,14 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
   stay as aliases), one error shape everywhere, typed responses on every route,
   and a written stability contract in [api.md](api.md) saying what freezes and
   what deliberately does not.
+- The parts that delete profile directories, run browsers and import spreadsheets
+  in bulk are under test, and the six bugs that turned up in doing it are fixed.
+  What is deliberately left uncovered, and why, is written down in
+  [CONTRIBUTING.md](../CONTRIBUTING.md#what-is-deliberately-not-covered).
 
 ## Now (0.1.x)
 
-- Fill remaining gaps in test coverage.
+- The 0.1.x scope is cleared; the items below are what comes next.
 
 ## Next
 

--- a/src/camoufox_pm/api/routes/profiles.py
+++ b/src/camoufox_pm/api/routes/profiles.py
@@ -351,6 +351,9 @@ async def clone_profile(profile_id: str, request: ProfileCloneRequest):
         return ProfileResponse.from_profile(cloned_profile)
 
     except HTTPException:
+        # Without this the 404 raised above is caught by the handler below and
+        # served as a 500: the client's own bad id reported as a server fault,
+        # and a page for whoever watches the error rate.
         raise
     except ValueError as e:
         # A missing source returns None above; a ValueError here is bad input

--- a/src/camoufox_pm/api/routes/system.py
+++ b/src/camoufox_pm/api/routes/system.py
@@ -30,6 +30,19 @@ router = APIRouter()
 startup_time = time.time()
 
 
+def _cleanup_manager() -> ProfileCleanupManager:
+    """Point the cleanup at the storage this instance actually uses.
+
+    It used to be constructed with its defaults, which are ``./data`` and
+    ``./data/profiles.db`` whatever ``CPM_DB_PATH`` says. With the database
+    configured under any other name, the cleanup opened an empty one beside it,
+    concluded that every profile directory on disk was an orphan, and deleted
+    them all.
+    """
+    db_path = Path(get_settings().db_path)
+    return ProfileCleanupManager(str(db_path.parent), str(db_path))
+
+
 @router.get(
     "/system/status",
     response_model=SystemStatusResponse,
@@ -71,7 +84,7 @@ async def get_system_status():
 async def diagnostic_profiles():
     """Diagnose profile storage health."""
     try:
-        cleanup_manager = ProfileCleanupManager()
+        cleanup_manager = _cleanup_manager()
         await cleanup_manager.initialize()
         try:
             result = await cleanup_manager.full_diagnostic()
@@ -102,7 +115,7 @@ async def diagnostic_profiles():
 async def cleanup_orphaned_profiles(dry_run: bool = False):
     """Clean up orphaned profile directories."""
     try:
-        cleanup_manager = ProfileCleanupManager()
+        cleanup_manager = _cleanup_manager()
         await cleanup_manager.initialize()
         try:
             if dry_run:

--- a/src/camoufox_pm/core/cleanup.py
+++ b/src/camoufox_pm/core/cleanup.py
@@ -19,10 +19,17 @@ from camoufox_pm.core.models import Profile
 class ProfileCleanupManager:
     """Reconcile profile directories on disk with the database."""
 
-    def __init__(self, data_dir: str = "data"):
+    def __init__(self, data_dir: str = "data", db_path: str | None = None):
+        """``db_path`` must be the database the application itself uses.
+
+        Deriving it from ``data_dir`` assumes the file is called ``profiles.db``.
+        Any other configured name means opening an empty database beside the real
+        one — and then every directory on disk has no profile behind it and is
+        reported, and removed, as an orphan.
+        """
         self.data_dir = Path(data_dir)
         self.profiles_dir = self.data_dir / "profiles"
-        self.storage = StorageManager(str(self.data_dir / "profiles.db"))
+        self.storage = StorageManager(db_path or str(self.data_dir / "profiles.db"))
 
     async def initialize(self) -> None:
         await self.storage.initialize()
@@ -176,9 +183,12 @@ async def main() -> None:
         "--dry-run", action="store_true", help="Report changes without applying them"
     )
     parser.add_argument("--data-dir", default="data", help="Path to the data directory")
+    parser.add_argument(
+        "--db-path", default=None, help="Path to the database (default: <data-dir>/profiles.db)"
+    )
     args = parser.parse_args()
 
-    manager = ProfileCleanupManager(args.data_dir)
+    manager = ProfileCleanupManager(args.data_dir, args.db_path)
     await manager.initialize()
     try:
         if args.action == "diagnostic":

--- a/src/camoufox_pm/core/database.py
+++ b/src/camoufox_pm/core/database.py
@@ -215,12 +215,14 @@ class DatabaseManager:
 
         query += " ORDER BY created_at DESC"
 
-        if limit:
+        # SQLite will not take an OFFSET without a LIMIT, so an offset on its own
+        # used to be dropped and the caller silently got the first page back.
+        if limit or offset:
             query += " LIMIT ?"
-            params.append(limit)
-            if offset:
-                query += " OFFSET ?"
-                params.append(offset)
+            params.append(limit if limit else -1)
+        if offset:
+            query += " OFFSET ?"
+            params.append(offset)
 
         cursor = self._connection.execute(query, params)
         rows = cursor.fetchall()

--- a/src/camoufox_pm/core/excel_manager.py
+++ b/src/camoufox_pm/core/excel_manager.py
@@ -11,7 +11,7 @@ from openpyxl.comments import Comment
 from openpyxl.styles import Alignment, Font, PatternFill
 from openpyxl.worksheet.datavalidation import DataValidation
 
-from .models import BrowserSettings, Profile, ProfileStatus, WebRTCMode
+from .models import BrowserSettings, Profile, WebRTCMode
 from .profile_manager import ProfileManager
 
 
@@ -220,10 +220,7 @@ class ExcelManager:
             wb = load_workbook(excel_buffer)
             ws = wb.active
 
-            # Read the headers
-            headers = {}
-            for col_idx, (field, _, _) in enumerate(self.columns, 1):
-                headers[field] = col_idx
+            headers = self._locate_columns(ws)
 
             # Process the rows
             for row_idx in range(2, ws.max_row + 1):
@@ -257,12 +254,40 @@ class ExcelManager:
 
         return result
 
+    def _locate_columns(self, ws) -> dict[str, int]:
+        """Find which column each field occupies in *this* sheet.
+
+        The layout used to be taken from ``self.columns`` by position, on the
+        assumption that the file still looks exactly like the export. Bulk
+        editing invites the opposite: a column dragged elsewhere, or a read-only
+        one deleted. Every field after the change was then read from its
+        neighbour's column, and because most of them are free text nothing
+        objected — a sheet with Locale moved ahead of Timezone imported cleanly
+        with the two values swapped, for every row.
+        """
+        present: dict[str, int] = {}
+        for col_idx in range(1, ws.max_column + 1):
+            value = ws.cell(row=1, column=col_idx).value
+            if value is not None:
+                present.setdefault(str(value).strip(), col_idx)
+
+        located = {field: present[header] for field, header, _ in self.columns if header in present}
+        if "name" not in located:
+            name_header = next(header for field, header, _ in self.columns if field == "name")
+            raise ValueError(
+                f"No '{name_header}' column found in the first row. "
+                "Export the profiles to Excel and edit that file."
+            )
+        return located
+
     async def _process_excel_row(
         self, ws, row_idx: int, headers: dict[str, int], result: dict[str, Any]
     ):
         """Process a single Excel row."""
-        # Read the values from the row
-        row_data = {}
+        # Every field is read, whether or not the sheet still has its column; a
+        # column the user removed leaves the value empty, which is what the
+        # defaults below are for.
+        row_data = {field: "" for field, _, _ in self.columns}
         for field, col_idx in headers.items():
             cell_value = ws.cell(row=row_idx, column=col_idx).value
             row_data[field] = str(cell_value).strip() if cell_value is not None else ""
@@ -286,87 +311,12 @@ class ExcelManager:
             browser_settings=browser_settings,
             proxy_config=proxy_config,
             generate_fingerprint=False,  # Use the data from Excel
+            # Both columns are exported and both were read here and then dropped
+            # on the floor, so every import came back active and without notes.
+            notes=row_data["notes"] or None,
+            status=row_data["status"] or None,
         )
         result["created_count"] += 1
-
-    def _prepare_profile_updates(self, row_data: dict[str, str]) -> dict[str, Any]:
-        """Build the profile-update payload from a row."""
-        updates: dict[str, Any] = {}
-
-        # Core profile fields
-        if row_data["name"]:
-            updates["name"] = row_data["name"]
-        if row_data["group"]:
-            updates["group"] = row_data["group"]
-        if row_data["status"]:
-            updates["status"] = ProfileStatus(row_data["status"])
-        if row_data["notes"]:
-            updates["notes"] = row_data["notes"]
-
-        # Browser settings
-        browser_updates: dict[str, Any] = {}
-        if row_data["os"]:
-            browser_updates["os"] = row_data["os"]
-        if row_data["screen"]:
-            browser_updates["screen"] = row_data["screen"]
-        if row_data["window_width"]:
-            browser_updates["window_width"] = int(row_data["window_width"])
-        if row_data["window_height"]:
-            browser_updates["window_height"] = int(row_data["window_height"])
-        if row_data["languages"]:
-            browser_updates["languages"] = [
-                lang.strip() for lang in row_data["languages"].split(",")
-            ]
-        if row_data["timezone"]:
-            browser_updates["timezone"] = row_data["timezone"]
-        if row_data["locale"]:
-            browser_updates["locale"] = row_data["locale"]
-        if row_data["webrtc_mode"]:
-            browser_updates["webrtc_mode"] = WebRTCMode(row_data["webrtc_mode"])
-        if row_data["canvas_noise"]:
-            browser_updates["canvas_noise"] = row_data["canvas_noise"].lower() == "true"
-        if row_data["webgl_noise"]:
-            browser_updates["webgl_noise"] = row_data["webgl_noise"].lower() == "true"
-        if row_data["audio_noise"]:
-            browser_updates["audio_noise"] = row_data["audio_noise"].lower() == "true"
-        if row_data["stable_canvas"]:
-            browser_updates["stable_canvas"] = row_data["stable_canvas"].lower() == "true"
-        if row_data["hardware_concurrency"]:
-            browser_updates["hardware_concurrency"] = int(row_data["hardware_concurrency"])
-        if row_data["device_memory"]:
-            browser_updates["device_memory"] = int(row_data["device_memory"])
-        if row_data["max_touch_points"]:
-            browser_updates["max_touch_points"] = int(row_data["max_touch_points"])
-
-        # Geolocation
-        if (
-            row_data["geo_mode"] == "manual"
-            and row_data["geo_latitude"]
-            and row_data["geo_longitude"]
-        ):
-            browser_updates["geolocation"] = {
-                "lat": float(row_data["geo_latitude"]),
-                "lon": float(row_data["geo_longitude"]),
-                "accuracy": int(row_data["geo_accuracy"]) if row_data["geo_accuracy"] else 10,
-            }
-        elif row_data["geo_mode"] == "auto":
-            browser_updates["geolocation"] = None
-
-        if browser_updates:
-            updates["browser_settings"] = browser_updates
-
-        # Proxy
-        if row_data["proxy_type"] and row_data["proxy_server"]:
-            updates["proxy_config"] = {
-                "type": row_data["proxy_type"],
-                "server": row_data["proxy_server"],
-                "username": row_data["proxy_username"] or None,
-                "password": row_data["proxy_password"] or None,
-            }
-        elif not row_data["proxy_type"]:
-            updates["proxy_config"] = None
-
-        return updates
 
     def _create_browser_settings(self, row_data: dict[str, str]) -> BrowserSettings:
         """Build a BrowserSettings object from Excel data."""

--- a/src/camoufox_pm/core/profile_manager.py
+++ b/src/camoufox_pm/core/profile_manager.py
@@ -383,6 +383,10 @@ class ProfileManager:
 
         stats = await self.storage.get_profile_usage_stats(profile_id)
 
+        # The keys here are the ones ProfileStatsResponse reads. They used to be
+        # named differently — total_usage_time against total_duration_minutes,
+        # and no last_session or actions at all — so the endpoint fell back to
+        # its defaults and reported every profile as never used.
         return {
             "profile_id": profile_id,
             "name": profile.name,
@@ -390,8 +394,18 @@ class ProfileManager:
             "created_at": profile.created_at,
             "last_used": profile.last_used,
             "total_sessions": len([s for s in stats if s.action == "launch_browser"]),
-            "total_usage_time": sum([s.duration or 0 for s in stats]),
+            # Nothing records a duration yet, so this stays 0 until something does.
+            "total_duration_minutes": sum(s.duration or 0 for s in stats) // 60,
+            "last_session": profile.last_used,
             "success_rate": len([s for s in stats if s.success]) / len(stats) if stats else 0,
+            "actions": [
+                {
+                    "action": s.action,
+                    "timestamp": s.timestamp.isoformat(),
+                    "success": s.success,
+                }
+                for s in stats
+            ],
         }
 
     async def bulk_update_profiles(self, profile_ids: list[str], updates: dict[str, Any]) -> int:

--- a/src/camoufox_pm/core/profile_manager.py
+++ b/src/camoufox_pm/core/profile_manager.py
@@ -304,6 +304,12 @@ class ProfileManager:
         if regenerate_fingerprint:
             fingerprint = await self.fingerprint_generator.generate_fingerprint()
             new_profile.browser_settings = fingerprint
+            # And drop the pinned machine, which the copy above brought along.
+            # Without this the clone reported the same GPU, screen, core count
+            # and noise seeds as its source for the rest of its life: two
+            # profiles that are provably one computer. The next launch pins a new
+            # one, exactly as it does for a profile that has never run.
+            new_profile.fingerprint = None
 
         # Create the directory for the new profile
         profile_dir = Path(new_profile.get_storage_path(str(self.profiles_dir)))

--- a/src/camoufox_pm/core/profile_manager.py
+++ b/src/camoufox_pm/core/profile_manager.py
@@ -50,6 +50,7 @@ class ProfileManager:
         generate_fingerprint: bool = True,
         notes: str | None = None,
         fingerprint_preset: str | None = None,
+        status: ProfileStatus | str | None = None,
     ) -> Profile:
         """Create a new profile.
 
@@ -62,6 +63,11 @@ class ProfileManager:
         # Notes belong to the user; the creation time is already in created_at,
         # so it is not stamped into the field the user types into.
         profile = Profile(name=name, group=group, notes=notes)
+        if status:
+            # Raises for an unknown value rather than falling back to active: a
+            # bulk import is where a typo would otherwise reactivate a fleet of
+            # profiles their owner had deliberately parked.
+            profile.status = ProfileStatus(status)
 
         # Generate a browser fingerprint if requested
         if generate_fingerprint:

--- a/tests/integration/test_api_browsers.py
+++ b/tests/integration/test_api_browsers.py
@@ -1,0 +1,107 @@
+"""Integration tests for the browser-control endpoints.
+
+No browser is started: a stand-in session is registered so the endpoints that
+report and close them can be checked without a Camoufox binary.
+"""
+
+import pytest
+
+from camoufox_pm.api.dependencies import get_profile_manager
+from camoufox_pm.core.browser_session import BrowserSession
+
+
+class FakeCamoufox:
+    """Stands in for a running AsyncCamoufox and records that it was closed."""
+
+    def __init__(self):
+        self.exits = 0
+
+    async def __aexit__(self, *_exc):
+        self.exits += 1
+
+
+def register(profile_id: str) -> FakeCamoufox:
+    """Register a running browser for a profile."""
+    camoufox = FakeCamoufox()
+    get_profile_manager().browser_sessions.active_sessions[profile_id] = BrowserSession(
+        profile_id, camoufox=camoufox, process_id=4242
+    )
+    return camoufox
+
+
+@pytest.mark.asyncio
+async def test_no_browsers_are_reported_when_none_are_running(client):
+    body = (await client.get("/api/browsers/active")).json()
+
+    assert body == {"active_browsers": [], "count": 0}
+
+
+@pytest.mark.asyncio
+async def test_a_running_browser_is_listed_with_its_process(client):
+    register("p1")
+
+    body = (await client.get("/api/browsers/active")).json()
+
+    assert body["count"] == 1
+    assert body["active_browsers"][0]["profile_id"] == "p1"
+    assert body["active_browsers"][0]["process_id"] == 4242
+    assert body["active_browsers"][0]["started_at"]
+
+
+@pytest.mark.asyncio
+async def test_closing_one_browser_leaves_the_others_running(client):
+    first = register("p1")
+    second = register("p2")
+
+    result = (await client.post("/api/profiles/p1/close")).json()
+
+    assert result["status"] == "closed"
+    assert first.exits == 1
+    assert second.exits == 0
+    assert (await client.get("/api/browsers/active")).json()["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_closing_a_browser_that_is_not_running_is_not_an_error(client):
+    """The window may already have been closed by hand; saying so beats a 500."""
+    response = await client.post("/api/profiles/nope/close")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "not_running"
+
+
+@pytest.mark.asyncio
+async def test_close_all_closes_every_browser_and_counts_them(client):
+    browsers = [register("p1"), register("p2"), register("p3")]
+
+    body = (await client.post("/api/browsers/close-all")).json()
+
+    assert body["closed_count"] == 3
+    assert [b.exits for b in browsers] == [1, 1, 1]
+    assert (await client.get("/api/browsers/active")).json()["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_launching_an_unknown_profile_is_a_404(client):
+    response = await client.post("/api/profiles/nope/launch", json={"headless": True})
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_a_clone_is_created_as_a_new_profile(client):
+    created = (await client.post("/api/profiles", json={"name": "source"})).json()
+
+    cloned = await client.post(f"/api/profiles/{created['id']}/clone", json={"new_name": "copy"})
+
+    assert cloned.status_code == 201
+    assert cloned.json()["name"] == "copy"
+    assert cloned.json()["id"] != created["id"]
+    assert (await client.get(f"/api/profiles/{created['id']}")).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_cloning_an_unknown_profile_is_a_404(client):
+    response = await client.post("/api/profiles/nope/clone", json={"new_name": "copy"})
+
+    assert response.status_code == 404

--- a/tests/integration/test_api_excel.py
+++ b/tests/integration/test_api_excel.py
@@ -1,0 +1,68 @@
+"""Integration tests for the spreadsheet endpoints.
+
+Bulk editing goes out through one endpoint and comes back through the other, so
+these check the pair over HTTP: the file the browser is handed, and what the
+server does with a file it should refuse.
+"""
+
+import pytest
+
+XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+
+@pytest.mark.asyncio
+async def test_the_export_is_served_as_a_spreadsheet_download(client):
+    await client.post("/api/profiles", json={"name": "a"})
+
+    response = await client.get("/api/profiles/export/excel")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == XLSX
+    assert "camoufox_profiles.xlsx" in response.headers["content-disposition"]
+    assert response.content[:2] == b"PK", "an xlsx is a zip"
+
+
+@pytest.mark.asyncio
+async def test_an_exported_sheet_can_be_imported_again(client):
+    await client.post("/api/profiles", json={"name": "a"})
+    await client.post("/api/profiles", json={"name": "b"})
+    exported = await client.get("/api/profiles/export/excel")
+
+    imported = await client.post(
+        "/api/profiles/import/excel",
+        files={"file": ("profiles.xlsx", exported.content, XLSX)},
+    )
+
+    assert imported.status_code == 200
+    body = imported.json()
+    assert body["success"] is True
+    assert body["data"]["created_count"] == 2
+    assert body["data"]["error_count"] == 0
+    assert (await client.get("/api/profiles")).json()["total"] == 4
+
+
+@pytest.mark.asyncio
+async def test_a_file_that_is_not_a_spreadsheet_is_refused(client):
+    response = await client.post(
+        "/api/profiles/import/excel",
+        files={"file": ("profiles.csv", b"name,group\na,b\n", "text/csv")},
+    )
+
+    assert response.status_code == 400
+    assert (await client.get("/api/profiles")).json()["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_a_corrupt_workbook_is_reported_rather_than_crashing_the_request(client):
+    """The upload is named .xlsx but is not one. The user gets told what went
+    wrong; a 500 would look like the server's fault."""
+    response = await client.post(
+        "/api/profiles/import/excel",
+        files={"file": ("profiles.xlsx", b"not really a workbook", XLSX)},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["success"] is False
+    assert body["data"]["created_count"] == 0
+    assert body["data"]["errors"]

--- a/tests/integration/test_api_groups.py
+++ b/tests/integration/test_api_groups.py
@@ -31,3 +31,47 @@ async def test_delete_group(client):
     assert deleted.status_code == 200
     missing = await client.get(f"/api/groups/{group['id']}")
     assert missing.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_group_keeps_its_profiles(client):
+    """A group is a label on a profile, not a container that owns it."""
+    group = (await client.post("/api/groups", json={"name": "Doomed"})).json()
+    profile = (
+        await client.post("/api/profiles", json={"name": "survivor", "group": group["id"]})
+    ).json()
+
+    await client.delete(f"/api/groups/{group['id']}")
+
+    fetched = await client.get(f"/api/profiles/{profile['id']}")
+    assert fetched.status_code == 200
+    assert fetched.json()["group"] is None
+
+
+@pytest.mark.asyncio
+async def test_updating_a_group_changes_only_what_was_sent(client):
+    group = (
+        await client.post("/api/groups", json={"name": "Before", "description": "keep me"})
+    ).json()
+
+    updated = await client.put(f"/api/groups/{group['id']}", json={"name": "After"})
+
+    assert updated.status_code == 200
+    assert updated.json()["name"] == "After"
+    assert updated.json()["description"] == "keep me"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [("put", "/api/groups/nope"), ("delete", "/api/groups/nope"), ("get", "/api/groups/nope")],
+)
+async def test_an_unknown_group_is_a_404(client, method, path):
+    request = getattr(client, method)
+    response = await (request(path, json={"name": "x"}) if method == "put" else request(path))
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_a_group_name_must_not_be_blank(client):
+    assert (await client.post("/api/groups", json={"name": ""})).status_code == 422

--- a/tests/integration/test_api_profiles.py
+++ b/tests/integration/test_api_profiles.py
@@ -1,8 +1,12 @@
 """Integration tests for the profiles API."""
 
+from datetime import datetime
+
 import pytest
 
+from camoufox_pm.api.dependencies import get_profile_manager
 from camoufox_pm.core import fingerprint_store
+from camoufox_pm.core.models import UsageStats
 
 
 @pytest.mark.asyncio
@@ -554,3 +558,31 @@ async def test_flattened_browser_fields_still_apply(client):
     settings = updated.json()["browser_settings"]
     assert settings["os"] == "linux"
     assert settings["hardware_concurrency"] == 12
+
+
+@pytest.mark.asyncio
+async def test_profile_statistics_report_the_sessions_that_happened(client):
+    """Regression: the endpoint read keys the manager did not return, so it
+    always answered zero sessions, no last session and no actions — whatever the
+    profile's history actually was.
+    """
+    created = await client.post("/api/profiles", json={"name": "busy"})
+    profile_id = created.json()["id"]
+    manager = get_profile_manager()
+    for _ in range(3):
+        await manager.storage.log_usage(UsageStats(profile_id=profile_id, action="launch_browser"))
+    profile = await manager.get_profile(profile_id)
+    profile.last_used = datetime(2026, 1, 2, 3, 4, 5)
+    await manager.storage.update_profile(profile)
+
+    body = (await client.get(f"/api/profiles/{profile_id}/stats")).json()
+
+    assert body["total_sessions"] == 3
+    assert body["last_session"].startswith("2026-01-02T03:04:05")
+    assert [a["action"] for a in body["actions"]].count("launch_browser") == 3
+    assert body["success_rate"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_statistics_for_an_unknown_profile_are_a_404(client):
+    assert (await client.get("/api/profiles/nope/stats")).status_code == 404

--- a/tests/integration/test_api_system.py
+++ b/tests/integration/test_api_system.py
@@ -46,7 +46,7 @@ def make_orphan(root, name: str = "deadbeef", size: int = 4096):
 @pytest.mark.asyncio
 async def test_status_reports_what_is_there(client):
     await client.post("/api/profiles", json={"name": "one"})
-    await client.post("/api/profiles", json={"name": "two", "status": "inactive"})
+    await client.post("/api/profiles", json={"name": "two"})
     await client.post("/api/groups", json={"name": "Social"})
 
     body = (await client.get("/api/system/status")).json()

--- a/tests/integration/test_api_system.py
+++ b/tests/integration/test_api_system.py
@@ -1,0 +1,152 @@
+"""Integration tests for the system API, including its two destructive endpoints."""
+
+import shutil
+
+import pytest
+
+from camoufox_pm.api.dependencies import get_profile_manager
+from camoufox_pm.config import get_settings
+from camoufox_pm.core.browser_session import BrowserSession
+
+
+class FakeCamoufox:
+    """Stands in for a running AsyncCamoufox and records that it was closed."""
+
+    def __init__(self):
+        self.exits = 0
+
+    async def __aexit__(self, *_exc):
+        self.exits += 1
+
+
+@pytest.fixture
+def storage_dir(client, tmp_path, monkeypatch):
+    """Point the settings at the same database and directory the client uses.
+
+    The working directory is moved as well, so that code reading the relative
+    default (``./data``) cannot reach anything real.
+    """
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    monkeypatch.setenv("CPM_DB_PATH", str(tmp_path / "api.db"))
+    get_settings.cache_clear()
+    yield tmp_path
+    get_settings.cache_clear()
+
+
+def make_orphan(root, name: str = "deadbeef", size: int = 4096):
+    """Create a profile directory that no database row refers to."""
+    directory = root / "profiles" / f"profile_{name}"
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "cookies.sqlite").write_bytes(b"x" * size)
+    return directory
+
+
+@pytest.mark.asyncio
+async def test_status_reports_what_is_there(client):
+    await client.post("/api/profiles", json={"name": "one"})
+    await client.post("/api/profiles", json={"name": "two", "status": "inactive"})
+    await client.post("/api/groups", json={"name": "Social"})
+
+    body = (await client.get("/api/system/status")).json()
+
+    assert body["total_profiles"] == 2
+    assert body["total_groups"] == 1
+    assert body["running_browsers"] == 0
+
+
+@pytest.mark.asyncio
+async def test_status_counts_a_running_browser(client):
+    await client.post("/api/profiles", json={"name": "one"})
+    manager = get_profile_manager()
+    manager.browser_sessions.active_sessions["p1"] = BrowserSession("p1", camoufox=FakeCamoufox())
+
+    body = (await client.get("/api/system/status")).json()
+
+    assert body["running_browsers"] == 1
+
+
+@pytest.mark.asyncio
+async def test_the_diagnostic_reports_orphaned_and_missing_directories(client, storage_dir):
+    created = (await client.post("/api/profiles", json={"name": "lost"})).json()
+    shutil.rmtree(storage_dir / "profiles" / f"profile_{created['id']}")
+    make_orphan(storage_dir)
+
+    body = (await client.get("/api/system/profiles/diagnostic")).json()
+
+    assert body["total_profiles_in_db"] == 1
+    assert body["orphaned_directories"] == 1
+    assert body["missing_directories"] == 1
+    assert body["issues_found"] == 2
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_the_orphan_and_keeps_the_live_profile(client, storage_dir):
+    """Regression: this endpoint deleted every profile directory on disk.
+
+    The cleanup was built with its own defaults — ``./data`` and
+    ``./data/profiles.db`` — rather than the configured database. Under any
+    other database file name it read an empty one, found no profiles to match
+    the directories against, and removed all of them.
+    """
+    live = (await client.post("/api/profiles", json={"name": "live"})).json()
+    live_dir = storage_dir / "profiles" / f"profile_{live['id']}"
+    (live_dir / "cookies.sqlite").write_bytes(b"session")
+    orphan = make_orphan(storage_dir)
+
+    body = (await client.post("/api/system/profiles/cleanup")).json()
+
+    assert body["orphaned_removed"] == 1
+    assert not orphan.exists()
+    assert (live_dir / "cookies.sqlite").read_bytes() == b"session"
+
+
+@pytest.mark.asyncio
+async def test_a_dry_run_reports_the_orphan_without_removing_it(client, storage_dir):
+    await client.post("/api/profiles", json={"name": "live"})
+    orphan = make_orphan(storage_dir)
+
+    body = (await client.post("/api/system/profiles/cleanup?dry_run=true")).json()
+
+    assert body["dry_run"] is True
+    assert body["orphaned_removed"] == 1
+    assert body["freed_space_mb"] == pytest.approx(4096 / (1024 * 1024))
+    assert orphan.exists()
+
+
+@pytest.mark.asyncio
+async def test_restart_closes_every_running_browser(client):
+    manager = get_profile_manager()
+    camoufoxes = [FakeCamoufox(), FakeCamoufox()]
+    for profile_id, camoufox in zip(("p1", "p2"), camoufoxes, strict=True):
+        manager.browser_sessions.active_sessions[profile_id] = BrowserSession(
+            profile_id, camoufox=camoufox
+        )
+
+    response = await client.post("/api/system/restart")
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    assert [c.exits for c in camoufoxes] == [1, 1]
+    assert manager.browser_sessions.list_active() == []
+
+
+@pytest.mark.asyncio
+async def test_the_config_endpoint_reports_secrets_as_set_but_never_their_values(
+    client, monkeypatch
+):
+    """The Settings screen has to show whether encryption and the key are on.
+    Reporting them means serving both secrets to anyone who reaches the API."""
+    monkeypatch.setenv("CPM_API_KEY", "top-secret-key")
+    monkeypatch.setenv("CPM_SECRET_KEY", "top-secret-encryption")
+    get_settings.cache_clear()
+    try:
+        response = await client.get("/api/system/config", headers={"X-API-Key": "top-secret-key"})
+
+        assert response.json()["data"]["api_key_set"] is True
+        assert response.json()["data"]["encryption_enabled"] is True
+        assert "top-secret-key" not in response.text
+        assert "top-secret-encryption" not in response.text
+    finally:
+        get_settings.cache_clear()

--- a/tests/integration/test_api_system.py
+++ b/tests/integration/test_api_system.py
@@ -4,6 +4,7 @@ import shutil
 
 import pytest
 
+from camoufox_pm.api import dependencies
 from camoufox_pm.api.dependencies import get_profile_manager
 from camoufox_pm.config import get_settings
 from camoufox_pm.core.browser_session import BrowserSession
@@ -130,6 +131,30 @@ async def test_restart_closes_every_running_browser(client):
     assert response.json()["success"] is True
     assert [c.exits for c in camoufoxes] == [1, 1]
     assert manager.browser_sessions.list_active() == []
+
+
+@pytest.mark.asyncio
+async def test_health_reports_the_database_and_the_profile_count(client):
+    await client.post("/api/profiles", json={"name": "one"})
+
+    body = (await client.get("/health")).json()
+
+    assert body["status"] == "healthy"
+    assert body["database"] == "connected"
+    assert body["profiles_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_health_answers_when_storage_is_unavailable(client, monkeypatch):
+    """This is what a container orchestrator polls. It has to answer 'unhealthy'
+    rather than raise, or a failing instance looks the same as an unreachable one."""
+    monkeypatch.setattr(dependencies, "_profile_manager", None)
+
+    response = await client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "unhealthy"
+    assert response.json()["database"] == "disconnected"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_api_system.py
+++ b/tests/integration/test_api_system.py
@@ -146,13 +146,14 @@ async def test_health_reports_the_database_and_the_profile_count(client):
 
 @pytest.mark.asyncio
 async def test_health_answers_when_storage_is_unavailable(client, monkeypatch):
-    """This is what a container orchestrator polls. It has to answer 'unhealthy'
-    rather than raise, or a failing instance looks the same as an unreachable one."""
+    """This is what a container orchestrator polls, and it reads the status code,
+    not the body: an unhealthy instance must answer 503, or a failing one looks
+    exactly like a healthy one to a load balancer."""
     monkeypatch.setattr(dependencies, "_profile_manager", None)
 
     response = await client.get("/health")
 
-    assert response.status_code == 200
+    assert response.status_code == 503
     assert response.json()["status"] == "unhealthy"
     assert response.json()["database"] == "disconnected"
 

--- a/tests/unit/test_browser_session.py
+++ b/tests/unit/test_browser_session.py
@@ -1,8 +1,81 @@
 """Tests for the browser session registry (no real browser launched)."""
 
+import asyncio
+
+import psutil
 import pytest
 
-from camoufox_pm.core.browser_session import BrowserSession, BrowserSessionManager
+from camoufox_pm.core import browser_session as bs
+from camoufox_pm.core.browser_session import (
+    BrowserLaunchError,
+    BrowserSession,
+    BrowserSessionManager,
+    _resolve_process_id,
+)
+
+
+class FakeBrowser:
+    """Stands in for the Playwright browser/context returned by a launch.
+
+    Records the handlers registered on it so that a user closing the window can
+    be simulated, which is the primary teardown signal in production.
+    """
+
+    def __init__(self, pid: int | None = None):
+        self.handlers: dict[str, list] = {}
+        if pid is not None:
+            self._browser_process = type("Proc", (), {"pid": pid})()
+
+    def on(self, event: str, handler) -> None:
+        self.handlers.setdefault(event, []).append(handler)
+
+    def fire(self, event: str) -> None:
+        for handler in self.handlers.get(event, []):
+            handler()
+
+
+class FakeCamoufox:
+    """Stands in for AsyncCamoufox, counting how often it was started and closed."""
+
+    def __init__(self, browser: FakeBrowser | None = None, fail: Exception | None = None):
+        self.browser = browser if browser is not None else FakeBrowser()
+        self.fail = fail
+        self.starts = 0
+        self.exits = 0
+        self.exit_error: Exception | None = None
+
+    async def start(self):
+        self.starts += 1
+        if self.fail is not None:
+            raise self.fail
+        return self.browser
+
+    async def __aexit__(self, *_exc):
+        self.exits += 1
+        if self.exit_error is not None:
+            raise self.exit_error
+
+
+@pytest.fixture
+def installed(monkeypatch):
+    """Pretend Camoufox is installed and hand every launch the given stand-in."""
+
+    def install(camoufox: FakeCamoufox) -> FakeCamoufox:
+        monkeypatch.setattr(bs, "CAMOUFOX_AVAILABLE", True)
+        monkeypatch.setattr(bs, "AsyncCamoufox", lambda **_options: camoufox)
+        return camoufox
+
+    return install
+
+
+async def settle(manager: BrowserSessionManager) -> None:
+    """Await the teardown tasks a close event scheduled.
+
+    The manager keeps strong references to them, so this is deterministic: no
+    sleeping and no polling.
+    """
+    while manager._exit_tasks:
+        await asyncio.gather(*list(manager._exit_tasks))
 
 
 def test_register_and_list_active():
@@ -62,3 +135,276 @@ async def test_handle_exit_notifies_once_and_prunes():
     # Fallback monitor firing after the close event must be a no-op.
     await mgr._handle_exit("p1")
     assert calls == ["p1"]
+
+
+# -- Launching ----------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_launching_a_profile_twice_reuses_the_running_browser(installed):
+    """Two windows on one profile would have them writing the same databases."""
+    camoufox = installed(FakeCamoufox())
+    mgr = BrowserSessionManager()
+
+    first = await mgr.launch("p1", {})
+    second = await mgr.launch("p1", {})
+
+    assert second is first
+    assert camoufox.starts == 1
+
+
+@pytest.mark.asyncio
+async def test_a_failed_launch_leaves_nothing_running(installed):
+    """A half-registered session would make the profile unlaunchable forever:
+    every later attempt would report it as already running."""
+    installed(FakeCamoufox(fail=RuntimeError("no display")))
+    mgr = BrowserSessionManager()
+
+    with pytest.raises(BrowserLaunchError, match="no display"):
+        await mgr.launch("p1", {})
+
+    assert mgr.is_running("p1") is False
+    assert mgr.list_active() == []
+
+
+@pytest.mark.asyncio
+async def test_without_camoufox_installed_the_error_says_how_to_install_it(monkeypatch):
+    monkeypatch.setattr(bs, "CAMOUFOX_AVAILABLE", False)
+    mgr = BrowserSessionManager()
+
+    with pytest.raises(BrowserLaunchError, match="pip install"):
+        await mgr.launch("p1", {})
+
+
+@pytest.mark.asyncio
+async def test_no_watchdog_is_started_when_no_process_id_could_be_resolved(installed):
+    """The watchdog tears the session down as soon as its pid stops existing, so
+    starting one for a pid we never resolved would close the browser at once."""
+    installed(FakeCamoufox(FakeBrowser(pid=None)))
+    mgr = BrowserSessionManager()
+
+    session = await mgr.launch("p1", {})
+
+    assert session.process_id is None
+    assert session.monitor_task is None
+
+
+# -- The user closes the window ------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_closing_the_window_tears_the_session_down(installed):
+    camoufox = installed(FakeCamoufox())
+    mgr = BrowserSessionManager()
+    closed = []
+
+    async def on_exit(profile_id):
+        closed.append(profile_id)
+
+    await mgr.launch("p1", {}, on_exit=on_exit)
+    camoufox.browser.fire("close")
+    await settle(mgr)
+
+    assert closed == ["p1"]
+    assert mgr.is_running("p1") is False
+    assert camoufox.exits == 1
+
+
+@pytest.mark.asyncio
+async def test_close_and_disconnected_together_tear_down_only_once(installed):
+    """Playwright fires both for one window; the profile must not be logged as
+    closed twice, nor the context closed twice."""
+    camoufox = installed(FakeCamoufox())
+    mgr = BrowserSessionManager()
+    closed = []
+
+    async def on_exit(profile_id):
+        closed.append(profile_id)
+
+    await mgr.launch("p1", {}, on_exit=on_exit)
+    camoufox.browser.fire("close")
+    camoufox.browser.fire("disconnected")
+    await settle(mgr)
+
+    assert closed == ["p1"]
+    assert camoufox.exits == 1
+
+
+@pytest.mark.asyncio
+async def test_a_session_whose_process_vanished_is_still_listed(monkeypatch):
+    """Listing used to prune those sessions, which skipped terminate() and the
+    exit handler and so leaked the Camoufox context. Listing is a pure read."""
+    monkeypatch.setattr(psutil, "pid_exists", lambda _pid: False)
+    mgr = BrowserSessionManager()
+    mgr.active_sessions["p1"] = BrowserSession("p1", camoufox=None, process_id=4242)
+
+    assert [s["profile_id"] for s in mgr.list_active()] == ["p1"]
+    assert mgr.is_running("p1") is True
+
+
+@pytest.mark.asyncio
+async def test_the_watchdog_tears_down_when_the_process_disappears(monkeypatch):
+    monkeypatch.setattr(psutil, "pid_exists", lambda _pid: False)
+    mgr = BrowserSessionManager()
+    camoufox = FakeCamoufox()
+    session = BrowserSession("p1", camoufox=camoufox, process_id=4242)
+    closed = []
+
+    async def on_exit(profile_id):
+        closed.append(profile_id)
+
+    session.on_exit = on_exit
+    mgr.active_sessions["p1"] = session
+
+    await mgr._monitor("p1", 4242)
+
+    assert closed == ["p1"]
+    assert mgr.is_running("p1") is False
+    assert camoufox.exits == 1
+
+
+@pytest.mark.asyncio
+async def test_terminating_stops_the_watchdog():
+    """A watchdog outliving its session would tear down whatever session took its
+    place under the same profile id."""
+    session = BrowserSession("p1", camoufox=None, process_id=4242)
+    session.monitor_task = asyncio.create_task(asyncio.sleep(3600))
+
+    await session.terminate()
+
+    assert session.monitor_task.cancelled()
+
+
+# -- Teardown that goes wrong ---------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_browser_that_fails_to_close_is_still_forgotten(installed):
+    """A crashed browser raises on close. Keeping the session would leave the
+    profile permanently 'running' and impossible to launch again."""
+    camoufox = installed(FakeCamoufox())
+    camoufox.exit_error = RuntimeError("connection already closed")
+    mgr = BrowserSessionManager()
+
+    await mgr.launch("p1", {})
+
+    assert await mgr.close("p1") is True
+    assert mgr.is_running("p1") is False
+
+
+@pytest.mark.asyncio
+async def test_an_exit_handler_that_raises_does_not_break_teardown(installed):
+    camoufox = installed(FakeCamoufox())
+    mgr = BrowserSessionManager()
+
+    async def on_exit(_profile_id):
+        raise RuntimeError("database gone")
+
+    await mgr.launch("p1", {}, on_exit=on_exit)
+    camoufox.browser.fire("close")
+    await settle(mgr)
+
+    assert mgr.is_running("p1") is False
+    assert camoufox.exits == 1
+
+
+@pytest.mark.asyncio
+async def test_a_driver_that_survived_the_close_is_killed(monkeypatch):
+    """The graceful close is the primary path; the pid is the backstop, and a
+    surviving driver process holds the profile directory open."""
+    actions = []
+
+    class FakeProcess:
+        def __init__(self, pid):
+            actions.append(("open", pid))
+
+        def terminate(self):
+            actions.append(("terminate", None))
+
+        def wait(self, timeout=None):
+            actions.append(("wait", timeout))
+
+    monkeypatch.setattr(bs.psutil, "Process", FakeProcess)
+    session = BrowserSession("p1", camoufox=FakeCamoufox(), process_id=4242)
+
+    await session.terminate()
+
+    assert actions == [("open", 4242), ("terminate", None), ("wait", 5)]
+
+
+@pytest.mark.asyncio
+async def test_a_driver_that_ignores_terminate_is_killed(monkeypatch):
+    killed = []
+
+    class StubbornProcess:
+        def __init__(self, pid):
+            pass
+
+        def terminate(self):
+            pass
+
+        def wait(self, timeout=None):
+            raise psutil.TimeoutExpired(timeout)
+
+        def kill(self):
+            killed.append(True)
+
+    monkeypatch.setattr(bs.psutil, "Process", StubbornProcess)
+    session = BrowserSession("p1", camoufox=FakeCamoufox(), process_id=4242)
+
+    await session.terminate()
+
+    assert killed == [True]
+
+
+@pytest.mark.asyncio
+async def test_a_process_that_is_already_gone_is_not_an_error(monkeypatch):
+    def gone(_pid):
+        raise psutil.NoSuchProcess(_pid)
+
+    monkeypatch.setattr(bs.psutil, "Process", gone)
+    session = BrowserSession("p1", camoufox=FakeCamoufox(), process_id=4242)
+
+    await session.terminate()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_close_all_closes_every_browser(installed):
+    installed(FakeCamoufox())
+    mgr = BrowserSessionManager()
+    for profile_id in ("p1", "p2", "p3"):
+        mgr.active_sessions[profile_id] = BrowserSession(profile_id, camoufox=FakeCamoufox())
+
+    assert await mgr.close_all() == 3
+    assert mgr.list_active() == []
+
+
+# -- Resolving a process id -----------------------------------------------------
+
+
+def test_a_process_id_is_never_fabricated():
+    """Returning a placeholder pid would make the watchdog kill an unrelated
+    process, and would start a watchdog that immediately tears the session down."""
+
+    class Opaque:
+        pass
+
+    assert _resolve_process_id(Opaque()) is None
+
+
+def test_a_process_id_is_found_through_the_nested_transport():
+    """Playwright does not expose the pid, so it is read from internals that move
+    between versions; each known shape must keep working."""
+
+    class Nested:
+        pass
+
+    obj = Nested()
+    obj.browser = Nested()
+    obj.browser._impl = Nested()
+    obj.browser._impl._connection = Nested()
+    obj.browser._impl._connection._transport = Nested()
+    obj.browser._impl._connection._transport._proc = Nested()
+    obj.browser._impl._connection._transport._proc.pid = 777
+
+    assert _resolve_process_id(obj) == 777

--- a/tests/unit/test_cleanup.py
+++ b/tests/unit/test_cleanup.py
@@ -1,0 +1,222 @@
+"""Reconciling profile directories with the database.
+
+This module deletes directories from disk, and a profile directory is the
+account: cookies, storage, saved logins. Every test here is about what survives.
+"""
+
+import shutil
+
+import pytest
+
+from camoufox_pm.core.cleanup import ProfileCleanupManager
+
+
+@pytest.fixture
+async def cleanup(profile_manager, tmp_path):
+    """A cleanup manager pointed at the same storage as ``profile_manager``."""
+    manager = ProfileCleanupManager(str(tmp_path), str(tmp_path / "test.db"))
+    await manager.initialize()
+    yield manager
+    await manager.close()
+
+
+def make_orphan(tmp_path, name: str = "deadbeef", size: int = 2048):
+    """Create a profile directory on disk that no database row refers to."""
+    directory = tmp_path / "profiles" / f"profile_{name}"
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "cookies.sqlite").write_bytes(b"x" * size)
+    return directory
+
+
+@pytest.mark.asyncio
+async def test_a_directory_no_profile_refers_to_is_orphaned(cleanup, tmp_path):
+    orphan = make_orphan(tmp_path)
+
+    found = await cleanup.find_orphaned_profile_directories()
+
+    assert [item["path"] for item in found] == [orphan]
+    assert found[0]["profile_id"] == "deadbeef"
+    assert found[0]["size_mb"] == pytest.approx(2048 / (1024 * 1024))
+
+
+@pytest.mark.asyncio
+async def test_a_directory_a_profile_refers_to_is_not_orphaned(cleanup, profile_manager):
+    await profile_manager.create_profile(name="live")
+
+    assert await cleanup.find_orphaned_profile_directories() == []
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_the_orphan_and_leaves_the_live_profile_alone(
+    cleanup, profile_manager, tmp_path
+):
+    """The whole point of the module, and the one mistake that cannot be undone."""
+    profile = await profile_manager.create_profile(name="live")
+    live_dir = tmp_path / "profiles" / f"profile_{profile.id}"
+    (live_dir / "cookies.sqlite").write_bytes(b"session")
+    orphan = make_orphan(tmp_path)
+
+    removed = await cleanup.cleanup_orphaned_directories(
+        await cleanup.find_orphaned_profile_directories(), confirm=False
+    )
+
+    assert removed == 1
+    assert not orphan.exists()
+    assert (live_dir / "cookies.sqlite").read_bytes() == b"session"
+
+
+@pytest.mark.asyncio
+async def test_anything_that_is_not_a_profile_directory_is_left_alone(cleanup, tmp_path):
+    """The profiles directory is a place users put things: backups, notes, exports.
+
+    Only ``profile_*`` directories are ours to delete.
+    """
+    profiles = tmp_path / "profiles"
+    profiles.mkdir(parents=True, exist_ok=True)
+    backup = profiles / "backup-before-upgrade"
+    backup.mkdir()
+    (backup / "keep.txt").write_text("mine")
+    loose_file = profiles / "profile_notes.txt"
+    loose_file.write_text("not a directory")
+
+    await cleanup.cleanup_orphaned_directories(
+        await cleanup.find_orphaned_profile_directories(), confirm=False
+    )
+
+    assert (backup / "keep.txt").exists()
+    assert loose_file.exists()
+
+
+@pytest.mark.parametrize(("answer", "expected"), [("yes", 1), ("y", 1), ("no", 0), ("", 0)])
+@pytest.mark.asyncio
+async def test_the_prompt_decides_whether_anything_is_deleted(
+    cleanup, tmp_path, monkeypatch, answer, expected
+):
+    orphan = make_orphan(tmp_path)
+    monkeypatch.setattr("builtins.input", lambda _: answer)
+
+    removed = await cleanup.cleanup_orphaned_directories(
+        await cleanup.find_orphaned_profile_directories(), confirm=True
+    )
+
+    assert removed == expected
+    assert orphan.exists() is (expected == 0)
+
+
+@pytest.mark.asyncio
+async def test_one_directory_that_cannot_be_removed_does_not_strand_the_rest(
+    cleanup, tmp_path, monkeypatch
+):
+    """A locked or permission-denied directory must not abort the run.
+
+    Half a cleanup that reports failure is worse than a cleanup that skips one
+    directory and says how many it managed.
+    """
+    stubborn = make_orphan(tmp_path, "aaaaaaaa")
+    removable = make_orphan(tmp_path, "bbbbbbbb")
+    real_rmtree = shutil.rmtree
+
+    def refuse_one(path, *args, **kwargs):
+        if path == stubborn:
+            raise PermissionError("in use")
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(shutil, "rmtree", refuse_one)
+
+    removed = await cleanup.cleanup_orphaned_directories(
+        await cleanup.find_orphaned_profile_directories(), confirm=False
+    )
+
+    assert removed == 1
+    assert stubborn.exists()
+    assert not removable.exists()
+
+
+@pytest.mark.asyncio
+async def test_a_profile_without_a_directory_is_reported_and_can_be_recreated(
+    cleanup, profile_manager, tmp_path
+):
+    profile = await profile_manager.create_profile(name="lost")
+    shutil.rmtree(tmp_path / "profiles" / f"profile_{profile.id}")
+
+    missing = await cleanup.find_missing_profile_directories()
+    assert [item["profile"].id for item in missing] == [profile.id]
+
+    assert await cleanup.create_missing_directories(missing) == 1
+    assert (tmp_path / "profiles" / f"profile_{profile.id}").is_dir()
+
+
+@pytest.mark.asyncio
+async def test_a_dry_run_changes_nothing_on_disk(cleanup, profile_manager, tmp_path):
+    profile = await profile_manager.create_profile(name="lost")
+    shutil.rmtree(tmp_path / "profiles" / f"profile_{profile.id}")
+    orphan = make_orphan(tmp_path)
+
+    results = await cleanup.auto_cleanup(dry_run=True)
+
+    assert results == {"orphaned_removed": 0, "directories_created": 0}
+    assert orphan.exists()
+    assert not (tmp_path / "profiles" / f"profile_{profile.id}").exists()
+
+
+@pytest.mark.asyncio
+async def test_auto_cleanup_both_removes_and_recreates(cleanup, profile_manager, tmp_path):
+    profile = await profile_manager.create_profile(name="lost")
+    shutil.rmtree(tmp_path / "profiles" / f"profile_{profile.id}")
+    orphan = make_orphan(tmp_path)
+
+    results = await cleanup.auto_cleanup()
+
+    assert results == {"orphaned_removed": 1, "directories_created": 1}
+    assert not orphan.exists()
+    assert (tmp_path / "profiles" / f"profile_{profile.id}").is_dir()
+
+
+@pytest.mark.asyncio
+async def test_the_diagnostic_counts_what_is_actually_there(cleanup, profile_manager, tmp_path):
+    healthy = await profile_manager.create_profile(name="healthy")
+    (tmp_path / "profiles" / f"profile_{healthy.id}" / "places.sqlite").write_bytes(b"y" * 1024)
+    lost = await profile_manager.create_profile(name="lost")
+    shutil.rmtree(tmp_path / "profiles" / f"profile_{lost.id}")
+    make_orphan(tmp_path, size=1024)
+
+    report = await cleanup.full_diagnostic()
+
+    assert report["total_profiles_in_db"] == 2
+    assert report["total_directories_on_disk"] == 2  # the healthy one and the orphan
+    assert report["orphaned_directories"] == 1
+    assert report["missing_directories"] == 1
+    assert report["healthy_profiles"] == 1
+    assert report["issues_found"] == 2
+    assert report["total_disk_size_mb"] == pytest.approx(2048 / (1024 * 1024))
+
+
+@pytest.mark.asyncio
+async def test_a_fresh_install_with_no_profiles_directory_is_not_an_error(tmp_path):
+    manager = ProfileCleanupManager(str(tmp_path / "empty"), str(tmp_path / "empty" / "test.db"))
+    await manager.initialize()
+    try:
+        assert manager.get_profile_directories_on_disk() == []
+        assert await manager.find_orphaned_profile_directories() == []
+        assert await manager.auto_cleanup() == {"orphaned_removed": 0, "directories_created": 0}
+    finally:
+        await manager.close()
+
+
+@pytest.mark.asyncio
+async def test_it_reads_the_database_it_was_given(profile_manager, tmp_path):
+    """Regression: the database was assumed to be ``<data_dir>/profiles.db``.
+
+    Any other configured file name (``CPM_DB_PATH=data/mine.db``) meant the
+    cleanup opened an empty database beside the real one, found no profiles in
+    it, and so considered every directory on disk orphaned.
+    """
+    profile = await profile_manager.create_profile(name="live")
+
+    manager = ProfileCleanupManager(str(tmp_path), str(tmp_path / "test.db"))
+    await manager.initialize()
+    try:
+        assert await manager.find_orphaned_profile_directories() == []
+        assert [p.id for p in await manager.get_profiles_in_database()] == [profile.id]
+    finally:
+        await manager.close()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,95 @@
+"""The console script: what the flags do before the server starts.
+
+Nothing here binds a port or opens a window — uvicorn, the browser timer and
+desktop mode are all stood in for. What is checked is the part with its own
+logic: the flags becoming the settings the rest of the app reads, and the URL a
+browser is pointed at.
+"""
+
+import sys
+
+import pytest
+
+from camoufox_pm import cli
+from camoufox_pm.config import get_settings
+
+
+@pytest.fixture
+def run(monkeypatch):
+    """Run ``main()`` with the given arguments, capturing what it would start."""
+    started: dict = {"uvicorn": None, "timers": [], "opened": [], "desktop": None}
+
+    class FakeTimer:
+        def __init__(self, delay, function):
+            started["timers"].append((delay, function))
+
+        def start(self):
+            """Deliberately does nothing: the callback is invoked by the test."""
+
+    monkeypatch.setattr(cli.uvicorn, "run", lambda app, **kw: started.update(uvicorn=kw))
+    monkeypatch.setattr(cli.threading, "Timer", FakeTimer)
+    monkeypatch.setattr(cli.webbrowser, "open", lambda url: started["opened"].append(url))
+
+    # main() writes these itself; setting them through monkeypatch first means
+    # the originals are restored however the run ends.
+    monkeypatch.setenv("CPM_HOST", "127.0.0.1")
+    monkeypatch.setenv("CPM_PORT", "8000")
+
+    def invoke(*args: str):
+        monkeypatch.setattr(sys, "argv", ["camoufox-pm", *args])
+        get_settings.cache_clear()
+        cli.main()
+        return started
+
+    yield invoke
+    get_settings.cache_clear()
+
+
+def test_the_flags_become_the_settings_the_rest_of_the_app_reads(run):
+    """The Settings screen, CORS and the logs all read get_settings(). Leaving it
+    on the defaults would have them report an address nothing is listening on."""
+    started = run("--host", "0.0.0.0", "--port", "9123", "--no-browser")
+
+    assert get_settings().host == "0.0.0.0"
+    assert get_settings().port == 9123
+    assert started["uvicorn"]["host"] == "0.0.0.0"
+    assert started["uvicorn"]["port"] == 9123
+
+
+def test_no_browser_opens_nothing(run):
+    started = run("--no-browser")
+
+    assert started["timers"] == []
+
+
+def test_a_wildcard_bind_is_opened_as_localhost(run):
+    """A browser cannot fetch http://0.0.0.0/ — the tab just fails."""
+    started = run("--host", "0.0.0.0", "--port", "9123")
+
+    assert len(started["timers"]) == 1
+    _delay, open_the_browser = started["timers"][0]
+    open_the_browser()
+
+    assert started["opened"] == ["http://localhost:9123/"]
+
+
+def test_a_real_address_is_opened_as_itself(run):
+    started = run("--host", "192.168.1.5", "--port", "9123")
+
+    started["timers"][0][1]()
+
+    assert started["opened"] == ["http://192.168.1.5:9123/"]
+
+
+def test_desktop_mode_hands_over_instead_of_serving_here(run, monkeypatch):
+    """run_desktop starts its own server; starting a second one would take the port."""
+    from camoufox_pm import desktop
+
+    asked: list[dict] = []
+    monkeypatch.setattr(desktop, "run_desktop", lambda **kw: asked.append(kw))
+
+    started = run("--desktop", "--port", "9123")
+
+    assert asked == [{"host": "127.0.0.1", "port": 9123}]
+    assert started["uvicorn"] is None
+    assert started["timers"] == []

--- a/tests/unit/test_crypto.py
+++ b/tests/unit/test_crypto.py
@@ -28,5 +28,33 @@ def test_decrypt_plaintext_is_tolerated(monkeypatch):
     assert crypto.decrypt("legacy-plaintext") == "legacy-plaintext"
 
 
+def test_an_encrypted_value_with_no_key_configured_is_handed_back_as_it_is(monkeypatch):
+    """Losing CPM_SECRET_KEY must not make every profile unreadable.
+
+    The password is useless in this state, but the profile still opens and the
+    log says what to set to get it back.
+    """
+    monkeypatch.setenv("CPM_SECRET_KEY", Fernet.generate_key().decode())
+    get_settings.cache_clear()
+    token = crypto.encrypt("secret-pass")
+
+    monkeypatch.delenv("CPM_SECRET_KEY")
+    get_settings.cache_clear()
+
+    assert crypto.decrypt(token) == token
+
+
+def test_a_value_encrypted_under_another_key_is_handed_back_as_it_is(monkeypatch):
+    """Same for a rotated key: one unreadable password, not a broken instance."""
+    monkeypatch.setenv("CPM_SECRET_KEY", Fernet.generate_key().decode())
+    get_settings.cache_clear()
+    token = crypto.encrypt("secret-pass")
+
+    monkeypatch.setenv("CPM_SECRET_KEY", Fernet.generate_key().decode())
+    get_settings.cache_clear()
+
+    assert crypto.decrypt(token) == token
+
+
 def teardown_module(_module):
     get_settings.cache_clear()

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -43,6 +43,43 @@ async def test_list_and_filter_profiles(storage):
 
 
 @pytest.mark.asyncio
+async def test_search_by_name_matches_part_of_it(storage):
+    await storage.save_profile(Profile(name="facebook-main"))
+    await storage.save_profile(Profile(name="twitter-alt"))
+
+    found = await storage.list_profiles({"name_like": "book"})
+
+    assert [p.name for p in found] == ["facebook-main"]
+
+
+@pytest.mark.asyncio
+async def test_a_page_can_be_taken_from_anywhere_in_the_list(storage):
+    """Regression: SQLite refuses an OFFSET without a LIMIT, so an offset on its
+    own was dropped from the query and the caller got the first page back."""
+    for i in range(5):
+        await storage.save_profile(Profile(name=f"p{i}"))
+
+    first_two = await storage.list_profiles(limit=2)
+    second_two = await storage.list_profiles(limit=2, offset=2)
+    from_the_third = await storage.list_profiles(offset=2)
+
+    assert len(first_two) == 2
+    assert {p.id for p in first_two}.isdisjoint({p.id for p in second_two})
+    assert len(from_the_third) == 3
+    assert await storage.count_profiles() == 5
+
+
+@pytest.mark.asyncio
+async def test_profiles_are_counted_with_the_same_filters_they_are_listed_with(storage):
+    await storage.save_profile(Profile(name="a", status=ProfileStatus.ACTIVE))
+    await storage.save_profile(Profile(name="b", status=ProfileStatus.INACTIVE))
+    await storage.save_profile(Profile(name="c", group="g1"))
+
+    assert await storage.count_profiles({"status": "active"}) == 2
+    assert await storage.count_profiles({"group": "g1"}) == 1
+
+
+@pytest.mark.asyncio
 async def test_proxy_password_roundtrips_through_storage(storage):
     profile = Profile(
         name="proxied",

--- a/tests/unit/test_excel_manager.py
+++ b/tests/unit/test_excel_manager.py
@@ -1,8 +1,39 @@
-"""Tests for Excel export/import."""
+"""Tests for Excel export/import.
+
+Import creates profiles in a loop, so a mistake here is never one profile: it is
+the whole sheet. These check what a bad row costs the good ones, and what a row
+is allowed to say about a profile that already exists.
+"""
+
+import io
 
 import pytest
+from openpyxl import Workbook, load_workbook
 
 from camoufox_pm.core.excel_manager import ExcelManager
+
+
+def build_sheet(excel_manager: ExcelManager, rows: list[dict], columns=None) -> bytes:
+    """Build a workbook laid out like an export, from field -> value rows.
+
+    ``columns`` overrides the layout, to stand in for a sheet a user has edited.
+    """
+    workbook = Workbook()
+    sheet = workbook.active
+    for column, (field, header, _help) in enumerate(columns or excel_manager.columns, 1):
+        sheet.cell(row=1, column=column, value=header)
+        for offset, row in enumerate(rows, 2):
+            sheet.cell(row=offset, column=column, value=row.get(field))
+    buffer = io.BytesIO()
+    workbook.save(buffer)
+    return buffer.getvalue()
+
+
+def cell(data: bytes, row: int, field: str, excel_manager: ExcelManager):
+    """Read one exported cell by field name."""
+    sheet = load_workbook(io.BytesIO(data)).active
+    column = next(i for i, (name, _, _) in enumerate(excel_manager.columns, 1) if name == field)
+    return sheet.cell(row=row, column=column).value
 
 
 @pytest.mark.asyncio
@@ -18,3 +49,250 @@ async def test_export_then_import_roundtrip(profile_manager):
     # Import always creates fresh profiles, so both rows come back in.
     assert result["created_count"] == 2
     assert result["error_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_a_row_without_a_name_fails_alone(profile_manager):
+    """One bad row in a hundred must not cost the other ninety-nine."""
+    excel_manager = ExcelManager(profile_manager)
+    data = build_sheet(
+        excel_manager, [{"name": "first"}, {"notes": "no name here"}, {"name": "third"}]
+    )
+
+    result = await excel_manager.import_profiles_from_excel(data)
+
+    assert result["created_count"] == 2
+    assert result["error_count"] == 1
+    assert result["success"] is False
+    assert "Row 3" in result["errors"][0]
+    assert {p.name for p in await profile_manager.list_profiles()} == {"first", "third"}
+
+
+@pytest.mark.asyncio
+async def test_a_row_with_an_unreadable_number_fails_alone(profile_manager):
+    excel_manager = ExcelManager(profile_manager)
+    data = build_sheet(
+        excel_manager,
+        [
+            {"name": "good", "hardware_concurrency": "8"},
+            {"name": "bad", "hardware_concurrency": "lots"},
+        ],
+    )
+
+    result = await excel_manager.import_profiles_from_excel(data)
+
+    assert result["created_count"] == 1
+    assert result["error_count"] == 1
+    assert [p.name for p in await profile_manager.list_profiles()] == ["good"]
+
+
+@pytest.mark.asyncio
+async def test_every_imported_row_gets_an_id_of_its_own(profile_manager):
+    """A bulk import is where an ID collision hurts: profiles are stored with
+    INSERT OR REPLACE, so two rows minted the same id silently became one."""
+    excel_manager = ExcelManager(profile_manager)
+    data = build_sheet(excel_manager, [{"name": f"bulk-{i}"} for i in range(50)])
+
+    result = await excel_manager.import_profiles_from_excel(data)
+
+    profiles = await profile_manager.list_profiles()
+    assert result["created_count"] == 50
+    assert len({p.id for p in profiles}) == 50
+
+
+@pytest.mark.asyncio
+async def test_a_row_carrying_an_existing_id_creates_a_profile_instead_of_replacing_it(
+    profile_manager,
+):
+    """Re-importing an exported sheet is how people bulk-edit. The ID column is
+    deliberately ignored, so the profiles it came from must survive untouched."""
+    original = await profile_manager.create_profile(name="original")
+    excel_manager = ExcelManager(profile_manager)
+    data = build_sheet(excel_manager, [{"id": original.id, "name": "edited"}])
+
+    await excel_manager.import_profiles_from_excel(data)
+
+    profiles = await profile_manager.list_profiles()
+    assert len(profiles) == 2
+    survivor = await profile_manager.get_profile(original.id)
+    assert survivor is not None and survivor.name == "original"
+
+
+@pytest.mark.asyncio
+async def test_a_profile_keeps_its_settings_through_an_export_and_import(profile_manager):
+    """What the sheet is for: edit a fleet in Excel and get the fleet back."""
+    original = await profile_manager.create_profile(
+        name="detailed",
+        status="inactive",
+        browser_settings={
+            "os": "macos",
+            "screen": "2560x1440",
+            "languages": ["de-DE", "de"],
+            "timezone": "Europe/Berlin",
+            "locale": "de_DE",
+            "hardware_concurrency": 12,
+            "device_memory": 16,
+            "stable_canvas": True,
+            "geolocation": {"lat": 52.52, "lon": 13.405, "accuracy": 25},
+        },
+        proxy_config={
+            "type": "http",
+            "server": "proxy.example:8080",
+            "username": "user",
+            "password": "secret",
+        },
+        notes="do not lose me",
+    )
+    excel_manager = ExcelManager(profile_manager)
+
+    data = await excel_manager.export_profiles_to_excel()
+    await excel_manager.import_profiles_from_excel(data)
+
+    # The source profile is still there, so the import is the other one.
+    imported = next(p for p in await profile_manager.list_profiles() if p.id != original.id)
+    settings = imported.browser_settings
+    assert imported.name == "detailed"
+    assert imported.notes == "do not lose me"
+    assert imported.status == "inactive"
+    assert settings.os == "macos"
+    assert settings.screen == "2560x1440"
+    assert settings.languages == ["de-DE", "de"]
+    assert settings.timezone == "Europe/Berlin"
+    assert settings.locale == "de_DE"
+    assert settings.hardware_concurrency == 12
+    assert settings.device_memory == 16
+    assert settings.stable_canvas is True
+    assert settings.geolocation == {"lat": 52.52, "lon": 13.405, "accuracy": 25}
+    assert imported.proxy is not None
+    assert imported.proxy.server == "proxy.example:8080"
+    assert imported.proxy.password == "secret"
+
+
+@pytest.mark.asyncio
+async def test_the_export_carries_the_proxy_password_in_clear(profile_manager):
+    """It is stored encrypted, and the sheet is what makes a bulk edit possible,
+    so it has to leave in clear. Anyone handing this file on should know."""
+    await profile_manager.create_profile(
+        name="p",
+        proxy_config={"type": "http", "server": "h:8080", "username": "u", "password": "secret"},
+    )
+    excel_manager = ExcelManager(profile_manager)
+
+    data = await excel_manager.export_profiles_to_excel()
+
+    assert cell(data, 2, "proxy_password", excel_manager) == "secret"
+
+
+@pytest.mark.asyncio
+async def test_blank_rows_are_skipped_rather_than_counted(profile_manager):
+    """Spreadsheets carry trailing blank rows; each one used to be an error."""
+    excel_manager = ExcelManager(profile_manager)
+    data = build_sheet(excel_manager, [{"name": "only"}, {}, {}, {}])
+
+    result = await excel_manager.import_profiles_from_excel(data)
+
+    assert result["created_count"] == 1
+    assert result["error_count"] == 0
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_manual_geolocation_without_coordinates_falls_back_to_the_proxy(profile_manager):
+    """Half-filled coordinates would place the profile at (0, 0), off West Africa."""
+    excel_manager = ExcelManager(profile_manager)
+    data = build_sheet(excel_manager, [{"name": "p", "geo_mode": "manual"}])
+
+    await excel_manager.import_profiles_from_excel(data)
+
+    imported = (await profile_manager.list_profiles())[0]
+    assert imported.browser_settings.geolocation is None
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_status_fails_the_row_instead_of_being_ignored(profile_manager):
+    """Silently importing it as active would put a parked profile back to work."""
+    excel_manager = ExcelManager(profile_manager)
+    data = build_sheet(excel_manager, [{"name": "p", "status": "paused"}])
+
+    result = await excel_manager.import_profiles_from_excel(data)
+
+    assert result["created_count"] == 0
+    assert result["error_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_a_moved_column_is_read_from_where_it_now_is(profile_manager):
+    """Regression: columns were read by position, so a sheet the user rearranged
+    imported cleanly with the values in the wrong fields. Moving Locale ahead of
+    Timezone gave every profile a timezone of "de_DE" and a locale of
+    "Europe/Berlin", and nothing objected — most of these fields are free text.
+    """
+    excel_manager = ExcelManager(profile_manager)
+    rearranged = list(excel_manager.columns)
+    timezone_at = next(i for i, c in enumerate(rearranged) if c[0] == "timezone")
+    locale_at = next(i for i, c in enumerate(rearranged) if c[0] == "locale")
+    rearranged[timezone_at], rearranged[locale_at] = (
+        rearranged[locale_at],
+        rearranged[timezone_at],
+    )
+    data = build_sheet(
+        excel_manager,
+        [{"name": "p", "timezone": "Europe/Berlin", "locale": "de_DE"}],
+        columns=rearranged,
+    )
+
+    await excel_manager.import_profiles_from_excel(data)
+
+    imported = (await profile_manager.list_profiles())[0]
+    assert imported.browser_settings.timezone == "Europe/Berlin"
+    assert imported.browser_settings.locale == "de_DE"
+
+
+@pytest.mark.asyncio
+async def test_a_deleted_column_leaves_its_field_at_the_default(profile_manager):
+    """The ID column is marked read-only, so deleting it before editing is the
+    obvious thing to do. It must not shift every column after it."""
+    excel_manager = ExcelManager(profile_manager)
+    without_id = [c for c in excel_manager.columns if c[0] != "id"]
+    data = build_sheet(
+        excel_manager,
+        [{"name": "p", "os": "macos", "notes": "kept"}],
+        columns=without_id,
+    )
+
+    result = await excel_manager.import_profiles_from_excel(data)
+
+    assert result["error_count"] == 0
+    imported = (await profile_manager.list_profiles())[0]
+    assert imported.name == "p"
+    assert imported.browser_settings.os == "macos"
+    assert imported.notes == "kept"
+
+
+@pytest.mark.asyncio
+async def test_a_sheet_with_no_recognisable_header_row_is_refused(profile_manager):
+    """Importing it row by row would create a fleet of mangled profiles."""
+    excel_manager = ExcelManager(profile_manager)
+    workbook = Workbook()
+    sheet = workbook.active
+    for column, value in enumerate(["Column A", "Column B"], 1):
+        sheet.cell(row=1, column=column, value=value)
+        sheet.cell(row=2, column=column, value="something")
+    buffer = io.BytesIO()
+    workbook.save(buffer)
+
+    result = await excel_manager.import_profiles_from_excel(buffer.getvalue())
+
+    assert result["success"] is False
+    assert result["created_count"] == 0
+    assert await profile_manager.list_profiles() == []
+    assert "Profile name" in result["errors"][0]
+
+
+@pytest.mark.asyncio
+async def test_a_file_that_is_not_a_workbook_is_reported_not_raised(profile_manager):
+    result = await ExcelManager(profile_manager).import_profiles_from_excel(b"not a workbook")
+
+    assert result["success"] is False
+    assert result["created_count"] == 0
+    assert result["errors"]

--- a/tests/unit/test_profile_manager.py
+++ b/tests/unit/test_profile_manager.py
@@ -1,0 +1,332 @@
+"""Cloning, deleting and launching: the operations that move data around.
+
+CRUD over the API is covered in tests/integration; these are the parts of the
+manager that touch the filesystem or a profile's identity.
+"""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from camoufox_pm.core import fingerprint_store
+from camoufox_pm.core import profile_manager as pm_module
+
+PINNED = {
+    "navigator.userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0",
+    "navigator.platform": "Win32",
+    "navigator.hardwareConcurrency": 12,
+    "screen.width": 2560,
+    "screen.height": 1440,
+    "webGl:renderer": "NVIDIA GeForce RTX 3070",
+}
+
+
+async def pin(profile_manager, profile):
+    """Give a profile a pinned machine, as its first launch would."""
+    profile.fingerprint = dict(PINNED)
+    await profile_manager.storage.update_profile(profile)
+    return profile
+
+
+# -- Cloning --------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_clone_carries_the_browser_data_into_a_directory_of_its_own(
+    profile_manager, tmp_path
+):
+    """Cloning exists to reuse a warmed-up profile, which is that directory."""
+    source = await profile_manager.create_profile(name="warm")
+    source_dir = Path(source.get_storage_path(str(profile_manager.profiles_dir)))
+    (source_dir / "cookies.sqlite").write_bytes(b"logged in")
+
+    clone = await profile_manager.clone_profile(source.id, "warm copy")
+
+    assert clone is not None and clone.id != source.id
+    clone_dir = Path(clone.get_storage_path(str(profile_manager.profiles_dir)))
+    assert clone_dir != source_dir
+    assert (clone_dir / "cookies.sqlite").read_bytes() == b"logged in"
+    assert (source_dir / "cookies.sqlite").exists()
+
+
+@pytest.mark.asyncio
+async def test_a_clone_is_a_different_machine(profile_manager):
+    """Regression: the pinned fingerprint was copied along with everything else.
+
+    The clone then reported the same GPU, screen, core count and noise seeds as
+    its source — two profiles that are provably one machine, which is the single
+    thing this product exists to prevent.
+    """
+    source = await pin(profile_manager, await profile_manager.create_profile(name="source"))
+
+    clone = await profile_manager.clone_profile(source.id, "copy")
+
+    assert clone is not None
+    assert clone.fingerprint is None
+    assert (await profile_manager.get_profile(source.id)).fingerprint == PINNED
+
+
+@pytest.mark.asyncio
+async def test_a_clone_can_be_asked_to_keep_the_machine(profile_manager):
+    """Deliberately the same computer — moving a profile between installs, say."""
+    source = await pin(profile_manager, await profile_manager.create_profile(name="source"))
+
+    clone = await profile_manager.clone_profile(source.id, "copy", regenerate_fingerprint=False)
+
+    assert clone is not None
+    assert clone.fingerprint == PINNED
+    assert clone.browser_settings == source.browser_settings
+
+
+@pytest.mark.asyncio
+async def test_cloning_an_unknown_profile_returns_nothing(profile_manager):
+    assert await profile_manager.clone_profile("nope", "copy") is None
+
+
+# -- Deleting -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_profile_removes_its_directory(profile_manager):
+    profile = await profile_manager.create_profile(name="gone")
+    directory = Path(profile.get_storage_path(str(profile_manager.profiles_dir)))
+    (directory / "cookies.sqlite").write_bytes(b"session")
+
+    assert await profile_manager.delete_profile(profile.id) is True
+    assert not directory.exists()
+    assert await profile_manager.get_profile(profile.id) is None
+
+
+@pytest.mark.asyncio
+async def test_the_data_can_be_kept_when_the_profile_is_deleted(profile_manager):
+    """The record goes, the directory stays — for a manual backup before a purge."""
+    profile = await profile_manager.create_profile(name="gone")
+    directory = Path(profile.get_storage_path(str(profile_manager.profiles_dir)))
+    (directory / "cookies.sqlite").write_bytes(b"session")
+
+    await profile_manager.delete_profile(profile.id, remove_data=False)
+
+    assert (directory / "cookies.sqlite").read_bytes() == b"session"
+
+
+@pytest.mark.asyncio
+async def test_a_profile_whose_directory_is_already_gone_still_deletes(profile_manager):
+    """Otherwise a half-removed profile could never be cleared from the list."""
+    profile = await profile_manager.create_profile(name="gone")
+    shutil.rmtree(profile.get_storage_path(str(profile_manager.profiles_dir)))
+
+    assert await profile_manager.delete_profile(profile.id) is True
+
+
+@pytest.mark.asyncio
+async def test_deleting_an_unknown_profile_reports_it_rather_than_raising(profile_manager):
+    assert await profile_manager.delete_profile("nope") is False
+
+
+# -- Groups ---------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_group_ungroups_its_profiles_and_keeps_them(profile_manager):
+    """A group is a label. Deleting one must never take the profiles with it."""
+    group = await profile_manager.create_group("Social")
+    first = await profile_manager.create_profile(name="a", group=group["id"])
+    second = await profile_manager.create_profile(name="b", group=group["id"])
+
+    assert await profile_manager.delete_group(group["id"]) is True
+
+    remaining = await profile_manager.list_profiles()
+    assert {p.id for p in remaining} == {first.id, second.id}
+    assert [p.group for p in remaining] == [None, None]
+
+
+@pytest.mark.asyncio
+async def test_deleting_an_unknown_group_reports_it(profile_manager):
+    assert await profile_manager.delete_group("nope") is False
+
+
+@pytest.mark.asyncio
+async def test_a_group_reports_how_many_profiles_it_holds(profile_manager):
+    group = await profile_manager.create_group("Social", description="socials")
+    await profile_manager.create_profile(name="a", group=group["id"])
+    await profile_manager.create_profile(name="b")
+
+    assert (await profile_manager.get_group(group["id"]))["profile_count"] == 1
+    assert [g["profile_count"] for g in await profile_manager.list_groups()] == [1]
+
+
+@pytest.mark.asyncio
+async def test_bulk_update_counts_only_the_profiles_that_exist(profile_manager):
+    first = await profile_manager.create_profile(name="a")
+    second = await profile_manager.create_profile(name="b")
+
+    updated = await profile_manager.bulk_update_profiles(
+        [first.id, "missing", second.id], {"status": "inactive"}
+    )
+
+    assert updated == 2
+    assert [p.status for p in await profile_manager.list_profiles()] == ["inactive", "inactive"]
+
+
+# -- Launching ------------------------------------------------------------------
+
+
+@pytest.fixture
+def launches(profile_manager, monkeypatch):
+    """Capture the launch options without starting a browser.
+
+    Fingerprint resolution is stubbed out too: it reads the installed browser,
+    which CI does not have and which would make these depend on the machine.
+    """
+    recorded: list[dict] = []
+
+    class FakeSession:
+        process_id = 4242
+
+    async def fake_launch(profile_id, options, on_exit=None):
+        recorded.append(options)
+        profile_manager.browser_sessions.active_sessions[profile_id] = FakeSession()
+        return FakeSession()
+
+    monkeypatch.setattr(profile_manager.browser_sessions, "launch", fake_launch)
+    monkeypatch.setattr(pm_module.fingerprint_store, "resolve", lambda *_args, **_kw: {})
+    return recorded
+
+
+@pytest.mark.asyncio
+async def test_launching_an_unknown_profile_says_so(profile_manager, launches):
+    with pytest.raises(ValueError, match="not found"):
+        await profile_manager.launch_browser("nope")
+
+
+@pytest.mark.asyncio
+async def test_a_window_size_is_passed_as_the_pair_camoufox_expects(profile_manager, launches):
+    profile = await profile_manager.create_profile(name="p")
+
+    await profile_manager.launch_browser(profile.id, window_size="1600x900")
+
+    assert launches[0]["window"] == (1600, 900)
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_window_size_is_ignored_rather_than_failing_the_launch(
+    profile_manager, launches
+):
+    """Losing the requested size is a nuisance; refusing to open the browser is not."""
+    profile = await profile_manager.create_profile(name="p", browser_settings={"os": "windows"})
+
+    result = await profile_manager.launch_browser(profile.id, window_size="huge")
+
+    assert result["status"] == "launched"
+    assert launches[0]["window"] == (
+        profile.browser_settings.window_width,
+        profile.browser_settings.window_height,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_second_launch_does_not_open_a_second_browser(profile_manager, launches):
+    profile = await profile_manager.create_profile(name="p")
+
+    await profile_manager.launch_browser(profile.id)
+    again = await profile_manager.launch_browser(profile.id)
+
+    assert again["status"] == "already_running"
+    assert len(launches) == 1
+
+
+@pytest.mark.asyncio
+async def test_a_pinned_machine_is_replayed_on_every_launch(profile_manager, launches):
+    profile = await pin(profile_manager, await profile_manager.create_profile(name="p"))
+
+    await profile_manager.launch_browser(profile.id)
+
+    assert launches[0]["config"]["webGl:renderer"] == PINNED["webGl:renderer"]
+    assert launches[0]["config"]["screen.width"] == 2560
+
+
+@pytest.mark.asyncio
+async def test_the_profiles_own_settings_still_beat_the_pin(profile_manager, launches, monkeypatch):
+    """A pin is the hardware; timezone and geolocation follow the proxy, and the
+    profile's explicit values have to survive the merge."""
+    profile = await profile_manager.create_profile(
+        name="p", browser_settings={"timezone": "Asia/Tokyo", "hardware_concurrency": 4}
+    )
+    await pin(profile_manager, profile)
+    monkeypatch.setattr(
+        pm_module.fingerprint_store,
+        "resolve",
+        lambda *_a, **_k: {"navigator.hardwareConcurrency": 12},
+    )
+
+    await profile_manager.launch_browser(profile.id)
+
+    assert launches[0]["config"]["timezone"] == "Asia/Tokyo"
+    assert launches[0]["config"]["navigator.hardwareConcurrency"] == 4
+
+
+@pytest.mark.asyncio
+async def test_the_first_launch_pins_the_machine_it_resolved(profile_manager, monkeypatch):
+    resolved = {"navigator.platform": "Win32", "screen.width": 1920}
+
+    async def fake_launch(profile_id, options, on_exit=None):
+        profile_manager.browser_sessions.active_sessions[profile_id] = object()
+        return type("S", (), {"process_id": None})()
+
+    monkeypatch.setattr(profile_manager.browser_sessions, "launch", fake_launch)
+    monkeypatch.setattr(pm_module.fingerprint_store, "resolve", lambda *_a, **_k: resolved)
+    profile = await profile_manager.create_profile(name="p")
+
+    await profile_manager.launch_browser(profile.id)
+
+    stored = await profile_manager.get_profile(profile.id)
+    assert stored.fingerprint == resolved
+    assert stored.last_used is not None
+
+
+@pytest.mark.asyncio
+async def test_closing_a_browser_that_is_not_running_says_so(profile_manager):
+    result = await profile_manager.close_browser("nope")
+
+    assert result["status"] == "not_running"
+
+
+@pytest.mark.asyncio
+async def test_rotating_the_fingerprint_drops_the_pinned_machine(profile_manager):
+    profile = await pin(profile_manager, await profile_manager.create_profile(name="p"))
+
+    rotated = await profile_manager.rotate_profile_fingerprint(profile.id)
+
+    assert rotated is not None and rotated.fingerprint is None
+
+
+@pytest.mark.asyncio
+async def test_refreshing_a_browser_version_without_a_pin_says_to_launch_first(profile_manager):
+    profile = await profile_manager.create_profile(name="p")
+
+    with pytest.raises(ValueError, match="no pinned machine"):
+        await profile_manager.refresh_browser_version(profile.id)
+
+
+@pytest.mark.asyncio
+async def test_refreshing_reads_the_operating_system_from_the_pin(profile_manager, monkeypatch):
+    """The OS dropdown can be changed after the machine was pinned; following it
+    would put a macOS user agent onto Windows hardware."""
+    profile = await profile_manager.create_profile(name="p", browser_settings={"os": "macos"})
+    await pin(profile_manager, profile)
+    asked: list[str] = []
+
+    def record(options, preset=None):
+        asked.append(options["os"])
+        return {"navigator.userAgent": "rv:141.0"}
+
+    monkeypatch.setattr(pm_module.fingerprint_store, "resolve", record)
+
+    await profile_manager.refresh_browser_version(profile.id)
+
+    assert asked == ["windows"]
+    assert (
+        fingerprint_store.browser_major((await profile_manager.get_profile(profile.id)).fingerprint)
+        == 141
+    )

--- a/tests/unit/test_proxy_check.py
+++ b/tests/unit/test_proxy_check.py
@@ -223,6 +223,30 @@ async def test_no_endpoint_gives_an_address(answers):
         await proxy_check.resolve_exit_ip(None)
 
 
+@pytest.mark.parametrize(
+    ("failure", "expected"),
+    [
+        (
+            httpx.HTTPStatusError("boom", request=None, response=httpx.Response(407)),  # type: ignore[arg-type]
+            "rejected the credentials",
+        ),
+        # httpx reports a failed CONNECT as a ProxyError rather than a status, so
+        # the commonest failure of all arrives without a status code on it.
+        (httpx.ProxyError("407 Proxy Authentication Required"), "rejected the credentials"),
+        (httpx.HTTPStatusError("boom", request=None, response=httpx.Response(502)), "answered 502"),
+        (httpx.TimeoutException("slow"), "did not answer in time"),
+        (httpx.UnsupportedProtocol("socks4h"), "SOCKS4 is not supported"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_a_failure_is_reported_in_words_the_user_can_act_on(answers, failure, expected):
+    """This string is the whole result of the check: it has to say what to fix."""
+    answers(failure, failure, failure)
+
+    with pytest.raises(ConnectionError, match=expected):
+        await proxy_check.resolve_exit_ip(None)
+
+
 @pytest.mark.asyncio
 async def test_the_ipv6_answer_goes_into_the_ipv6_key(answers):
     """Camoufox routes a v6 exit address to webrtc:ipv6, and so must this."""


### PR DESCRIPTION
Closes the roadmap item "Fill remaining gaps in test coverage." Coverage went **68% → 88%** (133 → 245 tests), but the point was never the number — the point was the six bugs that writing real tests uncovered. Each is fixed in its own commit with a test that fails without it.

## Bugs found

1. **`POST /api/system/profiles/cleanup` could delete every profile directory on the machine.** Both cleanup routes built `ProfileCleanupManager()` with its defaults — `./data`, `./data/profiles.db` — ignoring `CPM_DB_PATH`. Point the database anywhere else (a Docker volume, `data/mine.db`) and cleanup opened an *empty* database beside the real one, matched no directory to any profile, and removed all of them. A profile directory **is** the account. `9628ed1`
2. **A clone was the same machine as its source.** `clone_profile` copies the record via `model_dump()`, pinned fingerprint included, so the copy reported an identical GPU, screen, core count, fonts and noise seeds — forever, since a pin never ages. Two accounts that are provably one computer is the single thing this product exists to prevent. `48950a6`
3. **A rearranged spreadsheet imported into the wrong fields, silently.** Import located columns by position. Drag *Locale* ahead of *Timezone* (or delete the read-only ID column) and every row imports with `timezone='de_DE'`, `locale='Europe/Berlin'` — `created_count: 1`, zero errors. Now mapped by header text; a sheet with no recognisable header is refused. `7ddcc1d`
4. **Excel import dropped the Notes and Status columns** — both exported, both read out of the row, neither passed to `create_profile`, so every import came back active and note-less. An unknown status now fails that row instead of quietly reactivating a parked profile. `7ddcc1d`
5. **`GET /api/profiles/{id}/stats` was always empty** — the route read keys (`total_duration_minutes`, `last_session`, `actions`) the manager never returned, so every response was defaults regardless of history. `cf96031`
6. **Cloning an unknown profile answered 500, not 404** (the route's own `HTTPException` was swallowed by its `except Exception`), and **`list_profiles(offset=...)` silently ignored the offset** (SQLite drops `OFFSET` without `LIMIT`). `1dfcc9b`, `13f3698`

## Coverage by module

| Module | Before | After |
|---|---|---|
| `core/cleanup.py` | 20% | 81% |
| `core/browser_session.py` | 46% | 95% |
| `core/excel_manager.py` | 61% | 98% |
| `core/profile_manager.py` | 65% | 93% |
| `core/database.py` | 85% | 99% |
| `api/routes/system.py` | 39% | 84% |
| `cli.py` | 0% | 96% |

## What was deliberately left uncovered — now written into CONTRIBUTING

`desktop.py` (uvicorn + pywebview, no logic of its own, needs a display), the FastAPI lifespan (integration tests inject their own managers), the `except Exception → 500` handlers (not provokable without breaking SQLite under the process), and `resolve()` / `locate()` (need the browser, covered by `browser`-marked tests). The total was not chased. Also removed `ExcelManager._prepare_profile_updates` — 79 lines, never called — rather than test dead code.

## Gates — verified independently in a fresh worktree

I re-ran the `HOME=$(mktemp -d)` form the agent's sandbox had refused (it simulates a machine that never ran `camoufox fetch`):

```
ruff / format / mypy   clean
HOME=$(mktemp -d) pytest -m "not browser"   245 passed, 20 deselected
pytest -m browser                           20 passed
```

## Merge order

Heaviest overlap of the four wave-1 branches: touches `profile_manager.py` (with profile-coherence), `routes/system.py` and `routes/profiles.py` (with api-1.0), plus `cleanup.py`, `excel_manager.py`, `database.py`, `cli.py`. Best merged **last**, rebased onto the others, so its tests run against the final route/model shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)