### PR TITLE
User accounts and login sessions, beyond the API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,16 @@ CPM_PORT=8000
 # Comma-separated allowed CORS origins (the frontend dev server)
 CPM_CORS_ORIGINS=http://localhost:3000
 
-# Optional API key. Leave empty to disable auth (local-only use).
+# Optional API key for machine clients. Leave empty to disable (local-only use).
+# Human login is separate: create an account with `camoufox-pm user add <name>`.
 CPM_API_KEY=
+
+# Login session lifetime in hours (default 168 = one week).
+CPM_SESSION_TTL_HOURS=168
+
+# Force the Secure flag on the session cookie. Set to 1 behind a
+# TLS-terminating reverse proxy, where the app itself sees plain HTTP.
+CPM_SECURE_COOKIES=0
 
 # SQLite database path
 CPM_DB_PATH=data/profiles.db

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Added
+- **User accounts and login, for deployments more than one person can reach.**
+  The API key stays what it was — one shared machine secret — and humans now
+  get their own path: `camoufox-pm user add <name>` creates an account
+  (password prompted, argon2id-hashed, never in argv or logs), and from the
+  moment any account exists the API requires a login session or the API key.
+  The web UI grows a login screen and a logout control. Sessions are opaque
+  random tokens stored server-side as SHA-256 — the cookie is HttpOnly,
+  SameSite=Lax, Secure over TLS (`CPM_SECURE_COOKIES` forces it behind a
+  proxy), expires after `CPM_SESSION_TTL_HOURS` (default a week), and logout
+  deletes the server-side row, so a logged-out token is dead even if replayed.
+  A failed login does not reveal whether the username exists, and costs the
+  same argon2 work either way plus a half-second delay. There is deliberately
+  no self-registration and no role system: accounts are managed from the CLI
+  (`user add|passwd|remove|list`), and every authenticated user is equivalent —
+  profiles are shared, so there is nothing for roles to protect yet. With no
+  accounts and no `CPM_API_KEY`, the loopback default stays exactly as open as
+  before. `POST /api/v1/auth/login`, `POST /api/v1/auth/logout`,
+  `GET /api/v1/auth/session`; existing databases gain the `users` and
+  `sessions` tables on first start without touching existing rows.
 - **A stability contract for the REST API**, written down in `docs/api.md`:
   what 1.0 freezes (paths, field names, status codes, the error shape), what
   stays deliberately unstable (the `fingerprint` summary, launch internals),

--- a/README.md
+++ b/README.md
@@ -116,7 +116,9 @@ Settings come from environment variables (prefix `CPM_`). Copy `.env.example` to
 | `CPM_PORT`         | `8000`                  | Port                                            |
 | `CPM_DB_PATH`      | `data/profiles.db`      | SQLite database path                            |
 | `CPM_SECRET_KEY`   | *(empty)*               | Fernet key; encrypts proxy passwords at rest    |
-| `CPM_API_KEY`      | *(empty)*               | If set, required as the `X-API-Key` header      |
+| `CPM_API_KEY`      | *(empty)*               | If set, required as the `X-API-Key` header (machine clients) |
+| `CPM_SESSION_TTL_HOURS` | `168`              | Login session lifetime, in hours                |
+| `CPM_SECURE_COOKIES` | `0`                   | Force the session cookie's `Secure` flag (set behind a TLS proxy) |
 | `CPM_CORS_ORIGINS` | `http://localhost:3000` | Comma-separated allowed origins                 |
 | `CPM_WEBUI_DIR`    | *(auto)*                | Override where the bundled web UI is served from |
 
@@ -125,6 +127,10 @@ Generate an encryption key with:
 ```bash
 uv run python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
 ```
+
+User accounts for the web UI are managed from the CLI: `camoufox-pm user add
+<name>` creates one, and from then on the API and UI require a login (see
+[SECURITY.md](SECURITY.md#authentication)).
 
 ## Documentation
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,13 +33,51 @@ reproduce. We aim to acknowledge reports within a few days.
 - If a credential is ever committed by mistake, **rotate it immediately** — removing
   it from the latest commit does not remove it from git history.
 
+## Authentication
+
+The API has three configuration states, decided by what exists rather than by a
+switch, so the configuration cannot contradict the database:
+
+1. **Nothing configured** — no user accounts, no `CPM_API_KEY`. The API is
+   open. This is the default and is acceptable only because the app binds to
+   `127.0.0.1`; it is how most single-person installs run.
+2. **`CPM_API_KEY` set** — every request must carry the key in `X-API-Key`,
+   compared in constant time. This is the machine-to-machine path: one shared
+   secret, no identity.
+3. **User accounts exist** (`camoufox-pm user add <name>`) — humans log in with
+   a username and password; a valid session **or** the API key passes. Accounts
+   are created, changed and removed only from the CLI — there is no
+   self-registration, so creating an account requires shell access to the host.
+   Removing the last account turns login back off.
+
+What protects a session:
+
+- Passwords are hashed with **argon2id** (`argon2-cffi` defaults); plaintext
+  passwords are never stored or logged, and hashes never leave the database.
+- The session token is random (256 bits) and stored **only as its SHA-256**, so
+  a copy of the database contains nothing replayable.
+- The cookie is **HttpOnly** (page scripts cannot read it), **SameSite=Lax**
+  (cross-site POSTs do not carry it), and **Secure** when served over HTTPS or
+  when `CPM_SECURE_COOKIES=1`.
+- Logout deletes the server-side row: a logged-out token is invalid even if an
+  attacker kept a copy. Sessions expire after `CPM_SESSION_TTL_HOURS`
+  (default 168).
+- A failed login does not reveal whether the username exists — same status,
+  same body, the same argon2 work either way — and is delayed half a second as
+  brute-force friction. There is **no lockout or rate limit** beyond that; if
+  the login page is reachable from the internet, put fail2ban or your reverse
+  proxy's rate limiting in front of it.
+
 ## Deployment notes
 
-- The API binds to `127.0.0.1` by default. Only expose it beyond localhost behind
-  authentication (set `CPM_API_KEY`) and a TLS-terminating reverse proxy.
+- The API binds to `127.0.0.1` by default. To expose it beyond localhost:
+  create a user account (`camoufox-pm user add <name>`) for humans and/or set
+  `CPM_API_KEY` for machine clients, terminate TLS in a reverse proxy, and set
+  `CPM_SECURE_COOKIES=1` so the session cookie is never sent over plain HTTP
+  (the app itself does not serve TLS, so it cannot infer this behind a proxy).
 - Set `CPM_CORS_ORIGINS` to the specific origins you trust; do not use a wildcard
   together with credentials.
 - The proxy check connects to whatever host a request names and reports whether it
-  answered and how fast. On an instance reachable beyond localhost without
-  `CPM_API_KEY`, that is an unauthenticated way to probe hosts and ports the
-  server can reach but the caller cannot.
+  answered and how fast. On an instance reachable beyond localhost without any
+  authentication configured, that is an unauthenticated way to probe hosts and
+  ports the server can reach but the caller cannot.

--- a/docs/api.md
+++ b/docs/api.md
@@ -13,18 +13,56 @@ client sees each operation once. New code should use `/api/v1`.
 
 ## Authentication
 
-None by default, because the app binds to loopback. Set `CPM_API_KEY` and every
-request must carry it:
+Two independent mechanisms, either of which satisfies the guard on every
+`/api/...` route. Which ones are active follows from what is configured — there
+is no separate auth switch:
 
-```bash
-curl -H "X-API-Key: $CPM_API_KEY" http://localhost:8000/api/v1/profiles
+1. **Nothing configured** (no users, no `CPM_API_KEY`): the API is open. This is
+   the default, and it is fine because the app binds to loopback.
+2. **`CPM_API_KEY` set**: every request must carry the key — the
+   machine-to-machine path, unchanged from before user accounts existed:
+
+   ```bash
+   curl -H "X-API-Key: $CPM_API_KEY" http://localhost:8000/api/v1/profiles
+   ```
+
+   The key is compared in constant time. The web UI can send it too — paste it
+   into the Settings screen, which stores it in that browser only.
+3. **Any user account exists** (`camoufox-pm user add <name>`): the API requires
+   a login session — or the API key, so machine clients keep working the day a
+   human account is created. The web UI shows a login screen; other clients call
+   `POST /api/v1/auth/login` and carry the `cpm_session` cookie it sets. There
+   is no registration endpoint: accounts are created from the CLI, which
+   requires shell access to the host.
+
+**Configure at least one of them before binding to anything other than
+`127.0.0.1`.** Without either, anybody who can reach the port can read your
+profiles, including proxy passwords.
+
+### Login sessions
+
+```http
+POST /api/v1/auth/login       {"username": "...", "password": "..."}
+POST /api/v1/auth/logout
+GET  /api/v1/auth/session
 ```
 
-The key is compared in constant time. The web UI sends it too — paste it into the
-Settings screen, which stores it in that browser only.
+These three are the only unauthenticated API routes — login has to work logged
+out, and `GET /auth/session` is how the UI decides whether to show the login
+screen. All three answer `{user_auth_enabled, authenticated, username}`; login
+additionally sets the session cookie, and logout returns the action envelope.
 
-**Set a key before binding to anything other than `127.0.0.1`.** Without one,
-anybody who can reach the port can read your profiles, including proxy passwords.
+- A successful login sets `cpm_session`: **HttpOnly** (invisible to page
+  scripts), **SameSite=Lax**, `Path=/`, and **Secure** when the request came
+  over HTTPS or `CPM_SECURE_COOKIES=1`. It expires after `CPM_SESSION_TTL_HOURS`
+  (default 168, one week).
+- The session is server-side: the database stores only a SHA-256 of the token,
+  and logout deletes the row, so a logged-out token is dead even if replayed.
+- A failed login is a `401` with the same body whether the username exists or
+  the password is wrong, costs an argon2 verification either way, and is
+  delayed half a second.
+- Passwords are hashed with argon2id; no response or log ever carries a
+  password or a hash.
 
 ## Conventions
 
@@ -35,9 +73,10 @@ anybody who can reach the port can read your profiles, including proxy passwords
 - **A field you send is authoritative, including `null`, which clears it. A field
   you omit is left alone.** This matters most on `PUT /api/v1/profiles/{id}`:
   send `{"proxy_config": null}` to detach a proxy; omit the key to leave it.
-- Statuses: `400` for a bad request, `401` for a missing or wrong API key,
-  `404` for a missing resource, `409` for a state conflict (exporting a running
-  profile), `422` for values that fail validation, `500` otherwise.
+- Statuses: `400` for a bad request, `401` for missing or wrong credentials
+  (API key or login session), `404` for a missing resource, `409` for a state
+  conflict (exporting a running profile), `422` for values that fail
+  validation, `500` otherwise.
 
 ### Errors
 
@@ -320,9 +359,10 @@ POST /api/v1/system/restart                 close all browsers, ready for a rest
 unhealthy instance answers with the same body under a `503`, so a load balancer
 or container healthcheck sees the failure without parsing anything.
 
-`/api/v1/system/config` reports whether encryption and the API key are on, the
-bind address, the database path and whether the browser is installed — it never
-returns the values of secrets. It backs the Settings screen.
+`/api/v1/system/config` reports whether encryption, the API key and user login
+are on, the bind address, the database path and whether the browser is
+installed — it never returns the values of secrets. It backs the Settings
+screen.
 
 `/api/v1/system/restart` does **not** restart the process; it closes every
 browser so you can restart it cleanly yourself.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,6 +27,37 @@ camoufox-pm --desktop                # native window
 
 To stop it, press `Ctrl+C`. Any browsers it launched are closed with it.
 
+## `camoufox-pm user`
+
+Manages web UI login accounts. **Creating the first account turns login on**:
+from then on the API requires a session (or the API key), and the web UI shows
+a login screen. Removing the last account turns login back off. Accounts live
+in the CLI on purpose — there is no registration endpoint, so creating one
+requires shell access to the host, and the first user can be created without a
+chicken-and-egg lockout.
+
+```
+usage: camoufox-pm user {add,passwd,remove,list} ...
+```
+
+| Command | What it does |
+| ------- | ------------ |
+| `user add <name>` | Create an account. Prompts twice for the password (min 8 characters); it is argon2id-hashed before it touches the database and never appears in argv, the environment, or logs. |
+| `user passwd <name>` | Change an account's password. Existing sessions stay valid. |
+| `user remove <name>` | Delete an account and its open sessions. Warns when it was the last one. |
+| `user list` | List account names and creation times. Never shows hashes. |
+
+`add` and `passwd` take `--password-stdin` to read the password from the first
+line of stdin instead of prompting — for provisioning scripts and containers:
+
+```bash
+camoufox-pm user add alice                            # interactive
+openssl rand -base64 18 | camoufox-pm user add ci-bot --password-stdin
+```
+
+The commands work against `CPM_DB_PATH` and take effect immediately, even while
+the server is running — the guard checks the database per request.
+
 ## `camoufox fetch`
 
 Downloads the Camoufox browser (~300 MB). This comes from Camoufox itself, not

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,6 +35,12 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
   in bulk are under test, and the six bugs that turned up in doing it are fixed.
   What is deliberately left uncovered, and why, is written down in
   [CONTRIBUTING.md](../CONTRIBUTING.md#what-is-deliberately-not-covered).
+- Authentication beyond the API key: user accounts (`camoufox-pm user add`),
+  argon2id password hashes, HttpOnly session cookies with a real server-side
+  logout, and a login screen in the web UI. The three states stay coherent —
+  nothing configured is as open as before (loopback), the API key keeps
+  machine clients working unchanged, and the moment a user exists humans must
+  log in. See [SECURITY.md](../SECURITY.md#authentication).
 
 ## Now (0.1.x)
 
@@ -42,7 +48,6 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
 
 ## Next
 
-- Authentication for multi-user or hosted deployments, beyond the optional API key.
 - Task scheduling and automated fingerprint rotation.
 
 ## Later / ideas

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
     "aiofiles>=24.1",
     "openpyxl>=3.1",
     "cryptography>=44.0",
+    # argon2id password hashing for user accounts (OWASP first choice; memory-hard,
+    # unlike bcrypt, and without bcrypt's 72-byte input truncation).
+    "argon2-cffi>=23.1",
     "loguru>=0.7",
     "psutil>=6.1",
     # socks so a SOCKS5 proxy can be checked, not only HTTP ones.

--- a/src/camoufox_pm/api/dependencies.py
+++ b/src/camoufox_pm/api/dependencies.py
@@ -1,10 +1,11 @@
-"""API dependencies (dependency injection and auth guard)."""
+"""API dependencies (dependency injection and auth guards)."""
 
 import hmac
 
-from fastapi import Header, HTTPException
+from fastapi import Header, HTTPException, Request
 
 from camoufox_pm.config import get_settings
+from camoufox_pm.core import auth
 from camoufox_pm.core.database import StorageManager
 from camoufox_pm.core.profile_manager import ProfileManager
 
@@ -38,11 +39,44 @@ def get_profile_manager() -> ProfileManager:
     return _profile_manager
 
 
+def _api_key_matches(x_api_key: str | None) -> bool:
+    """Whether the presented key equals the configured one, in constant time."""
+    configured = get_settings().api_key
+    if not configured or x_api_key is None:
+        return False
+    # Constant-time comparison to avoid leaking the key via response timing.
+    return hmac.compare_digest(x_api_key, configured)
+
+
 async def require_api_key(x_api_key: str | None = Header(default=None)) -> None:
     """Enforce the API key when ``CPM_API_KEY`` is set; a no-op otherwise."""
-    configured = get_settings().api_key
-    if not configured:
+    if not get_settings().api_key:
         return
-    # Constant-time comparison to avoid leaking the key via response timing.
-    if x_api_key is None or not hmac.compare_digest(x_api_key, configured):
+    if not _api_key_matches(x_api_key):
         raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+
+async def require_auth(request: Request, x_api_key: str | None = Header(default=None)) -> None:
+    """The guard on every API route: a login session or the API key.
+
+    Three configurations, all decided per request so a user created by the CLI
+    while the server runs takes effect immediately:
+
+    - no users, no ``CPM_API_KEY`` — open, exactly the pre-auth loopback default;
+    - ``CPM_API_KEY`` set — a matching ``X-API-Key`` always passes, so machine
+      clients are unaffected by user accounts existing or not;
+    - any user account exists — everything else needs a valid session cookie.
+    """
+    if _api_key_matches(x_api_key):
+        return
+    storage = get_storage_manager()
+    if await storage.count_users() == 0:
+        if not get_settings().api_key:
+            return
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+    token = request.cookies.get(auth.SESSION_COOKIE)
+    if token and await auth.validate_session(storage, token) is not None:
+        return
+    raise HTTPException(
+        status_code=401, detail="Authentication required: log in or send a valid API key"
+    )

--- a/src/camoufox_pm/api/models/auth.py
+++ b/src/camoufox_pm/api/models/auth.py
@@ -1,0 +1,20 @@
+"""Auth API models."""
+
+from pydantic import BaseModel, Field
+
+
+class LoginRequest(BaseModel):
+    """Credentials for ``POST /auth/login``."""
+
+    username: str = Field(..., min_length=1, description="Account name")
+    password: str = Field(..., min_length=1, description="Account password")
+
+
+class AuthSessionResponse(BaseModel):
+    """The caller's authentication state; also the login response."""
+
+    user_auth_enabled: bool = Field(
+        ..., description="Whether any user account exists, i.e. whether login is required"
+    )
+    authenticated: bool = Field(..., description="Whether this request carries a valid session")
+    username: str | None = Field(None, description="The logged-in user, when authenticated")

--- a/src/camoufox_pm/api/models/system.py
+++ b/src/camoufox_pm/api/models/system.py
@@ -88,6 +88,9 @@ class SystemConfigData(BaseModel):
     port: int
     database_path: str
     api_key_set: bool
+    # Whether any user account exists, i.e. whether the API requires a login
+    # session (or the API key) rather than being open.
+    user_auth_enabled: bool
     encryption_enabled: bool
     cors_origins: list[str]
     camoufox_available: bool

--- a/src/camoufox_pm/api/routes/auth.py
+++ b/src/camoufox_pm/api/routes/auth.py
@@ -1,0 +1,120 @@
+"""API routes for user login sessions.
+
+Mounted without the auth guard: login must be reachable logged out, and the
+session probe is how the UI decides whether to show the login screen at all.
+"""
+
+import asyncio
+from typing import NoReturn
+
+from fastapi import APIRouter, HTTPException, Request, Response
+from loguru import logger
+
+from camoufox_pm.api.dependencies import get_storage_manager
+from camoufox_pm.api.models.auth import AuthSessionResponse, LoginRequest
+from camoufox_pm.api.models.system import ApiResponse
+from camoufox_pm.config import get_settings
+from camoufox_pm.core import auth
+
+router = APIRouter()
+
+# Flat friction against online guessing; argon2 already makes each attempt cost
+# real work, this keeps a loop from trying thousands per second regardless.
+FAILED_LOGIN_DELAY_SECONDS = 0.5
+
+
+def _set_session_cookie(request: Request, response: Response, token: str) -> None:
+    settings = get_settings()
+    response.set_cookie(
+        auth.SESSION_COOKIE,
+        token,
+        max_age=settings.session_ttl_hours * 3600,
+        path="/",
+        httponly=True,
+        samesite="lax",
+        secure=settings.secure_cookies or request.url.scheme == "https",
+    )
+
+
+async def _reject_login(password: str, burn_hash: bool) -> NoReturn:
+    """One indistinguishable failure for wrong password and unknown user."""
+    if burn_hash:
+        auth.verify_dummy(password)
+    await asyncio.sleep(FAILED_LOGIN_DELAY_SECONDS)
+    raise HTTPException(status_code=401, detail="Invalid username or password")
+
+
+@router.post(
+    "/auth/login",
+    response_model=AuthSessionResponse,
+    operation_id="login",
+    summary="Log in and receive a session cookie.",
+    description=(
+        "Exchange a username and password for an HttpOnly session cookie. The failure "
+        "response is identical whether the username exists or the password is wrong."
+    ),
+)
+async def login(body: LoginRequest, request: Request, response: Response) -> AuthSessionResponse:
+    """Verify credentials and open a session."""
+    storage = get_storage_manager()
+    user = await storage.get_user_by_username(body.username)
+    if user is None:
+        await _reject_login(body.password, burn_hash=True)
+    if not auth.verify_password(user["password_hash"], body.password):
+        await _reject_login(body.password, burn_hash=False)
+    if auth.password_needs_rehash(user["password_hash"]):
+        # Transparent upgrade to current argon2 parameters while we hold the
+        # plaintext; the old hash keeps working if this write is never reached.
+        await storage.update_user_password(user["username"], auth.hash_password(body.password))
+
+    await storage.delete_expired_sessions()
+    token = await auth.create_session(storage, user["id"])
+    _set_session_cookie(request, response, token)
+    logger.info(f"User {user['username']} logged in")
+    return AuthSessionResponse(
+        user_auth_enabled=True, authenticated=True, username=user["username"]
+    )
+
+
+@router.post(
+    "/auth/logout",
+    response_model=ApiResponse[None],
+    operation_id="logout",
+    summary="Log out and invalidate the session.",
+    description=(
+        "Delete the server-side session and clear the cookie. Idempotent: logging out "
+        "without a session is not an error."
+    ),
+)
+async def logout(request: Request, response: Response) -> ApiResponse[None]:
+    """Invalidate the caller's session, if any."""
+    token = request.cookies.get(auth.SESSION_COOKIE)
+    if token:
+        await get_storage_manager().delete_session(auth.hash_token(token))
+    response.delete_cookie(auth.SESSION_COOKIE, path="/")
+    return ApiResponse(success=True, message="Logged out", data=None)
+
+
+@router.get(
+    "/auth/session",
+    response_model=AuthSessionResponse,
+    operation_id="get_auth_session",
+    summary="Report the caller's authentication state.",
+    description=(
+        "Whether user login is enabled on this instance and whether this request "
+        "carries a valid session. Reachable without authentication."
+    ),
+)
+async def get_auth_session(request: Request) -> AuthSessionResponse:
+    """Report whether login is required and whether the caller is logged in."""
+    storage = get_storage_manager()
+    user_auth_enabled = await storage.count_users() > 0
+    username = None
+    token = request.cookies.get(auth.SESSION_COOKIE)
+    if token:
+        username = await auth.validate_session(storage, token)
+    return AuthSessionResponse(
+        user_auth_enabled=user_auth_enabled,
+        authenticated=username is not None,
+        username=username,
+    )

--- a/src/camoufox_pm/api/routes/system.py
+++ b/src/camoufox_pm/api/routes/system.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, HTTPException
 from loguru import logger
 
 from camoufox_pm import __version__
-from camoufox_pm.api.dependencies import get_profile_manager
+from camoufox_pm.api.dependencies import get_profile_manager, get_storage_manager
 from camoufox_pm.api.models.system import (
     ApiResponse,
     DevicePreset,
@@ -215,6 +215,7 @@ async def get_system_config():
             port=settings.port,
             database_path=str(Path(settings.db_path).resolve()),
             api_key_set=bool(settings.api_key),
+            user_auth_enabled=await get_storage_manager().count_users() > 0,
             encryption_enabled=bool(settings.secret_key),
             cors_origins=settings.cors_origins,
             camoufox_available=CAMOUFOX_AVAILABLE,

--- a/src/camoufox_pm/cli.py
+++ b/src/camoufox_pm/cli.py
@@ -1,13 +1,19 @@
 """Command-line launcher: run the API + bundled web UI as one process.
 
 Installed as the ``camoufox-pm`` console script. Starts the server and opens the
-web UI in the default browser.
+web UI in the default browser. The ``user`` subcommands manage login accounts —
+they exist on the CLI, not the API, so the first user can be created without a
+chicken-and-egg lockout and creating accounts requires shell access to the host.
 """
 
 import argparse
+import asyncio
+import getpass
 import os
+import sys
 import threading
 import webbrowser
+from typing import NoReturn
 
 import uvicorn
 
@@ -28,7 +34,45 @@ def main() -> None:
         action="store_true",
         help="Open a native desktop window instead of a browser tab (needs the 'desktop' extra)",
     )
+
+    subcommands = parser.add_subparsers(dest="command")
+    user_parser = subcommands.add_parser(
+        "user",
+        help="Manage login accounts (creating the first one turns login on)",
+        description=(
+            "Manage web UI login accounts. As long as any account exists, the API "
+            "requires a login session or the API key; removing the last one turns "
+            "login off again."
+        ),
+    )
+    user_commands = user_parser.add_subparsers(dest="user_command", required=True)
+
+    add = user_commands.add_parser("add", help="Create an account (prompts for the password)")
+    add.add_argument("username")
+    add.add_argument(
+        "--password-stdin",
+        action="store_true",
+        help="Read the password from the first line of stdin instead of prompting",
+    )
+
+    passwd = user_commands.add_parser("passwd", help="Change an account's password")
+    passwd.add_argument("username")
+    passwd.add_argument(
+        "--password-stdin",
+        action="store_true",
+        help="Read the password from the first line of stdin instead of prompting",
+    )
+
+    remove = user_commands.add_parser("remove", help="Delete an account and its sessions")
+    remove.add_argument("username")
+
+    user_commands.add_parser("list", help="List accounts (never shows password hashes)")
+
     args = parser.parse_args()
+
+    if args.command == "user":
+        asyncio.run(_run_user_command(args))
+        return
 
     # Make the settings match what we are about to bind, so everything that reads
     # them (the Settings screen, CORS, logs) reports the real address rather than
@@ -52,6 +96,69 @@ def main() -> None:
     from camoufox_pm.main import app
 
     uvicorn.run(app, host=args.host, port=args.port, log_level="info")
+
+
+def _fail(message: str) -> NoReturn:
+    print(message, file=sys.stderr)
+    raise SystemExit(1)
+
+
+def _read_password(args: argparse.Namespace) -> str:
+    """Collect a password without it ever appearing in argv or the environment."""
+    from camoufox_pm.core.auth import MIN_PASSWORD_LENGTH
+
+    if args.password_stdin:
+        password = sys.stdin.readline().rstrip("\n")
+    else:
+        password = getpass.getpass("Password: ")
+        if getpass.getpass("Repeat password: ") != password:
+            _fail("Passwords do not match.")
+    if len(password) < MIN_PASSWORD_LENGTH:
+        _fail(f"Password must be at least {MIN_PASSWORD_LENGTH} characters.")
+    return password
+
+
+async def _run_user_command(args: argparse.Namespace) -> None:
+    # Imported here so plain `camoufox-pm` startup does not pay for them.
+    from camoufox_pm.core import auth
+    from camoufox_pm.core.database import StorageManager
+
+    storage = StorageManager(get_settings().db_path)
+    await storage.initialize()
+    try:
+        if args.user_command == "add":
+            password = _read_password(args)
+            try:
+                await storage.create_user(
+                    auth.new_user_id(), args.username, auth.hash_password(password)
+                )
+            except ValueError as exc:
+                _fail(str(exc))
+            print(
+                f"User '{args.username}' created. The API and web UI now require "
+                "a login session (or the API key, if CPM_API_KEY is set)."
+            )
+        elif args.user_command == "passwd":
+            password = _read_password(args)
+            if not await storage.update_user_password(args.username, auth.hash_password(password)):
+                _fail(f"No user named '{args.username}'.")
+            print(f"Password updated for '{args.username}'.")
+        elif args.user_command == "remove":
+            if not await storage.delete_user(args.username):
+                _fail(f"No user named '{args.username}'.")
+            print(f"User '{args.username}' removed, along with any open sessions.")
+            if await storage.count_users() == 0:
+                print(
+                    "No users remain: login is now disabled and the API is back to its API-key/open behaviour."
+                )
+        elif args.user_command == "list":
+            users = await storage.list_users()
+            if not users:
+                print("No users. Create one with: camoufox-pm user add <name>")
+            for user in users:
+                print(f"{user['username']}\t(created {user['created_at']})")
+    finally:
+        await storage.close()
 
 
 if __name__ == "__main__":

--- a/src/camoufox_pm/config.py
+++ b/src/camoufox_pm/config.py
@@ -19,6 +19,13 @@ class Settings(BaseSettings):
     db_path: str = "data/profiles.db"
     secret_key: str | None = None
     webui_dir: str | None = None
+    # Lifetime of a login session. Sessions are stored server-side, so shortening
+    # this takes effect for existing sessions on their next request.
+    session_ttl_hours: int = 168
+    # Force the Secure flag on the session cookie. The flag is set automatically
+    # when the request itself arrived over HTTPS, but behind a TLS-terminating
+    # proxy the app sees plain HTTP — set this there.
+    secure_cookies: bool = False
 
     @field_validator("cors_origins", mode="before")
     @classmethod

--- a/src/camoufox_pm/core/auth.py
+++ b/src/camoufox_pm/core/auth.py
@@ -1,0 +1,88 @@
+"""User accounts and login sessions.
+
+Passwords are hashed with argon2id. Sessions are opaque random tokens stored
+server-side: only the SHA-256 of a token ever touches the database, so a copy
+of the database does not contain anything a browser could replay, and deleting
+the row is a real logout — nothing signed stays valid after it.
+"""
+
+import hashlib
+import secrets
+import uuid
+from datetime import datetime, timedelta
+
+from argon2 import PasswordHasher
+from argon2.exceptions import InvalidHashError, VerificationError
+
+from camoufox_pm.config import get_settings
+
+SESSION_COOKIE = "cpm_session"
+
+MIN_PASSWORD_LENGTH = 8
+
+_hasher = PasswordHasher()
+
+# Verified against when the username does not exist, so a login attempt costs
+# the same whether or not the account is real.
+_DUMMY_HASH = _hasher.hash(secrets.token_urlsafe(16))
+
+
+def hash_password(password: str) -> str:
+    """Hash ``password`` with argon2id (salt and parameters travel in the hash)."""
+    return _hasher.hash(password)
+
+
+def verify_password(password_hash: str, password: str) -> bool:
+    """Check ``password`` against a stored hash; malformed hashes verify false."""
+    try:
+        return _hasher.verify(password_hash, password)
+    except (VerificationError, InvalidHashError):
+        return False
+
+
+def verify_dummy(password: str) -> None:
+    """Burn the same argon2 work as a real check, for unknown usernames."""
+    try:
+        _hasher.verify(_DUMMY_HASH, password)
+    except VerificationError:
+        pass
+
+
+def password_needs_rehash(password_hash: str) -> bool:
+    """Whether the stored hash predates the current argon2 parameters."""
+    try:
+        return _hasher.check_needs_rehash(password_hash)
+    except InvalidHashError:
+        return False
+
+
+def new_user_id() -> str:
+    return uuid.uuid4().hex
+
+
+def new_session_token() -> str:
+    return secrets.token_urlsafe(32)
+
+
+def hash_token(token: str) -> str:
+    """The database stores this, never the token itself."""
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+async def create_session(storage, user_id: str) -> str:
+    """Open a session for ``user_id`` and return the token for the cookie."""
+    token = new_session_token()
+    expires_at = datetime.now() + timedelta(hours=get_settings().session_ttl_hours)
+    await storage.create_session(hash_token(token), user_id, expires_at)
+    return token
+
+
+async def validate_session(storage, token: str) -> str | None:
+    """Return the username the token belongs to, or None. Expired rows are removed."""
+    session = await storage.get_session(hash_token(token))
+    if session is None:
+        return None
+    if datetime.fromisoformat(session["expires_at"]) <= datetime.now():
+        await storage.delete_session(session["token_hash"])
+        return None
+    return session["username"]

--- a/src/camoufox_pm/core/database.py
+++ b/src/camoufox_pm/core/database.py
@@ -121,6 +121,28 @@ class DatabaseManager:
             )
         """)
 
+        # User accounts for the web UI. Their mere existence turns login on, so a
+        # database without rows here behaves exactly as before the table existed.
+        self._connection.execute("""
+            CREATE TABLE IF NOT EXISTS users (
+                id TEXT PRIMARY KEY,
+                username TEXT NOT NULL UNIQUE COLLATE NOCASE,
+                password_hash TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        # Login sessions, keyed by the SHA-256 of the cookie token — the token
+        # itself is never stored, so this table cannot be replayed if leaked.
+        self._connection.execute("""
+            CREATE TABLE IF NOT EXISTS sessions (
+                token_hash TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                expires_at TIMESTAMP NOT NULL
+            )
+        """)
+
         self._connection.commit()
 
     async def _create_indexes(self):
@@ -353,6 +375,85 @@ class DatabaseManager:
 
         return stats
 
+    # --- Users and sessions ---
+
+    async def create_user(self, user_id: str, username: str, password_hash: str) -> None:
+        """Create a user; raises ``ValueError`` when the username is taken."""
+        try:
+            self._connection.execute(
+                "INSERT INTO users (id, username, password_hash, created_at) VALUES (?, ?, ?, ?)",
+                (user_id, username, password_hash, datetime.now().isoformat()),
+            )
+        except sqlite3.IntegrityError as exc:
+            raise ValueError(f"User {username!r} already exists") from exc
+        self._connection.commit()
+        # Deliberately logs the name only, never the hash.
+        logger.info(f"User {username} created")
+
+    async def get_user_by_username(self, username: str) -> dict | None:
+        cursor = self._connection.execute(
+            "SELECT id, username, password_hash FROM users WHERE username = ?", (username,)
+        )
+        row = cursor.fetchone()
+        return dict(row) if row else None
+
+    async def update_user_password(self, username: str, password_hash: str) -> bool:
+        cursor = self._connection.execute(
+            "UPDATE users SET password_hash = ? WHERE username = ?", (password_hash, username)
+        )
+        self._connection.commit()
+        return cursor.rowcount > 0
+
+    async def delete_user(self, username: str) -> bool:
+        """Delete a user; the foreign key cascades their open sessions away."""
+        cursor = self._connection.execute("DELETE FROM users WHERE username = ?", (username,))
+        self._connection.commit()
+        return cursor.rowcount > 0
+
+    async def count_users(self) -> int:
+        cursor = self._connection.execute("SELECT COUNT(*) FROM users")
+        return cursor.fetchone()[0]
+
+    async def list_users(self) -> list[dict]:
+        """Usernames and creation times only — hashes stay in the table."""
+        cursor = self._connection.execute(
+            "SELECT username, created_at FROM users ORDER BY created_at"
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
+    async def create_session(self, token_hash: str, user_id: str, expires_at: datetime) -> None:
+        self._connection.execute(
+            "INSERT INTO sessions (token_hash, user_id, created_at, expires_at) VALUES (?, ?, ?, ?)",
+            (token_hash, user_id, datetime.now().isoformat(), expires_at.isoformat()),
+        )
+        self._connection.commit()
+
+    async def get_session(self, token_hash: str) -> dict | None:
+        cursor = self._connection.execute(
+            """
+            SELECT s.token_hash, s.user_id, s.expires_at, u.username
+            FROM sessions s JOIN users u ON u.id = s.user_id
+            WHERE s.token_hash = ?
+            """,
+            (token_hash,),
+        )
+        row = cursor.fetchone()
+        return dict(row) if row else None
+
+    async def delete_session(self, token_hash: str) -> bool:
+        cursor = self._connection.execute(
+            "DELETE FROM sessions WHERE token_hash = ?", (token_hash,)
+        )
+        self._connection.commit()
+        return cursor.rowcount > 0
+
+    async def delete_expired_sessions(self) -> int:
+        cursor = self._connection.execute(
+            "DELETE FROM sessions WHERE expires_at <= ?", (datetime.now().isoformat(),)
+        )
+        self._connection.commit()
+        return cursor.rowcount
+
     # --- Utilities ---
 
     def _row_to_profile(self, row) -> Profile:
@@ -450,6 +551,37 @@ class StorageManager:
 
     async def delete_profile_group(self, group_id: str) -> bool:
         return await self.db.delete_profile_group(group_id)
+
+    # User and session methods
+    async def create_user(self, user_id: str, username: str, password_hash: str) -> None:
+        await self.db.create_user(user_id, username, password_hash)
+
+    async def get_user_by_username(self, username: str) -> dict | None:
+        return await self.db.get_user_by_username(username)
+
+    async def update_user_password(self, username: str, password_hash: str) -> bool:
+        return await self.db.update_user_password(username, password_hash)
+
+    async def delete_user(self, username: str) -> bool:
+        return await self.db.delete_user(username)
+
+    async def count_users(self) -> int:
+        return await self.db.count_users()
+
+    async def list_users(self) -> list[dict]:
+        return await self.db.list_users()
+
+    async def create_session(self, token_hash: str, user_id: str, expires_at: datetime) -> None:
+        await self.db.create_session(token_hash, user_id, expires_at)
+
+    async def get_session(self, token_hash: str) -> dict | None:
+        return await self.db.get_session(token_hash)
+
+    async def delete_session(self, token_hash: str) -> bool:
+        return await self.db.delete_session(token_hash)
+
+    async def delete_expired_sessions(self) -> int:
+        return await self.db.delete_expired_sessions()
 
     async def close(self):
         """Close the database."""

--- a/src/camoufox_pm/main.py
+++ b/src/camoufox_pm/main.py
@@ -11,14 +11,14 @@ from loguru import logger
 
 from camoufox_pm import __version__
 from camoufox_pm.api.dependencies import (
-    require_api_key,
+    require_auth,
     set_profile_manager,
     set_storage_manager,
 )
 from camoufox_pm.api.errors import install_error_handlers
 from camoufox_pm.api.middleware.logging import LoggingMiddleware
 from camoufox_pm.api.models.system import ErrorResponse, HealthResponse
-from camoufox_pm.api.routes import groups, profiles, system
+from camoufox_pm.api.routes import auth, groups, profiles, system
 from camoufox_pm.config import get_settings
 from camoufox_pm.core.database import StorageManager
 from camoufox_pm.core.profile_manager import ProfileManager
@@ -78,12 +78,20 @@ app.add_middleware(
 )
 app.add_middleware(LoggingMiddleware)
 
-# Optional API-key guard; a no-op when CPM_API_KEY is unset.
-protected = [Depends(require_api_key)]
+# Session-or-API-key guard; a no-op when neither users nor CPM_API_KEY exist.
+protected = [Depends(require_auth)]
 # /api/v1 is the canonical prefix. The same routers are also served under the
 # pre-0.2 unversioned /api so existing scripts keep working; those copies are
 # left out of the schema so a generated client sees each operation once.
 for _prefix, _in_schema in (("/api/v1", True), ("/api", False)):
+    # Unguarded on purpose: login has to work logged out, and /auth/session is
+    # how the UI decides whether to show the login screen.
+    app.include_router(
+        auth.router,
+        prefix=_prefix,
+        tags=["Auth"],
+        include_in_schema=_in_schema,
+    )
     app.include_router(
         profiles.router,
         prefix=_prefix,

--- a/tests/integration/test_api_user_auth.py
+++ b/tests/integration/test_api_user_auth.py
@@ -1,0 +1,182 @@
+"""Integration tests for user login sessions and how they coexist with the
+API key and the open loopback default.
+
+The three configuration states, each of which must stay coherent:
+(a) nothing configured — open, exactly as before user accounts existed;
+(b) only ``CPM_API_KEY`` — machine clients unchanged;
+(c) a user exists — a session cookie or the API key is required.
+"""
+
+import pytest
+
+from camoufox_pm.api import dependencies
+from camoufox_pm.api.routes import auth as auth_routes
+from camoufox_pm.config import get_settings
+from camoufox_pm.core import auth
+
+PASSWORD = "a-decent-password"
+
+
+@pytest.fixture(autouse=True)
+def _fast_failures(monkeypatch):
+    """The anti-brute-force delay is pure waiting; tests skip it."""
+    monkeypatch.setattr(auth_routes, "FAILED_LOGIN_DELAY_SECONDS", 0.0)
+
+
+@pytest.fixture(autouse=True)
+def _no_api_key(monkeypatch):
+    """Each test states its own key; none leaks in from the environment."""
+    monkeypatch.delenv("CPM_API_KEY", raising=False)
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def _create_user(username: str = "alice", password: str = PASSWORD) -> None:
+    storage = dependencies.get_storage_manager()
+    await storage.create_user(auth.new_user_id(), username, auth.hash_password(password))
+
+
+@pytest.mark.asyncio
+async def test_state_a_nothing_configured_stays_open(client):
+    response = await client.get("/api/v1/profiles")
+    assert response.status_code == 200
+
+    session = await client.get("/api/v1/auth/session")
+    assert session.json() == {
+        "user_auth_enabled": False,
+        "authenticated": False,
+        "username": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_state_b_api_key_alone_behaves_exactly_as_before(client, monkeypatch):
+    monkeypatch.setenv("CPM_API_KEY", "top-secret")
+    get_settings.cache_clear()
+
+    assert (await client.get("/api/v1/profiles")).status_code == 401
+    wrong = await client.get("/api/v1/profiles", headers={"X-API-Key": "nope"})
+    assert wrong.status_code == 401
+    right = await client.get("/api/v1/profiles", headers={"X-API-Key": "top-secret"})
+    assert right.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_state_c_a_user_existing_closes_the_api(client):
+    await _create_user()
+    response = await client.get("/api/v1/profiles")
+    assert response.status_code == 401
+    assert response.json()["error"]["code"] == "unauthorized"
+
+    # The login screen's probe stays reachable, or nobody could ever log in.
+    session = await client.get("/api/v1/auth/session")
+    assert session.status_code == 200
+    assert session.json()["user_auth_enabled"] is True
+    assert session.json()["authenticated"] is False
+
+
+@pytest.mark.asyncio
+async def test_login_grants_a_session_that_passes_the_guard(client):
+    await _create_user()
+    login = await client.post(
+        "/api/v1/auth/login", json={"username": "alice", "password": PASSWORD}
+    )
+    assert login.status_code == 200
+    assert login.json() == {
+        "user_auth_enabled": True,
+        "authenticated": True,
+        "username": "alice",
+    }
+
+    set_cookie = login.headers["set-cookie"]
+    assert "cpm_session=" in set_cookie
+    assert "HttpOnly" in set_cookie
+    assert "SameSite=lax" in set_cookie
+    # Served over plain HTTP here, so Secure must not be set — it would make the
+    # cookie undeliverable on the loopback default.
+    assert "Secure" not in set_cookie
+
+    # httpx carries the cookie forward like a browser would.
+    assert (await client.get("/api/v1/profiles")).status_code == 200
+    session = await client.get("/api/v1/auth/session")
+    assert session.json()["username"] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_wrong_password_and_unknown_user_are_indistinguishable(client):
+    await _create_user()
+    wrong_password = await client.post(
+        "/api/v1/auth/login", json={"username": "alice", "password": "not-it-at-all"}
+    )
+    unknown_user = await client.post(
+        "/api/v1/auth/login", json={"username": "nobody", "password": "not-it-at-all"}
+    )
+    assert wrong_password.status_code == unknown_user.status_code == 401
+    assert wrong_password.json() == unknown_user.json()
+
+
+@pytest.mark.asyncio
+async def test_logout_really_invalidates_the_session(client):
+    await _create_user()
+    login = await client.post(
+        "/api/v1/auth/login", json={"username": "alice", "password": PASSWORD}
+    )
+    # Keep the raw token: the logout response clears the cookie jar, and the
+    # point is that the server side is dead too, not just the browser copy.
+    token = login.cookies["cpm_session"]
+
+    assert (await client.get("/api/v1/profiles")).status_code == 200
+    logout = await client.post("/api/v1/auth/logout")
+    assert logout.status_code == 200
+
+    assert (await client.get("/api/v1/profiles")).status_code == 401
+    replayed = await client.get("/api/v1/profiles", headers={"Cookie": f"cpm_session={token}"})
+    assert replayed.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_a_forged_cookie_does_not_pass(client):
+    await _create_user()
+    response = await client.get("/api/v1/profiles", headers={"Cookie": "cpm_session=" + "A" * 43})
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_api_key_still_works_when_users_exist(client, monkeypatch):
+    """Machine clients must not break the day a human account is created."""
+    monkeypatch.setenv("CPM_API_KEY", "top-secret")
+    get_settings.cache_clear()
+    await _create_user()
+
+    assert (await client.get("/api/v1/profiles")).status_code == 401
+    keyed = await client.get("/api/v1/profiles", headers={"X-API-Key": "top-secret"})
+    assert keyed.status_code == 200
+    wrong = await client.get("/api/v1/profiles", headers={"X-API-Key": "nope"})
+    assert wrong.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_no_response_ever_carries_the_password_hash(client):
+    await _create_user()
+    login = await client.post(
+        "/api/v1/auth/login", json={"username": "alice", "password": PASSWORD}
+    )
+    session = await client.get("/api/v1/auth/session")
+    for response in (login, session):
+        assert "argon2" not in response.text
+        assert PASSWORD not in response.text
+
+
+@pytest.mark.asyncio
+async def test_system_config_reports_user_auth(client):
+    before = await client.get("/api/v1/system/config")
+    assert before.json()["data"]["user_auth_enabled"] is False
+
+    await _create_user()
+    login = await client.post(
+        "/api/v1/auth/login", json={"username": "alice", "password": PASSWORD}
+    )
+    assert login.status_code == 200
+    after = await client.get("/api/v1/system/config")
+    assert after.json()["data"]["user_auth_enabled"] is True

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,0 +1,87 @@
+"""Password hashing and login-session logic."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from camoufox_pm.core import auth
+
+
+def test_password_hash_is_argon2id_and_never_the_password():
+    hashed = auth.hash_password("correct horse battery staple")
+    assert hashed.startswith("$argon2id$")
+    assert "correct horse battery staple" not in hashed
+
+
+def test_password_verifies_and_wrong_password_does_not():
+    hashed = auth.hash_password("right-password")
+    assert auth.verify_password(hashed, "right-password")
+    assert not auth.verify_password(hashed, "wrong-password")
+
+
+def test_same_password_hashes_differently_each_time():
+    """A random salt per hash, so equal passwords are not linkable in the table."""
+    assert auth.hash_password("pw-123456") != auth.hash_password("pw-123456")
+
+
+def test_garbage_hash_verifies_false_not_raises():
+    assert not auth.verify_password("not-a-hash-at-all", "anything")
+    assert not auth.verify_password("", "anything")
+
+
+def test_dummy_verify_swallows_the_mismatch():
+    """Burned for unknown usernames; must never raise."""
+    auth.verify_dummy("whatever")
+
+
+def test_token_is_stored_only_as_its_hash():
+    token = auth.new_session_token()
+    hashed = auth.hash_token(token)
+    assert hashed != token
+    assert token not in hashed
+    # Deterministic, so the lookup on the next request finds the row.
+    assert auth.hash_token(token) == hashed
+
+
+async def test_session_roundtrip(storage):
+    await storage.create_user("u1", "alice", auth.hash_password("pw-123456"))
+    token = await auth.create_session(storage, "u1")
+
+    assert await auth.validate_session(storage, token) == "alice"
+    assert await auth.validate_session(storage, "some-other-token") is None
+
+
+async def test_expired_session_is_rejected_and_removed(storage):
+    await storage.create_user("u1", "alice", auth.hash_password("pw-123456"))
+    token = auth.new_session_token()
+    await storage.create_session(
+        auth.hash_token(token), "u1", datetime.now() - timedelta(seconds=1)
+    )
+
+    assert await auth.validate_session(storage, token) is None
+    # The row is gone, not just ignored.
+    assert await storage.get_session(auth.hash_token(token)) is None
+
+
+async def test_deleting_a_user_invalidates_their_sessions(storage):
+    await storage.create_user("u1", "alice", auth.hash_password("pw-123456"))
+    token = await auth.create_session(storage, "u1")
+
+    assert await storage.delete_user("alice")
+    assert await auth.validate_session(storage, token) is None
+
+
+async def test_duplicate_username_is_refused_case_insensitively(storage):
+    await storage.create_user("u1", "Alice", auth.hash_password("pw-123456"))
+    with pytest.raises(ValueError):
+        await storage.create_user("u2", "alice", auth.hash_password("pw-123456"))
+
+
+async def test_expired_sessions_sweep(storage):
+    await storage.create_user("u1", "alice", auth.hash_password("pw-123456"))
+    live = await auth.create_session(storage, "u1")
+    stale = auth.new_session_token()
+    await storage.create_session(auth.hash_token(stale), "u1", datetime.now() - timedelta(hours=1))
+
+    assert await storage.delete_expired_sessions() == 1
+    assert await auth.validate_session(storage, live) == "alice"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -6,6 +6,7 @@ logic: the flags becoming the settings the rest of the app reads, and the URL a
 browser is pointed at.
 """
 
+import asyncio
 import sys
 
 import pytest
@@ -93,3 +94,99 @@ def test_desktop_mode_hands_over_instead_of_serving_here(run, monkeypatch):
     assert asked == [{"host": "127.0.0.1", "port": 9123}]
     assert started["uvicorn"] is None
     assert started["timers"] == []
+
+
+# --- `camoufox-pm user ...` ---------------------------------------------------
+
+
+@pytest.fixture
+def run_user(monkeypatch, tmp_path):
+    """Run a ``user`` subcommand against a throwaway database, with password
+    prompts answered from a scripted list."""
+
+    monkeypatch.setenv("CPM_DB_PATH", str(tmp_path / "cli.db"))
+    monkeypatch.setattr(cli.uvicorn, "run", lambda *a, **k: pytest.fail("must not serve"))
+
+    def invoke(*args: str, prompts: list[str] | None = None):
+        answers = list(prompts or [])
+        monkeypatch.setattr(cli.getpass, "getpass", lambda prompt="": answers.pop(0))
+        monkeypatch.setattr(sys, "argv", ["camoufox-pm", "user", *args])
+        get_settings.cache_clear()
+        try:
+            cli.main()
+        finally:
+            get_settings.cache_clear()
+
+    yield invoke
+
+
+async def _usernames(tmp_path) -> list[str]:
+    from camoufox_pm.core.database import StorageManager
+
+    storage = StorageManager(str(tmp_path / "cli.db"))
+    await storage.initialize()
+    try:
+        return [user["username"] for user in await storage.list_users()]
+    finally:
+        await storage.close()
+
+
+def test_user_add_creates_the_account(run_user, tmp_path):
+    run_user("add", "alice", prompts=["hunter22-long", "hunter22-long"])
+
+    assert asyncio.run(_usernames(tmp_path)) == ["alice"]
+
+
+def test_user_add_rejects_a_short_password(run_user, tmp_path):
+    with pytest.raises(SystemExit):
+        run_user("add", "alice", prompts=["short", "short"])
+
+    assert asyncio.run(_usernames(tmp_path)) == []
+
+
+def test_user_add_rejects_mismatched_prompts(run_user, tmp_path):
+    with pytest.raises(SystemExit):
+        run_user("add", "alice", prompts=["one-password-8", "another-password"])
+
+
+def test_user_add_refuses_a_duplicate(run_user):
+    run_user("add", "alice", prompts=["hunter22-long", "hunter22-long"])
+    with pytest.raises(SystemExit):
+        run_user("add", "alice", prompts=["hunter22-long", "hunter22-long"])
+
+
+def test_user_remove_deletes_the_account(run_user, tmp_path):
+    run_user("add", "alice", prompts=["hunter22-long", "hunter22-long"])
+    run_user("remove", "alice")
+
+    assert asyncio.run(_usernames(tmp_path)) == []
+
+
+def test_user_list_shows_names_and_never_hashes(run_user, capsys):
+    run_user("add", "alice", prompts=["hunter22-long", "hunter22-long"])
+    run_user("list")
+
+    out = capsys.readouterr().out
+    assert "alice" in out
+    assert "argon2" not in out
+    assert "hunter22-long" not in out
+
+
+def test_user_passwd_changes_the_password(run_user, tmp_path):
+    from camoufox_pm.core import auth
+    from camoufox_pm.core.database import StorageManager
+
+    run_user("add", "alice", prompts=["hunter22-long", "hunter22-long"])
+    run_user("passwd", "alice", prompts=["new-password-9", "new-password-9"])
+
+    async def check() -> bool:
+        storage = StorageManager(str(tmp_path / "cli.db"))
+        await storage.initialize()
+        try:
+            user = await storage.get_user_by_username("alice")
+            assert user is not None
+            return auth.verify_password(user["password_hash"], "new-password-9")
+        finally:
+            await storage.close()
+
+    assert asyncio.run(check())

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -118,3 +118,42 @@ async def test_proxy_password_is_encrypted_at_rest(storage, monkeypatch):
         assert loaded.proxy.password == "secret"
     finally:
         get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_a_pre_auth_database_gains_the_user_tables_without_losing_data(tmp_path):
+    """An install from before user accounts has no users/sessions tables; opening
+    it must add them and leave the existing rows exactly as they were."""
+    import sqlite3
+
+    from camoufox_pm.core.database import StorageManager
+
+    db_path = tmp_path / "old.db"
+    old = sqlite3.connect(str(db_path))
+    old.execute(
+        """
+        CREATE TABLE profiles (
+            id TEXT PRIMARY KEY, name TEXT NOT NULL, group_id TEXT,
+            status TEXT DEFAULT 'active', browser_settings TEXT NOT NULL,
+            proxy_config TEXT, extensions TEXT, storage_path TEXT, notes TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP, last_used TIMESTAMP
+        )
+        """
+    )
+    old.execute(
+        "INSERT INTO profiles (id, name, browser_settings, created_at, updated_at) "
+        "VALUES ('p1', 'survivor', '{}', '2025-01-01T00:00:00', '2025-01-01T00:00:00')"
+    )
+    old.commit()
+    old.close()
+
+    storage = StorageManager(str(db_path))
+    await storage.initialize()
+    try:
+        assert (await storage.get_profile("p1")).name == "survivor"
+        assert await storage.count_users() == 0
+        await storage.create_user("u1", "alice", "hash")
+        assert await storage.count_users() == 1
+    finally:
+        await storage.close()

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version >= '3.12' and python_full_version < '3.14'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
 ]
@@ -236,6 +237,54 @@ wheels = [
 ]
 
 [[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/ba4e4ca8d149f8dcc0d952ac0967089e1d759c7e5fcf0865a317eb680fbb/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:6dca33a9859abf613e22733131fc9194091c1fa7cb3e131c143056b4856aa47e", size = 24549, upload-time = "2025-07-30T10:02:00.101Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/82/9b2386cc75ac0bd3210e12a44bfc7fd1632065ed8b80d573036eecb10442/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:21378b40e1b8d1655dd5310c84a40fc19a9aa5e6366e835ceb8576bf0fea716d", size = 25539, upload-time = "2025-07-30T10:02:00.929Z" },
+    { url = "https://files.pythonhosted.org/packages/31/db/740de99a37aa727623730c90d92c22c9e12585b3c98c54b7960f7810289f/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d588dec224e2a83edbdc785a5e6f3c6cd736f46bfd4b441bbb5aa1f5085e584", size = 28467, upload-time = "2025-07-30T10:02:02.08Z" },
+    { url = "https://files.pythonhosted.org/packages/71/7a/47c4509ea18d755f44e2b92b7178914f0c113946d11e16e626df8eaa2b0b/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5acb4e41090d53f17ca1110c3427f0a130f944b896fc8c83973219c97f57b690", size = 27355, upload-time = "2025-07-30T10:02:02.867Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/82/82745642d3c46e7cea25e1885b014b033f4693346ce46b7f47483cf5d448/argon2_cffi_bindings-25.1.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:da0c79c23a63723aa5d782250fbf51b768abca630285262fb5144ba5ae01e520", size = 29187, upload-time = "2025-07-30T10:02:03.674Z" },
+]
+
+[[package]]
 name = "ast-serialize"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -401,6 +450,7 @@ version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
+    { name = "argon2-cffi" },
     { name = "camoufox", extra = ["geoip"] },
     { name = "cryptography" },
     { name = "fastapi" },
@@ -441,6 +491,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiofiles", specifier = ">=24.1" },
+    { name = "argon2-cffi", specifier = ">=23.1" },
     { name = "camoufox", extras = ["geoip"], specifier = ">=0.5.4" },
     { name = "cryptography", specifier = ">=44.0" },
     { name = "fastapi", specifier = ">=0.115" },
@@ -2053,7 +2104,8 @@ version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version >= '3.12' and python_full_version < '3.14'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
 wheels = [
@@ -3614,7 +3666,8 @@ version = "17.0.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.12' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*'",
+    "python_full_version >= '3.12' and python_full_version < '3.14'",
     "python_full_version == '3.11.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f7/96/e01084f83a64bcb3a27994bd0cb0db68ff29d9c6707fae37ec19b18ba990/websockets-17.0.1.tar.gz", hash = "sha256:5baa9bc0dfbae8c507e51c8cf1b6d4628086f7a87bbd3a9952bd5f035451f1cc", size = 183298, upload-time = "2026-07-31T11:31:27.665Z" }

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { IBM_Plex_Mono, IBM_Plex_Sans } from 'next/font/google'
 
 import { AppShell } from '@/components/app-shell'
+import { LoginGate } from '@/components/login-gate'
 import { ToastProvider } from '@/components/toast'
 import './globals.css'
 
@@ -31,7 +32,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" className={`${plexSans.variable} ${plexMono.variable}`}>
       <body>
         <ToastProvider>
-          <AppShell>{children}</AppShell>
+          <LoginGate>
+            <AppShell>{children}</AppShell>
+          </LoginGate>
         </ToastProvider>
       </body>
     </html>

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -75,11 +75,22 @@ export default function SettingsPage() {
               warnWhenOff
             />
             <Toggle
+              on={config.user_auth_enabled}
+              label="User accounts"
+              onText="Login is required. Manage accounts with: camoufox-pm user"
+              offText="No user accounts. Create one with: camoufox-pm user add <name>"
+              warnWhenOff={config.host !== '127.0.0.1' && !config.api_key_set}
+            />
+            <Toggle
               on={config.api_key_set}
               label="API key"
               onText="Requests must send a matching X-API-Key header."
-              offText="No API key is set. Anyone who can reach this port can use the API."
-              warnWhenOff={config.host !== '127.0.0.1'}
+              offText={
+                config.user_auth_enabled
+                  ? 'No API key is set. Machine clients have no way in; humans log in.'
+                  : 'No API key is set. Anyone who can reach this port can use the API.'
+              }
+              warnWhenOff={config.host !== '127.0.0.1' && !config.user_auth_enabled}
             />
             {config.api_key_set && (
               <form onSubmit={saveKey} className="flex items-start gap-4 px-4 py-2.5">

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Layers, Settings, Users } from 'lucide-react'
+import { Layers, LogOut, Settings, Users } from 'lucide-react'
 
+import { useAuth } from '@/components/login-gate'
 import { systemAPI } from '@/lib/api'
 
 const NAV = [
@@ -19,6 +20,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   // trailingSlash is on for the static export, so normalise before comparing.
   const current = pathname.replace(/\/+$/, '') || '/'
   const [address, setAddress] = useState<string | null>(null)
+  const { username, logout } = useAuth()
 
   useEffect(() => {
     // Report where the server actually is rather than assuming loopback.
@@ -57,8 +59,24 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           })}
         </nav>
 
-        <div className="mt-auto px-4 py-3 font-mono text-[11px] text-ink-faint">
-          {address ?? '—'}
+        <div className="mt-auto">
+          {username && (
+            <div className="flex items-center justify-between gap-2 border-t border-line px-4 py-2">
+              <span className="truncate text-ink-dim" title={username}>
+                {username}
+              </span>
+              <button
+                type="button"
+                onClick={logout}
+                aria-label="Log out"
+                title="Log out"
+                className="rounded p-1 text-ink-faint transition-colors hover:bg-raised hover:text-ink"
+              >
+                <LogOut size={14} strokeWidth={1.75} />
+              </button>
+            </div>
+          )}
+          <div className="px-4 py-3 font-mono text-[11px] text-ink-faint">{address ?? '—'}</div>
         </div>
       </aside>
 

--- a/web/src/components/login-gate.tsx
+++ b/web/src/components/login-gate.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { createContext, useCallback, useContext, useEffect, useState } from 'react'
+
+import { authAPI, type AuthSession } from '@/lib/api'
+
+interface AuthState {
+  /** The logged-in user, or null when login is off or not yet established. */
+  username: string | null
+  logout: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthState>({ username: null, logout: async () => {} })
+
+export function useAuth(): AuthState {
+  return useContext(AuthContext)
+}
+
+/**
+ * Blocks the app behind a login form when the instance has user accounts.
+ * The gate is presentation only — the API guard is what actually protects
+ * every request — so if the session probe itself fails (API down, old
+ * backend), it fails open and lets the API's own errors surface.
+ */
+export function LoginGate({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = useState<AuthSession | null>(null)
+  const [probeFailed, setProbeFailed] = useState(false)
+
+  const refresh = useCallback(async () => {
+    try {
+      setSession(await authAPI.session())
+      setProbeFailed(false)
+    } catch {
+      setProbeFailed(true)
+    }
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const logout = useCallback(async () => {
+    await authAPI.logout().catch(() => undefined)
+    await refresh()
+  }, [refresh])
+
+  if (!session && !probeFailed) {
+    // Nothing until the probe answers: flashing the app to a logged-out user
+    // would leak nothing (requests would 401) but looks broken.
+    return null
+  }
+
+  if (session && session.user_auth_enabled && !session.authenticated) {
+    return <LoginScreen onLoggedIn={setSession} />
+  }
+
+  return (
+    <AuthContext.Provider value={{ username: session?.username ?? null, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+function LoginScreen({ onLoggedIn }: { onLoggedIn: (session: AuthSession) => void }) {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  async function submit(event: React.FormEvent) {
+    event.preventDefault()
+    setBusy(true)
+    setError(null)
+    try {
+      onLoggedIn(await authAPI.login(username, password))
+    } catch (err) {
+      setError(String(err instanceof Error ? err.message : err))
+      setPassword('')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex h-screen items-center justify-center">
+      <form onSubmit={submit} className="panel flex w-[300px] flex-col gap-3 p-5">
+        <h1 className="text-[14px] font-semibold">Sign in</h1>
+        <label className="flex flex-col gap-1">
+          <span className="text-ink-dim">Username</span>
+          <input
+            className="field"
+            value={username}
+            onChange={(event) => setUsername(event.target.value)}
+            autoComplete="username"
+            autoFocus
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-ink-dim">Password</span>
+          <input
+            type="password"
+            className="field"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            autoComplete="current-password"
+          />
+        </label>
+        {error && <p className="text-danger">{error}</p>}
+        <button type="submit" className="btn btn-primary" disabled={busy || !username || !password}>
+          {busy ? 'Signing in…' : 'Sign in'}
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -354,6 +354,7 @@ export interface SystemConfig {
   port: number
   database_path: string
   api_key_set: boolean
+  user_auth_enabled: boolean
   encryption_enabled: boolean
   cors_origins: string[]
   camoufox_available: boolean
@@ -377,6 +378,32 @@ export const presetsAPI = {
       `${API_PREFIX}/fingerprints/presets${toQuery({ os })}`,
     )
     return body.data.presets
+  },
+}
+
+/** The caller's authentication state, from GET /auth/session. */
+export interface AuthSession {
+  user_auth_enabled: boolean
+  authenticated: boolean
+  username: string | null
+}
+
+// The session lives in an HttpOnly cookie the browser sends by itself on this
+// same-origin app; nothing here stores or reads a token.
+export const authAPI = {
+  session(): Promise<AuthSession> {
+    return request<AuthSession>(`${API_PREFIX}/auth/session`)
+  },
+
+  login(username: string, password: string): Promise<AuthSession> {
+    return request<AuthSession>(`${API_PREFIX}/auth/login`, {
+      method: 'POST',
+      body: JSON.stringify({ username, password }),
+    })
+  },
+
+  logout(): Promise<unknown> {
+    return request<unknown>(`${API_PREFIX}/auth/logout`, { method: 'POST' })
   },
 }
 


### PR DESCRIPTION
Closes the roadmap item "Authentication for multi-user or hosted deployments, beyond the optional API key."

The API key is a machine-to-machine secret: one value, all-or-nothing, no identity. It stays exactly as it is. What was missing is human login for a deployment more than one person can reach.

## Decisions

**argon2id (`argon2-cffi`), a runtime dependency.** OWASP's first choice: memory-hard, so cracking a leaked SQLite file is expensive in a way bcrypt is not, and without bcrypt's silent 72-byte truncation. `check_needs_rehash` upgrades stored hashes transparently on login.

**Server-side opaque tokens in an HttpOnly cookie** — not JWT, not bearer. The app serves the UI same-origin from one process, so a cookie needs no token-handling code in the static UI and HttpOnly keeps the credential away from any XSS. Server-side because **logout must actually invalidate** — a signed token stays valid until it expires. The database stores only the SHA-256 of the token, so a stolen database contains nothing replayable. `HttpOnly; SameSite=Lax; Path=/`, `Secure` when the request is HTTPS or `CPM_SECURE_COOKIES=1` (needed behind a TLS-terminating proxy, where the app itself sees plain HTTP).

**Auth is on exactly when a user exists — no env flag.** A flag can desync from the database in both directions: flag on with no users is a lockout, flag off with users is false security. Existence cannot. It also means `camoufox-pm user add` takes effect on a running server with no restart.

**CLI-only bootstrapping, no self-registration.** `camoufox-pm user add|passwd|remove|list`, password via double `getpass` or `--password-stdin` — never argv, never env. For a self-hosted admin tool, requiring shell access to mint accounts is safer than an open registration endpoint, and it dissolves the chicken-and-egg problem. Removing the last user turns login back off, and the CLI says so.

**Flat roles, deliberately.** Profiles are shared instance-wide; there is no per-user resource, so a role system would protect nothing. The `users` table can grow a column later without migration pain.

## The three states, each verified

| State | Behaviour |
|---|---|
| (a) nothing configured | loopback, open — **byte-for-byte as before**; this is how most people run it |
| (b) `CPM_API_KEY` set | machine clients unchanged; `require_api_key` itself untouched |
| (c) users exist | a valid session **or** a valid API key passes |

## Verified by me on a running server, not taken from the agent's report

```
state (a) no config      GET /api/v1/profiles          → 200   (open default intact)
user added while running GET /api/v1/profiles          → 401   (no restart needed)
wrong password           → {"code":"unauthorized","message":"Invalid username or password"}
unknown user             → byte-identical response     (no user enumeration)
login                    Set-Cookie: HttpOnly; SameSite=lax; Max-Age=604800, no Secure on plain HTTP
with cookie              → 200
after logout, replayed   → 401                          (server-side row deleted)
forged 43-char cookie    → 401
state (c) + API key      no creds 401 / key 200 / wrong key 401
/health unauthenticated  → 200                          (probes must not need a login)
```

Credential hygiene, checked directly against the database and the log: the `sessions` table has **no raw-token column** (`token_hash` only, and the stored value is not the token); `password_hash` is `$argon2id$v=19$…`; neither the password nor any hash appears in `/auth/session` or anywhere in the server log.

## Gates — verified independently in a fresh worktree

I re-ran the `HOME=$(mktemp -d)` form the agent's sandbox had refused:

```
ruff / format / mypy (32 files)   clean
HOME=$(mktemp -d) pytest -m "not browser"   312 passed, 20 deselected  (+23)
tsc / next lint / next build      clean
```

New endpoints follow the 1.0 contract (`/api/v1`, the single error shape, typed models, stable operation ids); `system/config` gains an additive `user_auth_enabled`. New tables are created in the same init path as the `fingerprint` migration, with a unit test that builds a pre-auth database containing a profile and proves it gains the tables with the row intact.

`SECURITY.md` documents all three states and includes the explicit caveat that there is no rate limiting beyond a fixed delay — front the app with a proxy if it is exposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)