### PR TITLE
Schedule launches and browser refreshes — and not hardware rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,30 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   before. `POST /api/v1/auth/login`, `POST /api/v1/auth/logout`,
   `GET /api/v1/auth/session`; existing databases gain the `users` and
   `sessions` tables on first start without touching existing rows.
+- **Task scheduling.** A profile can now be opened on a schedule (account
+  warming, a regular session — with an optional "close after N minutes" so the
+  session ends by itself), and its pinned fingerprint can be moved onto the
+  installed browser version on a schedule, so a long-lived profile keeps pace
+  with browser releases the way a real machine does. The scheduler runs inside
+  the `camoufox-pm` process — no cron, no extra service — and scheduled
+  launches go through the same session manager as manual ones. Schedules are
+  either *every N minutes* or *daily at HH:MM* on chosen weekdays, on the
+  server's clock; they persist in the database and survive restarts. Runs
+  missed while the app was closed are recorded as `missed` and skipped, never
+  replayed — a night's backlog of warming launches must not open at once on
+  startup. Every run is recorded (`ok`, `skipped`, `error`, `missed`; last 20
+  kept per schedule), one failing schedule never blocks another, and a schedule
+  whose profile is gone disables itself. New **Schedules** screen in the UI and
+  `GET/POST/PUT/DELETE /api/v1/schedules`, `POST /api/v1/schedules/{id}/run`,
+  `GET /api/v1/schedules/{id}/runs`.
+
+  **Deliberately absent: scheduled hardware rotation.** The roadmap item said
+  "automated fingerprint rotation", wording left over from before fingerprints
+  were pinned, when they changed every launch anyway. Rotating the hardware on
+  a timer would hand a warmed-up account a new GPU, screen and core count
+  overnight — exactly what the pinned machine exists to prevent — so it was not
+  built. Hardware regeneration stays a deliberate manual action; the honest
+  scheduled rotation is the browser-version refresh. See `docs/scheduling.md`.
 - **A stability contract for the REST API**, written down in `docs/api.md`:
   what 1.0 freezes (paths, field names, status codes, the error shape), what
   stays deliberately unstable (the `fingerprint` summary, launch internals),

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ from it in January still looks like the same computer in June.
   actions, and grouping by client or purpose.
 - **Browser control** — launch and stop a browser per profile; closing the window
   yourself is noticed and the session is cleaned up.
+- **Scheduling** — open a profile on a schedule (warming), and keep its pinned
+  browser version current automatically. Hardware never rotates on a timer, on
+  purpose — [docs/scheduling.md](docs/scheduling.md).
 - **Proxies** — HTTP, HTTPS and SOCKS, with passwords encrypted at rest when
   `CPM_SECRET_KEY` is set.
 - **Move a profile anywhere.** Export a profile with its fingerprint *and* its
@@ -139,6 +142,7 @@ User accounts for the web UI are managed from the CLI: `camoufox-pm user add
 | [docs/cli.md](docs/cli.md) | Every command and flag |
 | [docs/api.md](docs/api.md) | The REST API, endpoint by endpoint |
 | [docs/profile-settings.md](docs/profile-settings.md) | What each setting does, how the pinned machine works, and what Camoufox cannot do |
+| [docs/scheduling.md](docs/scheduling.md) | Scheduled launches and browser refresh, and why hardware rotation is not offered |
 | [docs/excel.md](docs/excel.md) | Bulk import and export |
 | [docs/accessibility-roadmap.md](docs/accessibility-roadmap.md) | Plan for reaching non-technical users |
 | [docs/releasing.md](docs/releasing.md) | Cutting a release |

--- a/docs/api.md
+++ b/docs/api.md
@@ -321,6 +321,63 @@ as `fingerprint_preset` when creating a profile.
 
 The catalogue reads without the browser installed; pinning one does not.
 
+## Schedules
+
+```http
+GET    /api/v1/schedules
+POST   /api/v1/schedules
+GET    /api/v1/schedules/{id}
+PUT    /api/v1/schedules/{id}
+DELETE /api/v1/schedules/{id}
+POST   /api/v1/schedules/{id}/run
+GET    /api/v1/schedules/{id}/runs
+```
+
+A schedule runs one of two actions against a profile: `launch` (open its
+browser; `run_minutes` optionally closes it again that many minutes later) or
+`refresh_browser` (move its pinned fingerprint onto the installed browser
+version, hardware untouched). Regenerating the hardware fingerprint is
+deliberately **not** schedulable — it would make the profile a new machine on a
+timer, which is what the pin exists to prevent; see
+[scheduling.md](scheduling.md).
+
+```json
+{
+  "profile_id": "a1b2c3d4",
+  "action": "launch",
+  "kind": "daily",
+  "at_time": "09:00",
+  "days": [0, 1, 2, 3, 4],
+  "run_minutes": 15
+}
+```
+
+- `kind` is `"interval"` with `interval_minutes`, or `"daily"` with `at_time`
+  (`HH:MM`, 24-hour, read on the **server's** clock) and optional `days`
+  (weekdays the schedule fires, `0` = Monday … `6` = Sunday; omitted = every
+  day). A body whose fields do not match its `kind` fails validation.
+- Creating against an unknown profile returns `400`. Deleting a profile deletes
+  its schedules.
+- The response carries `profile_name`, the planned `next_run_at` and the
+  `last_run`, so a client does not join these itself.
+
+`PUT` updates a schedule; omitted fields are left alone, and changing the
+timing (or re-enabling) recomputes `next_run_at` from now. `enabled: false`
+pauses a schedule without losing it.
+
+`POST .../run` executes the action immediately, records the outcome, and does
+**not** move the planned next run; it works on a paused schedule too. The run
+record is returned:
+
+```json
+{"schedule_id": "x9y8z7w6", "outcome": "ok", "message": "Browser launched", ...}
+```
+
+`GET .../runs` lists the newest runs, newest first; the last 20 are kept per
+schedule. `outcome` is `ok`, `skipped` (the browser was already running),
+`error` (the message says why), or `missed` — the run fell due while the app
+was not running and was skipped, never replayed.
+
 ## Groups
 
 ```http

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -41,6 +41,18 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
   nothing configured is as open as before (loopback), the API key keeps
   machine clients working unchanged, and the moment a user exists humans must
   log in. See [SECURITY.md](../SECURITY.md#authentication).
+- Task scheduling, in-process and stored in the database: open a profile's
+  browser on a schedule (with an optional self-closing session length), and
+  move its pinned fingerprint onto the installed browser version on a schedule.
+  Runs missed while the app was closed are recorded and skipped, not replayed.
+  This item was originally written as "task scheduling and automated
+  fingerprint rotation"; the second half was **deliberately not built**. The
+  wording predated pinned fingerprints, when the hardware changed every launch
+  anyway — now rotating it on a timer would hand a warmed-up account a new
+  machine overnight, which is exactly what the pin exists to prevent. Hardware
+  regeneration stays a manual action; the scheduled browser-version refresh is
+  the rotation that imitates what real machines do. See
+  [scheduling.md](scheduling.md).
 
 ## Now (0.1.x)
 
@@ -48,7 +60,7 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
 
 ## Next
 
-- Task scheduling and automated fingerprint rotation.
+- Nothing committed yet; the ideas below are candidates, not promises.
 
 ## Later / ideas
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -1,0 +1,56 @@
+# Scheduling
+
+The app can run two things against a profile on a schedule, from the
+**Schedules** screen or the [REST API](api.md#schedules). The scheduler lives
+inside the `camoufox-pm` process — no cron, no extra service — because that
+process owns the browser sessions: a scheduled launch goes through the same
+session manager as pressing *Open*, so the running-browsers list, the
+close-on-window-close handling and the usage log all behave identically.
+
+## What can be scheduled
+
+- **Open the browser.** For account warming or any regular session. If the
+  profile's browser is already running when the schedule fires, the run is
+  recorded as *skipped* and nothing is touched. An optional *close after N
+  minutes* ends the session by itself, so a 03:00 warming run does not leave a
+  window open until someone notices.
+- **Refresh the browser version.** A pinned fingerprint never ages on its own,
+  so a long-lived profile keeps advertising the Firefox release it was created
+  with. This moves the pin onto the browser currently installed — the same
+  action as the *Update* button — changing **only** the version. The screen,
+  GPU, cores, fonts and noise seeds stay. That is exactly what a real machine
+  looks like after its browser updates, which real machines do on their own
+  schedule; doing it automatically is the point.
+
+## What deliberately cannot be scheduled
+
+**Regenerating the hardware fingerprint.** The pinned machine exists so that a
+profile is *the same computer* every session — that guarantee is the core of
+this product, proven with real-browser tests (see
+[profile-settings.md](profile-settings.md)). Rotating the hardware on a timer
+would undo it: a site that has seen one GPU, one screen and one core count for
+months would suddenly see another at 3am, which is precisely the signal a
+long-lived account must never emit. "Automated fingerprint rotation" made
+sense before pinning existed, when the fingerprint changed every launch anyway;
+now it would be an automated way to look suspicious.
+
+Regenerating stays available as a deliberate, manual action — *Regenerate
+fingerprint* on the profile, which warns about what it costs.
+
+## How schedules fire
+
+- **Two expressions.** *Every N minutes*, or *daily at HH:MM* on chosen
+  weekdays. Not cron: the two forms cover warming and maintenance, they can be
+  displayed back unambiguously, and there is no syntax to get wrong.
+- **Whose clock?** The server's — the machine running `camoufox-pm`. In the
+  normal single-machine setup that is also your clock. If you run the server
+  remotely, "09:00" is 09:00 *there*.
+- **Missed runs are skipped, not replayed.** If the app was closed when a run
+  was due, the gap is recorded in the run history as one *missed* entry and the
+  schedule waits for its next occurrence. A warming launch is only meaningful
+  at its time, and replaying a night's backlog would open every missed browser
+  at once on startup.
+- **Failures don't stop the scheduler.** Each run is recorded — *ok*,
+  *skipped*, *error* or *missed*, with a message — and one failing schedule
+  never blocks another. A schedule whose profile has been deleted disables
+  itself. The last 20 runs are kept per schedule.

--- a/src/camoufox_pm/api/dependencies.py
+++ b/src/camoufox_pm/api/dependencies.py
@@ -8,9 +8,11 @@ from camoufox_pm.config import get_settings
 from camoufox_pm.core import auth
 from camoufox_pm.core.database import StorageManager
 from camoufox_pm.core.profile_manager import ProfileManager
+from camoufox_pm.core.scheduler import TaskScheduler
 
 _storage_manager: StorageManager | None = None
 _profile_manager: ProfileManager | None = None
+_scheduler: TaskScheduler | None = None
 
 
 def set_storage_manager(storage_manager: StorageManager) -> None:
@@ -46,6 +48,19 @@ def _api_key_matches(x_api_key: str | None) -> bool:
         return False
     # Constant-time comparison to avoid leaking the key via response timing.
     return hmac.compare_digest(x_api_key, configured)
+
+
+def set_scheduler(scheduler: TaskScheduler) -> None:
+    """Register the shared ``TaskScheduler`` instance."""
+    global _scheduler
+    _scheduler = scheduler
+
+
+def get_scheduler() -> TaskScheduler:
+    """Return the shared ``TaskScheduler`` instance."""
+    if _scheduler is None:
+        raise HTTPException(status_code=500, detail="TaskScheduler is not initialized")
+    return _scheduler
 
 
 async def require_api_key(x_api_key: str | None = Header(default=None)) -> None:

--- a/src/camoufox_pm/api/models/schedules.py
+++ b/src/camoufox_pm/api/models/schedules.py
@@ -1,0 +1,137 @@
+"""API models for schedule endpoints."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from camoufox_pm.core.models import (
+    Schedule,
+    ScheduleAction,
+    ScheduleKind,
+    ScheduleRun,
+    ScheduleRunOutcome,
+)
+
+
+class ScheduleCreateRequest(BaseModel):
+    """Request body for creating a schedule.
+
+    The cross-field rules (an interval schedule needs ``interval_minutes``, a
+    daily one ``at_time``) are enforced here so they fail as request
+    validation — the same 422 shape as every other bad field.
+    """
+
+    profile_id: str = Field(..., min_length=1)
+    action: ScheduleAction
+    kind: ScheduleKind
+    interval_minutes: int | None = Field(
+        None, ge=1, le=40320, description="Every N minutes (interval schedules)"
+    )
+    at_time: str | None = Field(None, description="HH:MM, 24-hour, on the server's clock")
+    days: list[int] | None = Field(
+        None, description="Weekdays a daily schedule fires, 0=Monday … 6=Sunday; empty = every day"
+    )
+    run_minutes: int | None = Field(
+        None, ge=1, le=1440, description="Launch only: close the browser after this many minutes"
+    )
+    enabled: bool = True
+
+    @model_validator(mode="after")
+    def _expression_is_complete(self) -> "ScheduleCreateRequest":
+        # Validate through the core model so the rules live in one place.
+        Schedule(profile_id=self.profile_id or "x", **self.model_dump(exclude={"profile_id"}))
+        return self
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "profile_id": "a1b2c3d4",
+                "action": "launch",
+                "kind": "daily",
+                "at_time": "09:00",
+                "days": [0, 1, 2, 3, 4],
+                "run_minutes": 15,
+            }
+        }
+    )
+
+
+class ScheduleUpdateRequest(BaseModel):
+    """Request body for updating a schedule. Omitted fields are left alone."""
+
+    action: ScheduleAction | None = None
+    kind: ScheduleKind | None = None
+    interval_minutes: int | None = Field(None, ge=1, le=40320)
+    at_time: str | None = None
+    days: list[int] | None = None
+    run_minutes: int | None = Field(None, ge=1, le=1440)
+    enabled: bool | None = None
+
+    model_config = ConfigDict(
+        json_schema_extra={"example": {"kind": "interval", "interval_minutes": 120}}
+    )
+
+
+class ScheduleRunResponse(BaseModel):
+    """One recorded firing of a schedule."""
+
+    id: int | None
+    schedule_id: str
+    started_at: datetime
+    finished_at: datetime | None
+    outcome: ScheduleRunOutcome
+    message: str | None
+
+    @classmethod
+    def from_run(cls, run: ScheduleRun) -> "ScheduleRunResponse":
+        return cls(**run.model_dump())
+
+
+class ScheduleResponse(BaseModel):
+    """Schedule data returned by the API."""
+
+    id: str
+    profile_id: str
+    profile_name: str | None = Field(
+        None, description="Resolved for display; null if the profile is gone"
+    )
+    action: ScheduleAction
+    kind: ScheduleKind
+    interval_minutes: int | None
+    at_time: str | None
+    days: list[int] | None
+    run_minutes: int | None
+    enabled: bool
+    next_run_at: datetime | None = Field(
+        None, description="Next planned firing, on the server's clock"
+    )
+    last_run: ScheduleRunResponse | None = Field(None, description="Most recent recorded firing")
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_schedule(
+        cls,
+        schedule: Schedule,
+        profile_name: str | None = None,
+        last_run: ScheduleRun | None = None,
+    ) -> "ScheduleResponse":
+        return cls(
+            profile_name=profile_name,
+            last_run=ScheduleRunResponse.from_run(last_run) if last_run else None,
+            **schedule.model_dump(),
+        )
+
+
+class ScheduleListResponse(BaseModel):
+    """List of schedules."""
+
+    schedules: list[ScheduleResponse]
+    total: int
+
+
+class ScheduleRunListResponse(BaseModel):
+    """Run history of one schedule, newest first."""
+
+    runs: list[ScheduleRunResponse]
+    total: int

--- a/src/camoufox_pm/api/routes/__init__.py
+++ b/src/camoufox_pm/api/routes/__init__.py
@@ -1,5 +1,5 @@
 """API routes for Camoufox Profile Manager."""
 
-from . import groups, profiles, system
+from . import groups, profiles, schedules, system
 
-__all__ = ["profiles", "groups", "system"]
+__all__ = ["profiles", "groups", "schedules", "system"]

--- a/src/camoufox_pm/api/routes/schedules.py
+++ b/src/camoufox_pm/api/routes/schedules.py
@@ -1,0 +1,204 @@
+"""API routes for schedules: recurring launches and browser-version refreshes."""
+
+from fastapi import APIRouter, HTTPException, status
+from loguru import logger
+
+from camoufox_pm.api.dependencies import get_scheduler, get_storage_manager
+from camoufox_pm.api.models.schedules import (
+    ScheduleCreateRequest,
+    ScheduleListResponse,
+    ScheduleResponse,
+    ScheduleRunListResponse,
+    ScheduleRunResponse,
+    ScheduleUpdateRequest,
+)
+from camoufox_pm.api.models.system import ApiResponse
+from camoufox_pm.core.models import Schedule
+from camoufox_pm.core.scheduler import next_run_after
+
+router = APIRouter()
+
+# Editing any of these changes when the schedule fires, so next_run_at is
+# recomputed; a rename-style edit leaves the planned time alone.
+_TIMING_FIELDS = {"kind", "interval_minutes", "at_time", "days", "enabled"}
+
+
+async def _respond(schedule: Schedule) -> ScheduleResponse:
+    """Build the response shape: the schedule plus display context."""
+    storage = get_storage_manager()
+    profile = await storage.get_profile(schedule.profile_id)
+    runs = await storage.list_schedule_runs(schedule.id, limit=1)
+    return ScheduleResponse.from_schedule(
+        schedule,
+        profile_name=profile.name if profile else None,
+        last_run=runs[0] if runs else None,
+    )
+
+
+@router.get(
+    "/schedules",
+    response_model=ScheduleListResponse,
+    operation_id="list_schedules",
+    summary="List schedules.",
+    description="List all schedules. They are few, so the list is not paginated.",
+)
+async def list_schedules():
+    """List all schedules with their profile names and last outcomes."""
+    try:
+        schedules = await get_storage_manager().list_schedules()
+        responses = [await _respond(schedule) for schedule in schedules]
+        return ScheduleListResponse(schedules=responses, total=len(responses))
+    except Exception as exc:
+        logger.error(f"Failed to list schedules: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post(
+    "/schedules",
+    response_model=ScheduleResponse,
+    status_code=status.HTTP_201_CREATED,
+    operation_id="create_schedule",
+    summary="Create a schedule.",
+    description=(
+        "Create a recurring task against a profile: launch its browser, or move its "
+        "pinned fingerprint onto the installed browser version. Daily times are read "
+        "on the server's clock. Regenerating hardware is deliberately not schedulable."
+    ),
+)
+async def create_schedule(request: ScheduleCreateRequest):
+    """Create a schedule and plan its first run."""
+    try:
+        storage = get_storage_manager()
+        profile = await storage.get_profile(request.profile_id)
+        if not profile:
+            raise HTTPException(
+                status_code=400, detail=f"Profile with ID {request.profile_id} not found"
+            )
+
+        schedule = Schedule(**request.model_dump())
+        if schedule.enabled:
+            schedule.next_run_at = next_run_after(schedule, get_scheduler().clock())
+        await storage.save_schedule(schedule)
+        logger.info(f"Created schedule {schedule.id} ({schedule.action}) for {profile.name}")
+        return await _respond(schedule)
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error(f"Failed to create schedule: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get(
+    "/schedules/{schedule_id}",
+    response_model=ScheduleResponse,
+    operation_id="get_schedule",
+    summary="Get a schedule.",
+    description="Get one schedule with its profile name and last outcome.",
+)
+async def get_schedule(schedule_id: str):
+    """Get a schedule by ID."""
+    schedule = await get_storage_manager().get_schedule(schedule_id)
+    if not schedule:
+        raise HTTPException(status_code=404, detail=f"Schedule with ID {schedule_id} not found")
+    return await _respond(schedule)
+
+
+@router.put(
+    "/schedules/{schedule_id}",
+    response_model=ScheduleResponse,
+    operation_id="update_schedule",
+    summary="Update a schedule.",
+    description=(
+        "Update a schedule. Omitted fields are left alone. Changing the timing or "
+        "re-enabling recomputes the next run from now."
+    ),
+)
+async def update_schedule(schedule_id: str, request: ScheduleUpdateRequest):
+    """Update a schedule."""
+    try:
+        storage = get_storage_manager()
+        schedule = await storage.get_schedule(schedule_id)
+        if not schedule:
+            raise HTTPException(status_code=404, detail=f"Schedule with ID {schedule_id} not found")
+
+        sent = request.model_dump(exclude_unset=True)
+        # Rebuild through the model so the cross-field rules hold for the
+        # merged result — switching kind without supplying the matching field
+        # must fail here, not at fire time.
+        now = get_scheduler().clock()
+        merged = {**schedule.model_dump(), **sent, "updated_at": now}
+        updated = Schedule(**merged)
+        if _TIMING_FIELDS & sent.keys():
+            updated.next_run_at = next_run_after(updated, now) if updated.enabled else None
+        await storage.save_schedule(updated)
+        logger.info(f"Updated schedule {schedule_id}")
+        return await _respond(updated)
+    except HTTPException:
+        raise
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.error(f"Failed to update schedule {schedule_id}: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.delete(
+    "/schedules/{schedule_id}",
+    response_model=ApiResponse[None],
+    operation_id="delete_schedule",
+    summary="Delete a schedule.",
+    description="Delete a schedule and its run history.",
+)
+async def delete_schedule(schedule_id: str):
+    """Delete a schedule."""
+    deleted = await get_storage_manager().delete_schedule(schedule_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Schedule with ID {schedule_id} not found")
+    logger.info(f"Deleted schedule {schedule_id}")
+    return ApiResponse(success=True, message=f"Schedule {schedule_id} deleted", data=None)
+
+
+@router.post(
+    "/schedules/{schedule_id}/run",
+    response_model=ScheduleRunResponse,
+    operation_id="run_schedule",
+    summary="Run a schedule now.",
+    description=(
+        "Execute the schedule's task immediately and record the outcome. The next "
+        "planned run is left alone. Works on a disabled schedule."
+    ),
+)
+async def run_schedule(schedule_id: str):
+    """Run a schedule immediately."""
+    schedule = await get_storage_manager().get_schedule(schedule_id)
+    if not schedule:
+        raise HTTPException(status_code=404, detail=f"Schedule with ID {schedule_id} not found")
+    try:
+        run = await get_scheduler().run_now(schedule)
+        return ScheduleRunResponse.from_run(run)
+    except Exception as exc:
+        # execute() records failures as run outcomes; reaching here means the
+        # recording itself broke.
+        logger.error(f"Failed to run schedule {schedule_id}: {exc}")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get(
+    "/schedules/{schedule_id}/runs",
+    response_model=ScheduleRunListResponse,
+    operation_id="list_schedule_runs",
+    summary="Get a schedule's run history.",
+    description="The newest recorded firings, newest first. History is capped at 20 runs.",
+)
+async def list_schedule_runs(schedule_id: str):
+    """Get the run history of a schedule."""
+    storage = get_storage_manager()
+    schedule = await storage.get_schedule(schedule_id)
+    if not schedule:
+        raise HTTPException(status_code=404, detail=f"Schedule with ID {schedule_id} not found")
+    runs = await storage.list_schedule_runs(schedule_id)
+    return ScheduleRunListResponse(
+        runs=[ScheduleRunResponse.from_run(run) for run in runs], total=len(runs)
+    )

--- a/src/camoufox_pm/core/database.py
+++ b/src/camoufox_pm/core/database.py
@@ -15,6 +15,8 @@ from .models import (
     ProfileGroup,
     ProfileStatus,
     ProxyConfig,
+    Schedule,
+    ScheduleRun,
     UsageStats,
 )
 
@@ -143,6 +145,36 @@ class DatabaseManager:
             )
         """)
 
+        # Scheduled tasks. New tables need no _migrate entry: IF NOT EXISTS adds
+        # them to an existing database without touching what is already there.
+        self._connection.execute("""
+            CREATE TABLE IF NOT EXISTS schedules (
+                id TEXT PRIMARY KEY,
+                profile_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                interval_minutes INTEGER,
+                at_time TEXT,
+                days TEXT,
+                run_minutes INTEGER,
+                enabled BOOLEAN DEFAULT 1,
+                next_run_at TIMESTAMP,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        self._connection.execute("""
+            CREATE TABLE IF NOT EXISTS schedule_runs (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                schedule_id TEXT NOT NULL,
+                started_at TIMESTAMP NOT NULL,
+                finished_at TIMESTAMP,
+                outcome TEXT NOT NULL,
+                message TEXT
+            )
+        """)
+
         self._connection.commit()
 
     async def _create_indexes(self):
@@ -153,6 +185,8 @@ class DatabaseManager:
             "CREATE INDEX IF NOT EXISTS idx_profiles_created ON profiles(created_at)",
             "CREATE INDEX IF NOT EXISTS idx_usage_stats_profile ON usage_stats(profile_id)",
             "CREATE INDEX IF NOT EXISTS idx_usage_stats_timestamp ON usage_stats(timestamp)",
+            "CREATE INDEX IF NOT EXISTS idx_schedules_profile ON schedules(profile_id)",
+            "CREATE INDEX IF NOT EXISTS idx_schedule_runs_schedule ON schedule_runs(schedule_id)",
         ]
 
         for index_sql in indexes:
@@ -207,7 +241,13 @@ class DatabaseManager:
         logger.debug(f"Profile {profile.name} updated")
 
     async def delete_profile(self, profile_id: str) -> bool:
-        """Delete a profile."""
+        """Delete a profile, and the schedules that would otherwise fire against it."""
+        self._connection.execute(
+            "DELETE FROM schedule_runs WHERE schedule_id IN "
+            "(SELECT id FROM schedules WHERE profile_id = ?)",
+            (profile_id,),
+        )
+        self._connection.execute("DELETE FROM schedules WHERE profile_id = ?", (profile_id,))
         cursor = self._connection.execute("DELETE FROM profiles WHERE id = ?", (profile_id,))
         self._connection.commit()
         deleted = cursor.rowcount > 0
@@ -453,8 +493,130 @@ class DatabaseManager:
         )
         self._connection.commit()
         return cursor.rowcount
+    # --- Schedules ---
+
+    async def save_schedule(self, schedule: Schedule):
+        """Insert or replace a schedule."""
+        self._connection.execute(
+            """
+            INSERT OR REPLACE INTO schedules (
+                id, profile_id, action, kind, interval_minutes, at_time, days,
+                run_minutes, enabled, next_run_at, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+            (
+                schedule.id,
+                schedule.profile_id,
+                schedule.action,
+                schedule.kind,
+                schedule.interval_minutes,
+                schedule.at_time,
+                json.dumps(schedule.days) if schedule.days else None,
+                schedule.run_minutes,
+                schedule.enabled,
+                schedule.next_run_at.isoformat() if schedule.next_run_at else None,
+                schedule.created_at.isoformat(),
+                schedule.updated_at.isoformat(),
+            ),
+        )
+        self._connection.commit()
+
+    async def get_schedule(self, schedule_id: str) -> Schedule | None:
+        """Get a schedule by ID."""
+        cursor = self._connection.execute("SELECT * FROM schedules WHERE id = ?", (schedule_id,))
+        row = cursor.fetchone()
+        return self._row_to_schedule(row) if row else None
+
+    async def list_schedules(self, profile_id: str | None = None) -> list[Schedule]:
+        """List schedules, oldest first so the UI order is stable."""
+        if profile_id:
+            cursor = self._connection.execute(
+                "SELECT * FROM schedules WHERE profile_id = ? ORDER BY created_at",
+                (profile_id,),
+            )
+        else:
+            cursor = self._connection.execute("SELECT * FROM schedules ORDER BY created_at")
+        return [self._row_to_schedule(row) for row in cursor.fetchall()]
+
+    async def delete_schedule(self, schedule_id: str) -> bool:
+        """Delete a schedule and its run history."""
+        self._connection.execute("DELETE FROM schedule_runs WHERE schedule_id = ?", (schedule_id,))
+        cursor = self._connection.execute("DELETE FROM schedules WHERE id = ?", (schedule_id,))
+        self._connection.commit()
+        return cursor.rowcount > 0
+
+    async def log_schedule_run(self, run: ScheduleRun, keep: int = 20) -> ScheduleRun:
+        """Record one firing and prune the history to the newest ``keep`` rows.
+
+        Bounded per schedule rather than by age: an every-five-minutes schedule
+        would otherwise write hundreds of rows a day into a database that also
+        holds the profiles.
+        """
+        cursor = self._connection.execute(
+            """
+            INSERT INTO schedule_runs (schedule_id, started_at, finished_at, outcome, message)
+            VALUES (?, ?, ?, ?, ?)
+        """,
+            (
+                run.schedule_id,
+                run.started_at.isoformat(),
+                run.finished_at.isoformat() if run.finished_at else None,
+                run.outcome,
+                run.message,
+            ),
+        )
+        run.id = cursor.lastrowid
+        self._connection.execute(
+            """
+            DELETE FROM schedule_runs WHERE schedule_id = ? AND id NOT IN (
+                SELECT id FROM schedule_runs WHERE schedule_id = ? ORDER BY id DESC LIMIT ?
+            )
+        """,
+            (run.schedule_id, run.schedule_id, keep),
+        )
+        self._connection.commit()
+        return run
+
+    async def list_schedule_runs(self, schedule_id: str, limit: int = 20) -> list[ScheduleRun]:
+        """Get the newest runs of a schedule, newest first."""
+        cursor = self._connection.execute(
+            "SELECT * FROM schedule_runs WHERE schedule_id = ? ORDER BY id DESC LIMIT ?",
+            (schedule_id, limit),
+        )
+        return [
+            ScheduleRun(
+                id=row["id"],
+                schedule_id=row["schedule_id"],
+                started_at=datetime.fromisoformat(row["started_at"]),
+                finished_at=(
+                    datetime.fromisoformat(row["finished_at"]) if row["finished_at"] else None
+                ),
+                outcome=row["outcome"],
+                message=row["message"],
+            )
+            for row in cursor.fetchall()
+        ]
 
     # --- Utilities ---
+
+    def _row_to_schedule(self, row) -> Schedule:
+        """Convert a database row into a Schedule object."""
+        return Schedule(
+            id=row["id"],
+            profile_id=row["profile_id"],
+            action=row["action"],
+            kind=row["kind"],
+            interval_minutes=row["interval_minutes"],
+            at_time=row["at_time"],
+            days=json.loads(row["days"]) if row["days"] else None,
+            run_minutes=row["run_minutes"],
+            enabled=bool(row["enabled"]),
+            next_run_at=(
+                datetime.fromisoformat(row["next_run_at"]) if row["next_run_at"] else None
+            ),
+            created_at=datetime.fromisoformat(row["created_at"]),
+            updated_at=datetime.fromisoformat(row["updated_at"]),
+        )
 
     def _row_to_profile(self, row) -> Profile:
         """Convert a database row into a Profile object."""
@@ -582,6 +744,24 @@ class StorageManager:
 
     async def delete_expired_sessions(self) -> int:
         return await self.db.delete_expired_sessions()
+    # Schedule methods
+    async def save_schedule(self, schedule: Schedule):
+        await self.db.save_schedule(schedule)
+
+    async def get_schedule(self, schedule_id: str) -> Schedule | None:
+        return await self.db.get_schedule(schedule_id)
+
+    async def list_schedules(self, profile_id: str | None = None) -> list[Schedule]:
+        return await self.db.list_schedules(profile_id)
+
+    async def delete_schedule(self, schedule_id: str) -> bool:
+        return await self.db.delete_schedule(schedule_id)
+
+    async def log_schedule_run(self, run: ScheduleRun) -> ScheduleRun:
+        return await self.db.log_schedule_run(run)
+
+    async def list_schedule_runs(self, schedule_id: str, limit: int = 20) -> list[ScheduleRun]:
+        return await self.db.list_schedule_runs(schedule_id, limit)
 
     async def close(self):
         """Close the database."""

--- a/src/camoufox_pm/core/database.py
+++ b/src/camoufox_pm/core/database.py
@@ -493,6 +493,7 @@ class DatabaseManager:
         )
         self._connection.commit()
         return cursor.rowcount
+
     # --- Schedules ---
 
     async def save_schedule(self, schedule: Schedule):
@@ -744,6 +745,7 @@ class StorageManager:
 
     async def delete_expired_sessions(self) -> int:
         return await self.db.delete_expired_sessions()
+
     # Schedule methods
     async def save_schedule(self, schedule: Schedule):
         await self.db.save_schedule(schedule)

--- a/src/camoufox_pm/core/models.py
+++ b/src/camoufox_pm/core/models.py
@@ -1,12 +1,13 @@
 """Data models for the Camoufox profile management system."""
 
+import re
 import secrets
 import string
 from datetime import datetime
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 # Characters used for short IDs, excluding visually confusing ones (0, o, 1, l, i).
 _ID_ALPHABET = "".join(c for c in (string.ascii_lowercase + string.digits) if c not in "0o1li")
@@ -35,6 +36,11 @@ def generate_profile_id() -> str:
 
 def generate_group_id() -> str:
     """Generate a short ID for a group."""
+    return generate_short_id(8)
+
+
+def generate_schedule_id() -> str:
+    """Generate a short ID for a schedule."""
     return generate_short_id(8)
 
 
@@ -296,3 +302,95 @@ class SystemStatus(BaseModel):
     memory_usage: float
     disk_usage: float
     uptime_seconds: int
+
+
+class ScheduleAction(str, Enum):
+    """What a schedule does to its profile when it fires.
+
+    Deliberately absent: regenerating the hardware fingerprint. The pinned
+    machine exists so a profile stays the same computer between sessions;
+    swapping its GPU, screen and cores on a timer would hand a warmed-up
+    account new hardware overnight — the one thing the pin prevents. Hardware
+    regeneration stays a manual action (reset-fingerprint), which warns about
+    the cost. REFRESH_BROWSER is the honest scheduled rotation: it moves only
+    the browser version, which is what a real machine does when it updates.
+    """
+
+    LAUNCH = "launch"
+    REFRESH_BROWSER = "refresh_browser"
+
+
+class ScheduleKind(str, Enum):
+    """How a schedule's fire times are expressed."""
+
+    INTERVAL = "interval"  # every N minutes
+    DAILY = "daily"  # at HH:MM on the chosen weekdays
+
+
+class ScheduleRunOutcome(str, Enum):
+    """How one firing of a schedule ended."""
+
+    OK = "ok"
+    SKIPPED = "skipped"  # e.g. the browser was already running
+    ERROR = "error"
+    MISSED = "missed"  # fell due while the process was down; not replayed
+
+
+_TIME_OF_DAY = re.compile(r"^([01]\d|2[0-3]):[0-5]\d$")
+
+
+class Schedule(BaseModel):
+    """A recurring task against one profile.
+
+    ``at_time`` is read on the server's own clock: this is a single-process
+    tool that runs next to its browsers, so "09:00" means 09:00 where the
+    process runs, with no timezone bookkeeping to get wrong. ``days`` uses
+    Python's weekday numbering, 0 = Monday … 6 = Sunday; empty means every day.
+    """
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    id: str = Field(default_factory=generate_schedule_id)
+    profile_id: str
+    action: ScheduleAction
+    kind: ScheduleKind
+    interval_minutes: int | None = Field(None, ge=1)
+    at_time: str | None = None
+    days: list[int] | None = None
+    # Launch schedules only: close the browser this long after opening it, so a
+    # warming session ends by itself instead of staying open until the next run
+    # finds it and skips.
+    run_minutes: int | None = Field(None, ge=1)
+    enabled: bool = True
+    next_run_at: datetime | None = None
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+    @model_validator(mode="after")
+    def _expression_is_complete(self) -> "Schedule":
+        if self.kind == ScheduleKind.INTERVAL:
+            if not self.interval_minutes:
+                raise ValueError("An interval schedule needs interval_minutes")
+        else:
+            if not self.at_time or not _TIME_OF_DAY.match(self.at_time):
+                raise ValueError("A daily schedule needs at_time as HH:MM (24-hour)")
+        if self.days is not None:
+            if any(day < 0 or day > 6 for day in self.days):
+                raise ValueError("days entries are weekdays, 0 (Monday) to 6 (Sunday)")
+            self.days = sorted(set(self.days)) or None
+        if self.action == ScheduleAction.REFRESH_BROWSER and self.run_minutes:
+            raise ValueError("run_minutes only applies to launch schedules")
+        return self
+
+
+class ScheduleRun(BaseModel):
+    """The record of one firing of a schedule."""
+
+    id: int | None = None
+    schedule_id: str
+    started_at: datetime = Field(default_factory=datetime.now)
+    finished_at: datetime | None = None
+    outcome: ScheduleRunOutcome
+    message: str | None = None
+
+    model_config = ConfigDict(use_enum_values=True)

--- a/src/camoufox_pm/core/scheduler.py
+++ b/src/camoufox_pm/core/scheduler.py
@@ -1,0 +1,237 @@
+"""Run schedules against profiles from inside the app process.
+
+A plain asyncio loop over the schedules table — no APScheduler, no crontab.
+The app already owns the browser sessions, so a scheduled launch has to happen
+in this process and go through the same ``ProfileManager`` a manual one does;
+an external scheduler could only talk to the API and would be one more thing
+to install and keep running.
+
+What is schedulable is deliberately narrow: opening a profile's browser, and
+moving its pinned fingerprint onto the installed browser version. Hardware
+regeneration is not — see ``ScheduleAction`` in ``models.py`` for why.
+
+Time is read through an injectable ``now`` callable so tests can drive the
+clock instead of sleeping. All datetimes are naive local time, like the rest
+of the codebase: the process runs next to its browsers, and "09:00" means
+09:00 on this machine's clock.
+"""
+
+import asyncio
+from collections.abc import Callable
+from datetime import datetime, timedelta
+
+from loguru import logger
+
+from .database import StorageManager
+from .models import (
+    Schedule,
+    ScheduleAction,
+    ScheduleKind,
+    ScheduleRun,
+    ScheduleRunOutcome,
+)
+from .profile_manager import ProfileManager
+
+
+def next_run_after(schedule: Schedule, after: datetime) -> datetime:
+    """The first time this schedule should fire strictly after ``after``.
+
+    Always computed forward from ``after`` rather than from the previous fire
+    time, so a late or missed run can never produce a next run in the past —
+    which would make the schedule fire again immediately, forever.
+    """
+    if schedule.kind == ScheduleKind.INTERVAL:
+        assert schedule.interval_minutes  # validated on the model
+        return after + timedelta(minutes=schedule.interval_minutes)
+
+    assert schedule.at_time  # validated on the model
+    hour, minute = (int(part) for part in schedule.at_time.split(":"))
+    candidate = after.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if candidate <= after:
+        candidate += timedelta(days=1)
+    allowed = set(schedule.days) if schedule.days else set(range(7))
+    while candidate.weekday() not in allowed:
+        candidate += timedelta(days=1)
+    return candidate
+
+
+class TaskScheduler:
+    """Fire due schedules, record what happened, and never die doing it."""
+
+    def __init__(
+        self,
+        storage: StorageManager,
+        profile_manager: ProfileManager,
+        now: Callable[[], datetime] = datetime.now,
+        poll_seconds: float = 5.0,
+    ) -> None:
+        self.storage = storage
+        self.profiles = profile_manager
+        self._now = now
+        self.poll_seconds = poll_seconds
+        self._task: asyncio.Task[None] | None = None
+        self._stop: asyncio.Event | None = None
+        # Launch schedules with run_minutes: profile id -> when to close its
+        # browser. In memory only — if the process dies, its child browsers die
+        # with it, so there is nothing left to close after a restart.
+        self._timed_closes: dict[str, datetime] = {}
+
+    def clock(self) -> datetime:
+        """The scheduler's idea of now, so callers plan with the clock tests inject."""
+        return self._now()
+
+    async def start(self) -> None:
+        """Reconcile what fell due while we were down, then start the loop."""
+        await self.reconcile_missed()
+        self._stop = asyncio.Event()
+        self._task = asyncio.create_task(self._loop())
+        logger.info("Task scheduler started")
+
+    async def stop(self) -> None:
+        """Stop the loop. Safe to call without start()."""
+        if self._stop is not None:
+            self._stop.set()
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        logger.info("Task scheduler stopped")
+
+    async def reconcile_missed(self) -> None:
+        """Skip — never replay — occurrences that fell while the process was down.
+
+        A scheduled browser launch is only meaningful at its time: warming a
+        profile at 09:00 the next morning because the machine was off at 03:00
+        is at best pointless, and replaying a backlog would open every missed
+        browser at once on startup. A version refresh simply happens at its
+        next occurrence instead. The gap is recorded as one ``missed`` run per
+        schedule — one row, however many occurrences fell in it — so it is
+        visible in the history rather than silently absorbed.
+        """
+        now = self._now()
+        for schedule in await self.storage.list_schedules():
+            if not schedule.enabled:
+                continue
+            if schedule.next_run_at is not None and schedule.next_run_at <= now:
+                await self.storage.log_schedule_run(
+                    ScheduleRun(
+                        schedule_id=schedule.id,
+                        started_at=now,
+                        finished_at=now,
+                        outcome=ScheduleRunOutcome.MISSED,
+                        message=(
+                            f"Due {schedule.next_run_at:%Y-%m-%d %H:%M} while the app "
+                            "was not running; waiting for the next occurrence"
+                        ),
+                    )
+                )
+            if schedule.next_run_at is None or schedule.next_run_at <= now:
+                schedule.next_run_at = next_run_after(schedule, now)
+                schedule.updated_at = now
+                await self.storage.save_schedule(schedule)
+
+    async def _loop(self) -> None:
+        assert self._stop is not None
+        while not self._stop.is_set():
+            try:
+                await self.tick()
+            except Exception as exc:  # noqa: BLE001 - the loop must survive anything
+                logger.error(f"Scheduler tick failed: {exc}")
+            try:
+                # asyncio.TimeoutError: builtins.TimeoutError only matches it on 3.11+.
+                await asyncio.wait_for(self._stop.wait(), timeout=self.poll_seconds)
+            except asyncio.TimeoutError:  # noqa: UP041 - py310 support
+                pass
+
+    async def tick(self) -> None:
+        """One pass: close timed-out sessions, then fire everything due.
+
+        Due schedules run sequentially, each with its own error handling — one
+        that raises is recorded and the next still runs. Reading the table
+        every pass costs a few rows and means an edit made through the API is
+        picked up within one poll, with no cache to invalidate.
+        """
+        now = self._now()
+
+        for profile_id, close_at in list(self._timed_closes.items()):
+            if close_at <= now:
+                del self._timed_closes[profile_id]
+                try:
+                    # A no-op if the user already closed the window themselves.
+                    await self.profiles.close_browser(profile_id)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning(f"Timed close of {profile_id} failed: {exc}")
+
+        for schedule in await self.storage.list_schedules():
+            if not schedule.enabled or schedule.next_run_at is None:
+                continue
+            if schedule.next_run_at <= now:
+                # Advance before executing, so a run that crashes the process
+                # cannot leave a past next_run_at that fires again on startup.
+                schedule.next_run_at = next_run_after(schedule, now)
+                schedule.updated_at = now
+                await self.storage.save_schedule(schedule)
+                await self.execute(schedule)
+
+    async def run_now(self, schedule: Schedule) -> ScheduleRun:
+        """Execute a schedule immediately, leaving its next planned run alone.
+
+        Works on a disabled schedule too: pressing "run now" is the user doing
+        the task by hand, not the timer firing.
+        """
+        return await self.execute(schedule)
+
+    async def execute(self, schedule: Schedule) -> ScheduleRun:
+        """Run one schedule's action and record how it went."""
+        started = self._now()
+        outcome = ScheduleRunOutcome.ERROR
+        message: str | None = None
+
+        try:
+            profile = await self.profiles.get_profile(schedule.profile_id)
+            if profile is None:
+                # Deleting a profile deletes its schedules, so this is a race,
+                # not a normal path — but a schedule that can never succeed
+                # again must not keep firing every occurrence forever.
+                message = "Profile no longer exists; schedule disabled"
+                schedule.enabled = False
+                schedule.updated_at = started
+                await self.storage.save_schedule(schedule)
+            elif schedule.action == ScheduleAction.LAUNCH:
+                if self.profiles.browser_sessions.is_running(schedule.profile_id):
+                    outcome = ScheduleRunOutcome.SKIPPED
+                    message = "Browser already running; left it alone"
+                else:
+                    await self.profiles.launch_browser(schedule.profile_id)
+                    outcome = ScheduleRunOutcome.OK
+                    message = "Browser launched"
+                    if schedule.run_minutes:
+                        self._timed_closes[schedule.profile_id] = started + timedelta(
+                            minutes=schedule.run_minutes
+                        )
+                        message += f"; closing after {schedule.run_minutes} min"
+            else:  # ScheduleAction.REFRESH_BROWSER
+                refreshed = await self.profiles.refresh_browser_version(schedule.profile_id)
+                outcome = ScheduleRunOutcome.OK
+                if refreshed is not None and refreshed.fingerprint is not None:
+                    from . import fingerprint_store
+
+                    major = fingerprint_store.browser_major(refreshed.fingerprint)
+                    message = f"Pin moved onto Firefox {major}" if major else "Pin refreshed"
+                else:
+                    message = "Pin refreshed"
+        except Exception as exc:  # noqa: BLE001 - one bad run must not kill the loop
+            message = str(exc) or exc.__class__.__name__
+            logger.warning(f"Schedule {schedule.id} ({schedule.action}) failed: {message}")
+
+        run = ScheduleRun(
+            schedule_id=schedule.id,
+            started_at=started,
+            finished_at=self._now(),
+            outcome=outcome,
+            message=message,
+        )
+        return await self.storage.log_schedule_run(run)

--- a/src/camoufox_pm/main.py
+++ b/src/camoufox_pm/main.py
@@ -13,15 +13,17 @@ from camoufox_pm import __version__
 from camoufox_pm.api.dependencies import (
     require_auth,
     set_profile_manager,
+    set_scheduler,
     set_storage_manager,
 )
 from camoufox_pm.api.errors import install_error_handlers
 from camoufox_pm.api.middleware.logging import LoggingMiddleware
 from camoufox_pm.api.models.system import ErrorResponse, HealthResponse
-from camoufox_pm.api.routes import auth, groups, profiles, system
+from camoufox_pm.api.routes import auth, groups, profiles, schedules, system
 from camoufox_pm.config import get_settings
 from camoufox_pm.core.database import StorageManager
 from camoufox_pm.core.profile_manager import ProfileManager
+from camoufox_pm.core.scheduler import TaskScheduler
 
 settings = get_settings()
 
@@ -41,11 +43,18 @@ async def lifespan(app: FastAPI):
     set_storage_manager(storage_manager)
     set_profile_manager(profile_manager)
 
+    # In-process on purpose: the app owns the browser sessions, so scheduled
+    # launches must run where the sessions live, through the same manager.
+    scheduler = TaskScheduler(storage_manager, profile_manager)
+    await scheduler.start()
+    set_scheduler(scheduler)
+
     logger.info("API ready")
     try:
         yield
     finally:
         logger.info("Shutting down API...")
+        await scheduler.stop()
         await storage_manager.close()
 
 
@@ -103,6 +112,13 @@ for _prefix, _in_schema in (("/api/v1", True), ("/api", False)):
         groups.router,
         prefix=_prefix,
         tags=["Groups"],
+        dependencies=protected,
+        include_in_schema=_in_schema,
+    )
+    app.include_router(
+        schedules.router,
+        prefix=_prefix,
+        tags=["Schedules"],
         dependencies=protected,
         include_in_schema=_in_schema,
     )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,6 +7,7 @@ from httpx import ASGITransport
 from camoufox_pm.api import dependencies
 from camoufox_pm.core.database import StorageManager
 from camoufox_pm.core.profile_manager import ProfileManager
+from camoufox_pm.core.scheduler import TaskScheduler
 from camoufox_pm.main import app
 
 
@@ -20,6 +21,9 @@ async def client(tmp_path):
 
     dependencies.set_storage_manager(storage)
     dependencies.set_profile_manager(manager)
+    # Not started: the routes only need it to plan and to run-now; the loop
+    # would poll on a real clock, which tests must not depend on.
+    dependencies.set_scheduler(TaskScheduler(storage, manager))
 
     transport = ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://test") as http_client:

--- a/tests/integration/test_api_schedules.py
+++ b/tests/integration/test_api_schedules.py
@@ -1,0 +1,159 @@
+"""Integration tests for the schedule endpoints."""
+
+import pytest
+
+from camoufox_pm.api import dependencies
+
+
+async def make_profile(client, name="scheduled") -> str:
+    response = await client.post("/api/v1/profiles", json={"name": name})
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+async def make_schedule(client, profile_id: str, **overrides) -> dict:
+    body = {
+        "profile_id": profile_id,
+        "action": "launch",
+        "kind": "interval",
+        "interval_minutes": 60,
+        **overrides,
+    }
+    response = await client.post("/api/v1/schedules", json=body)
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+@pytest.mark.asyncio
+async def test_a_schedule_is_created_planned_and_listed(client):
+    profile_id = await make_profile(client)
+    created = await make_schedule(client, profile_id)
+
+    assert created["profile_name"] == "scheduled"
+    assert created["enabled"] is True
+    assert created["next_run_at"] is not None
+    assert created["last_run"] is None
+
+    listing = await client.get("/api/v1/schedules")
+    assert listing.status_code == 200
+    assert listing.json()["total"] == 1
+    assert listing.json()["schedules"][0]["id"] == created["id"]
+
+
+@pytest.mark.asyncio
+async def test_a_schedule_for_a_missing_profile_is_refused(client):
+    response = await client.post(
+        "/api/v1/schedules",
+        json={"profile_id": "ghost", "action": "launch", "kind": "interval", "interval_minutes": 5},
+    )
+    assert response.status_code == 400
+    assert "not found" in response.json()["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_an_incomplete_expression_fails_as_request_validation(client):
+    profile_id = await make_profile(client)
+    response = await client.post(
+        "/api/v1/schedules",
+        json={"profile_id": profile_id, "action": "launch", "kind": "daily"},
+    )
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "validation_error"
+
+
+@pytest.mark.asyncio
+async def test_updating_the_timing_replans_and_renames_do_not(client):
+    profile_id = await make_profile(client)
+    created = await make_schedule(client, profile_id)
+    schedule_id = created["id"]
+
+    switched = await client.put(
+        f"/api/v1/schedules/{schedule_id}",
+        json={"kind": "daily", "at_time": "09:00", "days": [0, 4]},
+    )
+    assert switched.status_code == 200, switched.text
+    body = switched.json()
+    assert body["kind"] == "daily"
+    assert body["at_time"] == "09:00"
+    assert body["next_run_at"] != created["next_run_at"]
+
+    # Disabling clears the plan; nothing should fire while paused.
+    paused = await client.put(f"/api/v1/schedules/{schedule_id}", json={"enabled": False})
+    assert paused.json()["enabled"] is False
+    assert paused.json()["next_run_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_switching_kind_without_its_field_is_refused(client):
+    profile_id = await make_profile(client)
+    created = await make_schedule(client, profile_id)
+
+    response = await client.put(f"/api/v1/schedules/{created['id']}", json={"kind": "daily"})
+    assert response.status_code == 400
+    assert "at_time" in response.json()["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_deleting_a_schedule_and_missing_ids_answer_correctly(client):
+    profile_id = await make_profile(client)
+    created = await make_schedule(client, profile_id)
+
+    deleted = await client.delete(f"/api/v1/schedules/{created['id']}")
+    assert deleted.status_code == 200
+    assert deleted.json()["success"] is True
+
+    assert (await client.get(f"/api/v1/schedules/{created['id']}")).status_code == 404
+    assert (await client.delete(f"/api/v1/schedules/{created['id']}")).status_code == 404
+    assert (await client.get("/api/v1/schedules/nope/runs")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_run_now_records_an_outcome_and_history_serves_it(client, monkeypatch):
+    profile_id = await make_profile(client)
+    created = await make_schedule(client, profile_id)
+
+    manager = dependencies.get_profile_manager()
+
+    class FakeSession:
+        process_id = 4242
+
+        async def terminate(self):
+            pass
+
+    async def fake_launch(pid, options, on_exit=None):
+        manager.browser_sessions.active_sessions[pid] = FakeSession()
+        return FakeSession()
+
+    from camoufox_pm.core import profile_manager as pm_module
+
+    monkeypatch.setattr(manager.browser_sessions, "launch", fake_launch)
+    monkeypatch.setattr(pm_module.fingerprint_store, "resolve", lambda *_a, **_k: {})
+
+    ran = await client.post(f"/api/v1/schedules/{created['id']}/run")
+    assert ran.status_code == 200, ran.text
+    assert ran.json()["outcome"] == "ok"
+
+    # A second run finds the browser open and says so instead of failing.
+    again = await client.post(f"/api/v1/schedules/{created['id']}/run")
+    assert again.json()["outcome"] == "skipped"
+
+    history = await client.get(f"/api/v1/schedules/{created['id']}/runs")
+    assert history.status_code == 200
+    outcomes = [run["outcome"] for run in history.json()["runs"]]
+    assert outcomes == ["skipped", "ok"]
+
+    # The manual runs did not move the planned next run.
+    fetched = await client.get(f"/api/v1/schedules/{created['id']}")
+    assert fetched.json()["next_run_at"] == created["next_run_at"]
+    assert fetched.json()["last_run"]["outcome"] == "skipped"
+
+    await manager.browser_sessions.close(profile_id)
+
+
+@pytest.mark.asyncio
+async def test_deleting_the_profile_deletes_its_schedules(client):
+    profile_id = await make_profile(client)
+    created = await make_schedule(client, profile_id)
+
+    assert (await client.delete(f"/api/v1/profiles/{profile_id}")).status_code == 200
+    assert (await client.get(f"/api/v1/schedules/{created['id']}")).status_code == 404

--- a/tests/unit/test_scheduler.py
+++ b/tests/unit/test_scheduler.py
@@ -1,0 +1,420 @@
+"""Tests for the task scheduler: what runs when, driven by an injected clock.
+
+No test here sleeps. The scheduler reads time through a callable, so these hand
+it a clock they control and call ``tick()`` themselves; the background loop is
+only glue around that.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from camoufox_pm.core import profile_manager as pm_module
+from camoufox_pm.core.models import Schedule, ScheduleRun, ScheduleRunOutcome
+from camoufox_pm.core.scheduler import TaskScheduler, next_run_after
+
+MONDAY = datetime(2026, 8, 3, 10, 0)  # a known Monday, 10:00
+
+
+class Clock:
+    """A clock the test moves by hand."""
+
+    def __init__(self, at: datetime):
+        self.at = at
+
+    def __call__(self) -> datetime:
+        return self.at
+
+    def advance(self, **kwargs) -> None:
+        self.at += timedelta(**kwargs)
+
+
+@pytest.fixture
+def clock():
+    return Clock(MONDAY)
+
+
+@pytest.fixture
+def scheduler(profile_manager, clock):
+    """A scheduler on the fake clock, never started: tests drive tick() directly."""
+    return TaskScheduler(profile_manager.storage, profile_manager, now=clock)
+
+
+@pytest.fixture
+def launches(profile_manager, monkeypatch):
+    """Capture launches without a browser, as the profile manager tests do."""
+    recorded: list[str] = []
+
+    class FakeSession:
+        process_id = 4242
+
+    async def fake_launch(profile_id, options, on_exit=None):
+        recorded.append(profile_id)
+        profile_manager.browser_sessions.active_sessions[profile_id] = FakeSession()
+        return FakeSession()
+
+    monkeypatch.setattr(profile_manager.browser_sessions, "launch", fake_launch)
+    monkeypatch.setattr(pm_module.fingerprint_store, "resolve", lambda *_a, **_k: {})
+    return recorded
+
+
+def make_schedule(profile_id: str, **overrides) -> Schedule:
+    fields = {
+        "profile_id": profile_id,
+        "action": "launch",
+        "kind": "interval",
+        "interval_minutes": 30,
+        **overrides,
+    }
+    return Schedule(**fields)
+
+
+# -- When the next run falls ----------------------------------------------------
+
+
+def test_an_interval_schedule_fires_that_long_from_now():
+    schedule = make_schedule("p", interval_minutes=45)
+    assert next_run_after(schedule, MONDAY) == MONDAY + timedelta(minutes=45)
+
+
+def test_a_daily_schedule_fires_later_today_if_the_time_is_still_ahead():
+    schedule = make_schedule("p", kind="daily", interval_minutes=None, at_time="14:30")
+    assert next_run_after(schedule, MONDAY) == MONDAY.replace(hour=14, minute=30)
+
+
+def test_a_daily_schedule_whose_time_has_passed_waits_for_tomorrow():
+    schedule = make_schedule("p", kind="daily", interval_minutes=None, at_time="09:00")
+    assert next_run_after(schedule, MONDAY) == (MONDAY + timedelta(days=1)).replace(
+        hour=9, minute=0
+    )
+
+
+def test_a_daily_schedule_skips_days_it_is_not_allowed_on():
+    # Monday 10:00, allowed only Friday (4): jumps four days ahead.
+    schedule = make_schedule("p", kind="daily", interval_minutes=None, at_time="09:00", days=[4])
+    assert next_run_after(schedule, MONDAY) == datetime(2026, 8, 7, 9, 0)
+
+
+def test_the_expression_must_match_the_kind():
+    with pytest.raises(ValueError, match="interval_minutes"):
+        make_schedule("p", interval_minutes=None)
+    with pytest.raises(ValueError, match="HH:MM"):
+        make_schedule("p", kind="daily", interval_minutes=None, at_time="25:99")
+    with pytest.raises(ValueError, match="weekdays"):
+        make_schedule("p", kind="daily", interval_minutes=None, at_time="09:00", days=[7])
+    with pytest.raises(ValueError, match="launch"):
+        make_schedule("p", action="refresh_browser", run_minutes=10)
+
+
+# -- Firing ---------------------------------------------------------------------
+
+
+async def test_a_due_schedule_fires_and_advances(profile_manager, scheduler, clock, launches):
+    profile = await profile_manager.create_profile(name="warmed")
+    schedule = make_schedule(profile.id, next_run_at=MONDAY - timedelta(minutes=1))
+    await profile_manager.storage.save_schedule(schedule)
+
+    await scheduler.tick()
+
+    assert launches == [profile.id]
+    stored = await profile_manager.storage.get_schedule(schedule.id)
+    assert stored.next_run_at == MONDAY + timedelta(minutes=30)
+    runs = await profile_manager.storage.list_schedule_runs(schedule.id)
+    assert [run.outcome for run in runs] == [ScheduleRunOutcome.OK]
+
+
+async def test_a_schedule_that_is_not_due_yet_does_nothing(
+    profile_manager, scheduler, clock, launches
+):
+    profile = await profile_manager.create_profile(name="later")
+    schedule = make_schedule(profile.id, next_run_at=MONDAY + timedelta(minutes=5))
+    await profile_manager.storage.save_schedule(schedule)
+
+    await scheduler.tick()
+
+    assert launches == []
+    assert await profile_manager.storage.list_schedule_runs(schedule.id) == []
+
+
+async def test_a_failing_task_is_recorded_and_the_next_one_still_runs(
+    profile_manager, scheduler, clock, launches, monkeypatch
+):
+    """One bad schedule must not take the tick — or the scheduler — down with it."""
+    broken = await profile_manager.create_profile(name="broken")
+    healthy = await profile_manager.create_profile(name="healthy")
+
+    async def explode(profile_id, **kwargs):
+        raise RuntimeError("browser exploded")
+
+    schedule_a = make_schedule(broken.id, next_run_at=MONDAY - timedelta(minutes=1))
+    schedule_b = make_schedule(healthy.id, next_run_at=MONDAY - timedelta(minutes=1))
+    await profile_manager.storage.save_schedule(schedule_a)
+    await profile_manager.storage.save_schedule(schedule_b)
+
+    real_launch = profile_manager.launch_browser
+
+    async def selective(profile_id, **kwargs):
+        if profile_id == broken.id:
+            return await explode(profile_id, **kwargs)
+        return await real_launch(profile_id, **kwargs)
+
+    monkeypatch.setattr(profile_manager, "launch_browser", selective)
+
+    await scheduler.tick()
+
+    failed = await profile_manager.storage.list_schedule_runs(schedule_a.id)
+    assert failed[0].outcome == ScheduleRunOutcome.ERROR
+    assert "browser exploded" in failed[0].message
+    assert launches == [healthy.id]
+    # And the failed schedule is still planned, not wedged in the past.
+    stored = await profile_manager.storage.get_schedule(schedule_a.id)
+    assert stored.next_run_at > MONDAY
+
+
+async def test_a_launch_is_skipped_while_the_browser_is_already_open(
+    profile_manager, scheduler, clock, launches
+):
+    profile = await profile_manager.create_profile(name="busy")
+    await profile_manager.launch_browser(profile.id)
+    launches.clear()
+
+    schedule = make_schedule(profile.id, next_run_at=MONDAY - timedelta(minutes=1))
+    await profile_manager.storage.save_schedule(schedule)
+
+    await scheduler.tick()
+
+    assert launches == []
+    runs = await profile_manager.storage.list_schedule_runs(schedule.id)
+    assert runs[0].outcome == ScheduleRunOutcome.SKIPPED
+    assert "already running" in runs[0].message
+
+
+async def test_a_timed_launch_closes_itself_when_its_minutes_are_up(
+    profile_manager, scheduler, clock, launches
+):
+    profile = await profile_manager.create_profile(name="timed")
+    schedule = make_schedule(profile.id, run_minutes=15, next_run_at=MONDAY - timedelta(minutes=1))
+    await profile_manager.storage.save_schedule(schedule)
+
+    await scheduler.tick()
+    assert profile_manager.browser_sessions.is_running(profile.id)
+
+    clock.advance(minutes=14)
+    await scheduler.tick()
+    assert profile_manager.browser_sessions.is_running(profile.id)
+
+    clock.advance(minutes=2)
+    await scheduler.tick()
+    assert not profile_manager.browser_sessions.is_running(profile.id)
+
+
+async def test_a_schedule_whose_profile_is_gone_disables_itself(
+    profile_manager, scheduler, clock, launches
+):
+    """Deleting a profile removes its schedules; this covers the race where one
+    fires in between. It must not keep erroring every occurrence forever."""
+    schedule = make_schedule("vanished", next_run_at=MONDAY - timedelta(minutes=1))
+    await profile_manager.storage.save_schedule(schedule)
+
+    await scheduler.tick()
+
+    stored = await profile_manager.storage.get_schedule(schedule.id)
+    assert stored.enabled is False
+    runs = await profile_manager.storage.list_schedule_runs(schedule.id)
+    assert runs[0].outcome == ScheduleRunOutcome.ERROR
+    assert "no longer exists" in runs[0].message
+
+
+async def test_a_disabled_schedule_never_fires(profile_manager, scheduler, clock, launches):
+    profile = await profile_manager.create_profile(name="paused")
+    schedule = make_schedule(profile.id, enabled=False, next_run_at=MONDAY - timedelta(minutes=1))
+    await profile_manager.storage.save_schedule(schedule)
+
+    await scheduler.tick()
+
+    assert launches == []
+
+
+async def test_run_now_executes_but_leaves_the_plan_alone(
+    profile_manager, scheduler, clock, launches
+):
+    profile = await profile_manager.create_profile(name="manual")
+    planned = MONDAY + timedelta(hours=3)
+    schedule = make_schedule(profile.id, next_run_at=planned)
+    await profile_manager.storage.save_schedule(schedule)
+
+    run = await scheduler.run_now(schedule)
+
+    assert run.outcome == ScheduleRunOutcome.OK
+    assert launches == [profile.id]
+    stored = await profile_manager.storage.get_schedule(schedule.id)
+    assert stored.next_run_at == planned
+
+
+async def test_refresh_browser_records_the_failure_when_there_is_no_pin(
+    profile_manager, scheduler, clock
+):
+    """Without a pinned machine there is nothing to refresh; the run says so."""
+    profile = await profile_manager.create_profile(name="unpinned")
+    schedule = make_schedule(
+        profile.id,
+        action="refresh_browser",
+        next_run_at=MONDAY - timedelta(minutes=1),
+    )
+    await profile_manager.storage.save_schedule(schedule)
+
+    await scheduler.tick()
+
+    runs = await profile_manager.storage.list_schedule_runs(schedule.id)
+    assert runs[0].outcome == ScheduleRunOutcome.ERROR
+    assert "no pinned machine" in runs[0].message
+
+
+# -- Restart behaviour ----------------------------------------------------------
+
+
+async def test_runs_missed_while_down_are_recorded_once_and_skipped(
+    profile_manager, scheduler, clock, launches
+):
+    """Twelve missed warming launches must not fire at once on startup: the gap
+    becomes one visible 'missed' row and the schedule waits for its next slot."""
+    profile = await profile_manager.create_profile(name="offline")
+    schedule = make_schedule(
+        profile.id, interval_minutes=60, next_run_at=MONDAY - timedelta(hours=12)
+    )
+    await profile_manager.storage.save_schedule(schedule)
+
+    await scheduler.reconcile_missed()
+
+    assert launches == []
+    runs = await profile_manager.storage.list_schedule_runs(schedule.id)
+    assert [run.outcome for run in runs] == [ScheduleRunOutcome.MISSED]
+    stored = await profile_manager.storage.get_schedule(schedule.id)
+    assert stored.next_run_at == MONDAY + timedelta(hours=1)
+
+    # And the reconciled schedule does not fire on the first tick either.
+    await scheduler.tick()
+    assert launches == []
+
+
+async def test_a_schedule_that_never_ran_gets_a_first_plan_on_startup(
+    profile_manager, scheduler, clock
+):
+    profile = await profile_manager.create_profile(name="fresh")
+    schedule = make_schedule(profile.id, next_run_at=None)
+    await profile_manager.storage.save_schedule(schedule)
+
+    await scheduler.reconcile_missed()
+
+    stored = await profile_manager.storage.get_schedule(schedule.id)
+    assert stored.next_run_at == MONDAY + timedelta(minutes=30)
+    assert await profile_manager.storage.list_schedule_runs(schedule.id) == []
+
+
+async def test_a_future_schedule_survives_a_restart_untouched(profile_manager, scheduler, clock):
+    profile = await profile_manager.create_profile(name="pending")
+    planned = MONDAY + timedelta(minutes=10)
+    schedule = make_schedule(profile.id, next_run_at=planned)
+    await profile_manager.storage.save_schedule(schedule)
+
+    await scheduler.reconcile_missed()
+
+    stored = await profile_manager.storage.get_schedule(schedule.id)
+    assert stored.next_run_at == planned
+    assert await profile_manager.storage.list_schedule_runs(schedule.id) == []
+
+
+# -- Storage --------------------------------------------------------------------
+
+
+async def test_a_schedule_round_trips_through_the_database(storage):
+    schedule = Schedule(
+        profile_id="p1",
+        action="launch",
+        kind="daily",
+        at_time="09:00",
+        days=[0, 2, 4],
+        run_minutes=20,
+        next_run_at=datetime(2026, 8, 5, 9, 0),
+    )
+    await storage.save_schedule(schedule)
+
+    loaded = await storage.get_schedule(schedule.id)
+    assert loaded == schedule
+    assert await storage.list_schedules() == [schedule]
+
+    assert await storage.delete_schedule(schedule.id) is True
+    assert await storage.get_schedule(schedule.id) is None
+
+
+async def test_deleting_a_profile_takes_its_schedules_and_history_with_it(profile_manager):
+    profile = await profile_manager.create_profile(name="doomed")
+    schedule = make_schedule(profile.id)
+    storage = profile_manager.storage
+    await storage.save_schedule(schedule)
+    await storage.log_schedule_run(
+        ScheduleRun(schedule_id=schedule.id, outcome=ScheduleRunOutcome.OK)
+    )
+
+    await profile_manager.delete_profile(profile.id)
+
+    assert await storage.get_schedule(schedule.id) is None
+    assert await storage.list_schedule_runs(schedule.id) == []
+
+
+async def test_run_history_is_pruned_to_the_newest_twenty(storage):
+    for index in range(25):
+        await storage.log_schedule_run(
+            ScheduleRun(schedule_id="s1", outcome=ScheduleRunOutcome.OK, message=str(index))
+        )
+
+    runs = await storage.list_schedule_runs("s1", limit=50)
+    assert len(runs) == 20
+    assert runs[0].message == "24"
+    assert runs[-1].message == "5"
+
+
+async def test_an_existing_database_gains_the_schedule_tables(tmp_path):
+    """An install from before schedules existed opens cleanly and keeps its data."""
+    import sqlite3
+
+    from camoufox_pm.core.database import StorageManager
+
+    db_path = tmp_path / "old.db"
+    connection = sqlite3.connect(db_path)
+    # The profiles table exactly as 0.1.0 created it: no fingerprint column,
+    # no schedule tables anywhere.
+    connection.execute("""
+        CREATE TABLE profiles (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            group_id TEXT,
+            status TEXT DEFAULT 'active',
+            browser_settings TEXT NOT NULL,
+            proxy_config TEXT,
+            extensions TEXT,
+            storage_path TEXT,
+            notes TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            last_used TIMESTAMP
+        )
+    """)
+    connection.execute(
+        "INSERT INTO profiles (id, name, browser_settings, created_at, updated_at) "
+        "VALUES ('old1', 'survivor', '{}', '2026-01-01T00:00:00', '2026-01-01T00:00:00')"
+    )
+    connection.commit()
+    connection.close()
+
+    storage = StorageManager(str(db_path))
+    await storage.initialize()
+    try:
+        survivor = await storage.get_profile("old1")
+        assert survivor is not None and survivor.name == "survivor"
+
+        schedule = make_schedule("old1")
+        await storage.save_schedule(schedule)
+        assert (await storage.get_schedule(schedule.id)) == schedule
+    finally:
+        await storage.close()

--- a/web/src/app/schedules/page.tsx
+++ b/web/src/app/schedules/page.tsx
@@ -1,0 +1,558 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import {
+  CalendarClock,
+  History,
+  Pause,
+  Pencil,
+  Play,
+  Plus,
+  Trash2,
+} from 'lucide-react'
+
+import { EmptyState } from '@/components/empty-state'
+import { ConfirmDialog, Modal } from '@/components/modal'
+import { useToast } from '@/components/toast'
+import {
+  formatLastUsed,
+  profilesAPI,
+  schedulesAPI,
+  type Profile,
+  type Schedule,
+  type ScheduleAction,
+  type ScheduleKind,
+  type ScheduleRun,
+  type ScheduleRunOutcome,
+} from '@/lib/api'
+
+const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+const ACTION_LABELS: Record<ScheduleAction, string> = {
+  launch: 'Open browser',
+  refresh_browser: 'Refresh browser version',
+}
+
+const OUTCOME_STYLES: Record<ScheduleRunOutcome, string> = {
+  ok: 'text-ok',
+  skipped: 'text-ink-dim',
+  error: 'text-danger',
+  missed: 'text-warn',
+}
+
+function describeWhen(schedule: Schedule): string {
+  if (schedule.kind === 'interval') {
+    const minutes = schedule.interval_minutes ?? 0
+    if (minutes % 1440 === 0) return `every ${minutes / 1440}d`
+    if (minutes % 60 === 0) return `every ${minutes / 60}h`
+    return `every ${minutes}m`
+  }
+  const days =
+    schedule.days && schedule.days.length > 0
+      ? ` · ${schedule.days.map((day) => DAY_LABELS[day]).join(' ')}`
+      : ''
+  return `daily at ${schedule.at_time}${days}`
+}
+
+function formatNextRun(value: string | null): string {
+  if (!value) return '—'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return '—'
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export default function SchedulesPage() {
+  const [schedules, setSchedules] = useState<Schedule[]>([])
+  const [profiles, setProfiles] = useState<Profile[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [formOpen, setFormOpen] = useState(false)
+  const [editing, setEditing] = useState<Schedule | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState<Schedule | null>(null)
+  const [historyFor, setHistoryFor] = useState<Schedule | null>(null)
+  const [historyRuns, setHistoryRuns] = useState<ScheduleRun[]>([])
+
+  // Form fields
+  const [profileId, setProfileId] = useState('')
+  const [action, setAction] = useState<ScheduleAction>('launch')
+  const [kind, setKind] = useState<ScheduleKind>('daily')
+  const [intervalMinutes, setIntervalMinutes] = useState('60')
+  const [atTime, setAtTime] = useState('09:00')
+  const [days, setDays] = useState<number[]>([])
+  const [runMinutes, setRunMinutes] = useState('')
+
+  const toast = useToast()
+
+  const load = useCallback(async () => {
+    try {
+      setError(null)
+      const [scheduleList, profileList] = await Promise.all([
+        schedulesAPI.list(),
+        profilesAPI.getProfiles({ per_page: 100 }),
+      ])
+      setSchedules(scheduleList.schedules)
+      setProfiles(profileList.profiles)
+    } catch (err) {
+      setError(String(err instanceof Error ? err.message : err))
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    load()
+  }, [load])
+
+  function openCreate() {
+    setEditing(null)
+    setProfileId(profiles[0]?.id ?? '')
+    setAction('launch')
+    setKind('daily')
+    setIntervalMinutes('60')
+    setAtTime('09:00')
+    setDays([])
+    setRunMinutes('')
+    setFormOpen(true)
+  }
+
+  function openEdit(schedule: Schedule) {
+    setEditing(schedule)
+    setProfileId(schedule.profile_id)
+    setAction(schedule.action)
+    setKind(schedule.kind)
+    setIntervalMinutes(String(schedule.interval_minutes ?? 60))
+    setAtTime(schedule.at_time ?? '09:00')
+    setDays(schedule.days ?? [])
+    setRunMinutes(schedule.run_minutes ? String(schedule.run_minutes) : '')
+    setFormOpen(true)
+  }
+
+  async function save(event: React.FormEvent) {
+    event.preventDefault()
+    if (!profileId) {
+      toast('error', 'Choose a profile')
+      return
+    }
+    const payload = {
+      action,
+      kind,
+      interval_minutes: kind === 'interval' ? Number(intervalMinutes) || 60 : null,
+      at_time: kind === 'daily' ? atTime : null,
+      days: kind === 'daily' && days.length > 0 ? days : null,
+      run_minutes: action === 'launch' && runMinutes ? Number(runMinutes) : null,
+    }
+    setSaving(true)
+    try {
+      if (editing) {
+        await schedulesAPI.update(editing.id, payload)
+        toast('ok', 'Schedule updated')
+      } else {
+        await schedulesAPI.create({ ...payload, profile_id: profileId })
+        toast('ok', 'Schedule created')
+      }
+      setFormOpen(false)
+      load()
+    } catch (err) {
+      toast('error', editing ? 'Could not update schedule' : 'Could not create schedule', String(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function toggle(schedule: Schedule) {
+    try {
+      await schedulesAPI.update(schedule.id, { enabled: !schedule.enabled })
+      toast('ok', schedule.enabled ? 'Schedule paused' : 'Schedule resumed')
+      load()
+    } catch (err) {
+      toast('error', 'Could not update schedule', String(err))
+    }
+  }
+
+  async function runNow(schedule: Schedule) {
+    try {
+      const run = await schedulesAPI.runNow(schedule.id)
+      if (run.outcome === 'ok') toast('ok', 'Task ran', run.message ?? undefined)
+      else if (run.outcome === 'skipped') toast('ok', 'Task skipped', run.message ?? undefined)
+      else toast('error', 'Task failed', run.message ?? undefined)
+      load()
+    } catch (err) {
+      toast('error', 'Could not run the task', String(err))
+    }
+  }
+
+  async function remove() {
+    if (!deleting) return
+    const schedule = deleting
+    setDeleting(null)
+    try {
+      await schedulesAPI.remove(schedule.id)
+      toast('ok', 'Schedule deleted')
+      load()
+    } catch (err) {
+      toast('error', 'Could not delete schedule', String(err))
+    }
+  }
+
+  async function openHistory(schedule: Schedule) {
+    setHistoryFor(schedule)
+    setHistoryRuns([])
+    try {
+      const response = await schedulesAPI.runs(schedule.id)
+      setHistoryRuns(response.runs)
+    } catch (err) {
+      toast('error', 'Could not load the history', String(err))
+    }
+  }
+
+  return (
+    <>
+      <header className="sticky top-0 z-20 flex h-[52px] items-center gap-3 border-b border-line bg-canvas/85 px-5 backdrop-blur">
+        <h1 className="text-[14px] font-semibold">Schedules</h1>
+        <span className="font-mono text-ink-faint">{schedules.length}</span>
+        <button className="btn btn-primary ml-auto" onClick={openCreate}>
+          <Plus size={14} strokeWidth={2.5} />
+          New schedule
+        </button>
+      </header>
+
+      {error ? (
+        <EmptyState
+          icon={<CalendarClock size={18} />}
+          title="Cannot reach the API"
+          body={error}
+          action={
+            <button className="btn btn-default" onClick={load}>
+              Retry
+            </button>
+          }
+        />
+      ) : loading ? (
+        <p className="px-5 py-8 text-ink-faint">Loading…</p>
+      ) : schedules.length === 0 ? (
+        <EmptyState
+          icon={<CalendarClock size={18} />}
+          title="Nothing scheduled"
+          body="Open a profile's browser on a schedule, or keep its pinned browser version current. Runs missed while the app is closed are skipped, not replayed."
+          action={
+            <button className="btn btn-primary" onClick={openCreate}>
+              <Plus size={14} strokeWidth={2.5} />
+              Create a schedule
+            </button>
+          }
+        />
+      ) : (
+        <table className="w-full border-collapse">
+          <thead>
+            <tr className="border-b border-line text-left text-[11px] uppercase tracking-[0.05em] text-ink-faint">
+              <th className="py-2 pl-5 pr-4 font-medium">Profile</th>
+              <th className="py-2 pr-4 font-medium">Task</th>
+              <th className="py-2 pr-4 font-medium">When</th>
+              <th className="py-2 pr-4 font-medium">Next run</th>
+              <th className="py-2 pr-4 font-medium">Last run</th>
+              <th className="w-[168px] py-2 pr-5" />
+            </tr>
+          </thead>
+          <tbody>
+            {schedules.map((schedule, index) => (
+              <tr
+                key={schedule.id}
+                className={`row-in border-b border-line/60 hover:bg-surface ${
+                  schedule.enabled ? '' : 'opacity-50'
+                }`}
+                style={{ animationDelay: `${Math.min(index, 12) * 12}ms` }}
+              >
+                <td className="py-2.5 pl-5 pr-4 font-medium">
+                  {schedule.profile_name ?? <span className="text-ink-faint">deleted</span>}
+                </td>
+                <td className="py-2.5 pr-4 text-ink-dim">
+                  {ACTION_LABELS[schedule.action]}
+                  {schedule.run_minutes ? (
+                    <span className="text-ink-faint"> · {schedule.run_minutes}m session</span>
+                  ) : null}
+                </td>
+                <td className="py-2.5 pr-4 font-mono text-ink-dim">{describeWhen(schedule)}</td>
+                <td className="py-2.5 pr-4 font-mono text-ink-dim">
+                  {schedule.enabled ? formatNextRun(schedule.next_run_at) : 'paused'}
+                </td>
+                <td className="py-2.5 pr-4">
+                  {schedule.last_run ? (
+                    <button
+                      className={`font-mono ${OUTCOME_STYLES[schedule.last_run.outcome]} hover:underline`}
+                      title={schedule.last_run.message ?? undefined}
+                      onClick={() => openHistory(schedule)}
+                    >
+                      {schedule.last_run.outcome} · {formatLastUsed(schedule.last_run.started_at)}
+                    </button>
+                  ) : (
+                    <span className="text-ink-faint">—</span>
+                  )}
+                </td>
+                <td className="py-2.5 pr-5">
+                  <div className="flex items-center justify-end gap-1">
+                    <button
+                      className="btn btn-ghost h-7 w-7 p-0"
+                      aria-label={`Run ${schedule.profile_name ?? schedule.id} now`}
+                      title="Run now"
+                      onClick={() => runNow(schedule)}
+                    >
+                      <Play size={13} />
+                    </button>
+                    <button
+                      className="btn btn-ghost h-7 w-7 p-0"
+                      aria-label={schedule.enabled ? 'Pause schedule' : 'Resume schedule'}
+                      title={schedule.enabled ? 'Pause' : 'Resume'}
+                      onClick={() => toggle(schedule)}
+                    >
+                      {schedule.enabled ? <Pause size={13} /> : <Play size={13} className="text-signal" />}
+                    </button>
+                    <button
+                      className="btn btn-ghost h-7 w-7 p-0"
+                      aria-label="Run history"
+                      title="History"
+                      onClick={() => openHistory(schedule)}
+                    >
+                      <History size={13} />
+                    </button>
+                    <button
+                      className="btn btn-ghost h-7 w-7 p-0"
+                      aria-label="Edit schedule"
+                      title="Edit"
+                      onClick={() => openEdit(schedule)}
+                    >
+                      <Pencil size={13} />
+                    </button>
+                    <button
+                      className="btn btn-ghost h-7 w-7 p-0 hover:text-danger"
+                      aria-label="Delete schedule"
+                      title="Delete"
+                      onClick={() => setDeleting(schedule)}
+                    >
+                      <Trash2 size={13} />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <Modal
+        open={formOpen}
+        title={editing ? 'Edit schedule' : 'New schedule'}
+        subtitle="Times are read on the server's clock — the machine running camoufox-pm."
+        onClose={() => setFormOpen(false)}
+        width={480}
+        footer={
+          <>
+            <button className="btn btn-default" onClick={() => setFormOpen(false)}>
+              Cancel
+            </button>
+            <button type="submit" form="schedule-form" className="btn btn-primary" disabled={saving}>
+              {editing ? 'Save changes' : 'Create schedule'}
+            </button>
+          </>
+        }
+      >
+        <form id="schedule-form" onSubmit={save} className="flex flex-col gap-3">
+          <div>
+            <label className="field-label" htmlFor="schedule-profile">
+              Profile
+            </label>
+            <select
+              id="schedule-profile"
+              className="field"
+              value={profileId}
+              onChange={(event) => setProfileId(event.target.value)}
+              disabled={editing !== null}
+              required
+            >
+              <option value="" disabled>
+                Choose a profile
+              </option>
+              {profiles.map((profile) => (
+                <option key={profile.id} value={profile.id}>
+                  {profile.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="field-label" htmlFor="schedule-action">
+              Task
+            </label>
+            <select
+              id="schedule-action"
+              className="field"
+              value={action}
+              onChange={(event) => setAction(event.target.value as ScheduleAction)}
+            >
+              <option value="launch">Open browser — warm the profile with a session</option>
+              <option value="refresh_browser">
+                Refresh browser version — keep the pinned machine&apos;s browser current
+              </option>
+            </select>
+            <p className="mt-1 text-ink-faint">
+              {action === 'refresh_browser'
+                ? 'Moves only the browser version onto the installed one; the screen, GPU, cores and seeds stay. Regenerating the hardware itself is deliberately not schedulable — it would make the profile a new machine on a timer.'
+                : 'Launches through the same session manager as the Open button; if the browser is already running, the run is skipped.'}
+            </p>
+          </div>
+
+          <div>
+            <span className="field-label">Repeats</span>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                className={kind === 'daily' ? 'btn btn-default border-signal text-ink' : 'btn btn-default'}
+                aria-pressed={kind === 'daily'}
+                onClick={() => setKind('daily')}
+              >
+                Daily at a time
+              </button>
+              <button
+                type="button"
+                className={kind === 'interval' ? 'btn btn-default border-signal text-ink' : 'btn btn-default'}
+                aria-pressed={kind === 'interval'}
+                onClick={() => setKind('interval')}
+              >
+                Every N minutes
+              </button>
+            </div>
+          </div>
+
+          {kind === 'interval' ? (
+            <div>
+              <label className="field-label" htmlFor="schedule-interval">
+                Every (minutes)
+              </label>
+              <input
+                id="schedule-interval"
+                type="number"
+                min={1}
+                max={40320}
+                className="field font-mono"
+                value={intervalMinutes}
+                onChange={(event) => setIntervalMinutes(event.target.value)}
+                required
+              />
+            </div>
+          ) : (
+            <>
+              <div>
+                <label className="field-label" htmlFor="schedule-time">
+                  At (server time)
+                </label>
+                <input
+                  id="schedule-time"
+                  type="time"
+                  className="field font-mono"
+                  value={atTime}
+                  onChange={(event) => setAtTime(event.target.value)}
+                  required
+                />
+              </div>
+              <div>
+                <span className="field-label">On days (none = every day)</span>
+                <div className="flex gap-1">
+                  {DAY_LABELS.map((label, day) => (
+                    <button
+                      key={label}
+                      type="button"
+                      aria-pressed={days.includes(day)}
+                      className={`btn h-7 px-2 font-mono ${
+                        days.includes(day) ? 'btn-default border-signal text-ink' : 'btn-ghost'
+                      }`}
+                      onClick={() =>
+                        setDays((current) =>
+                          current.includes(day)
+                            ? current.filter((d) => d !== day)
+                            : [...current, day].sort(),
+                        )
+                      }
+                    >
+                      {label}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </>
+          )}
+
+          {action === 'launch' && (
+            <div>
+              <label className="field-label" htmlFor="schedule-run-minutes">
+                Close after (minutes, empty = leave open)
+              </label>
+              <input
+                id="schedule-run-minutes"
+                type="number"
+                min={1}
+                max={1440}
+                className="field font-mono"
+                value={runMinutes}
+                onChange={(event) => setRunMinutes(event.target.value)}
+                placeholder="Leave the browser open"
+              />
+            </div>
+          )}
+        </form>
+      </Modal>
+
+      <Modal
+        open={historyFor !== null}
+        title="Run history"
+        subtitle={
+          historyFor
+            ? `${historyFor.profile_name ?? historyFor.profile_id} · ${ACTION_LABELS[historyFor.action]} · newest first, last 20 kept`
+            : undefined
+        }
+        onClose={() => setHistoryFor(null)}
+        width={520}
+      >
+        {historyRuns.length === 0 ? (
+          <p className="text-ink-faint">No runs recorded yet.</p>
+        ) : (
+          <ul className="flex flex-col divide-y divide-line">
+            {historyRuns.map((run) => (
+              <li key={run.id} className="flex items-baseline gap-3 py-2">
+                <span className={`w-[64px] shrink-0 font-mono ${OUTCOME_STYLES[run.outcome]}`}>
+                  {run.outcome}
+                </span>
+                <span className="w-[128px] shrink-0 font-mono text-ink-dim">
+                  {formatNextRun(run.started_at)}
+                </span>
+                <span className="text-ink-dim">{run.message ?? '—'}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </Modal>
+
+      <ConfirmDialog
+        open={deleting !== null}
+        title="Delete schedule"
+        body={
+          deleting
+            ? `The ${ACTION_LABELS[deleting.action].toLowerCase()} schedule for "${
+                deleting.profile_name ?? deleting.profile_id
+              }" and its run history will be removed. The profile itself is not touched.`
+            : ''
+        }
+        confirmLabel="Delete"
+        destructive
+        onConfirm={remove}
+        onCancel={() => setDeleting(null)}
+      />
+    </>
+  )
+}

--- a/web/src/components/app-shell.tsx
+++ b/web/src/components/app-shell.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Layers, LogOut, Settings, Users } from 'lucide-react'
+import { CalendarClock, Layers, LogOut, Settings, Users } from 'lucide-react'
 
 import { useAuth } from '@/components/login-gate'
 import { systemAPI } from '@/lib/api'
@@ -11,6 +11,7 @@ import { systemAPI } from '@/lib/api'
 const NAV = [
   { href: '/', label: 'Profiles', icon: Users },
   { href: '/groups/', label: 'Groups', icon: Layers },
+  { href: '/schedules/', label: 'Schedules', icon: CalendarClock },
   { href: '/settings/', label: 'Settings', icon: Settings },
 ]
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -348,6 +348,82 @@ export const groupsAPI = {
   },
 }
 
+// --- Schedules ---------------------------------------------------------------
+
+/** What a schedule does when it fires. Hardware regeneration is deliberately
+ * not schedulable: it would hand a warmed-up account new hardware on a timer,
+ * which is exactly what the pinned machine exists to prevent. */
+export type ScheduleAction = 'launch' | 'refresh_browser'
+
+export type ScheduleKind = 'interval' | 'daily'
+
+export type ScheduleRunOutcome = 'ok' | 'skipped' | 'error' | 'missed'
+
+export interface ScheduleRun {
+  id: number | null
+  schedule_id: string
+  started_at: string
+  finished_at: string | null
+  outcome: ScheduleRunOutcome
+  message: string | null
+}
+
+export interface Schedule {
+  id: string
+  profile_id: string
+  profile_name: string | null
+  action: ScheduleAction
+  kind: ScheduleKind
+  interval_minutes: number | null
+  /** HH:MM on the server's clock. */
+  at_time: string | null
+  /** Weekdays a daily schedule fires, 0=Monday … 6=Sunday; null = every day. */
+  days: number[] | null
+  run_minutes: number | null
+  enabled: boolean
+  next_run_at: string | null
+  last_run: ScheduleRun | null
+  created_at: string
+  updated_at: string
+}
+
+export interface SchedulePayload {
+  profile_id?: string
+  action?: ScheduleAction
+  kind?: ScheduleKind
+  interval_minutes?: number | null
+  at_time?: string | null
+  days?: number[] | null
+  run_minutes?: number | null
+  enabled?: boolean
+}
+
+export const schedulesAPI = {
+  list(): Promise<{ schedules: Schedule[]; total: number }> {
+    return request(`${API_PREFIX}/schedules`)
+  },
+
+  create(data: SchedulePayload): Promise<Schedule> {
+    return request<Schedule>(`${API_PREFIX}/schedules`, { method: 'POST', body: JSON.stringify(data) })
+  },
+
+  update(id: string, data: SchedulePayload): Promise<Schedule> {
+    return request<Schedule>(`${API_PREFIX}/schedules/${id}`, { method: 'PUT', body: JSON.stringify(data) })
+  },
+
+  remove(id: string): Promise<void> {
+    return request<void>(`${API_PREFIX}/schedules/${id}`, { method: 'DELETE' })
+  },
+
+  runNow(id: string): Promise<ScheduleRun> {
+    return request<ScheduleRun>(`${API_PREFIX}/schedules/${id}/run`, { method: 'POST' })
+  },
+
+  runs(id: string): Promise<{ runs: ScheduleRun[]; total: number }> {
+    return request(`${API_PREFIX}/schedules/${id}/runs`)
+  },
+}
+
 export interface SystemConfig {
   version: string
   host: string


### PR DESCRIPTION
Closes the roadmap item "Task scheduling and automated fingerprint rotation" — and **replaces its wording**, because half of it was wrong.

## The thing deliberately not built

**Automated fingerprint rotation contradicts the core of this product.** Six branches of work exist to make a profile *the same machine* between sessions, proven with real-browser tests. Rotating hardware on a schedule would turn a warmed-up account into a new computer at 3am: a site that has seen one GPU for months suddenly sees another. The roadmap wording predates pinning, when the fingerprint changed on every launch anyway and "rotation" cost nothing.

So the reasoning is written where someone will go looking for the missing feature: a comment on `ScheduleAction`, the action-picker help text in the UI, `docs/scheduling.md`, `docs/api.md`, the roadmap entry and the CHANGELOG. Hardware regeneration stays the deliberate manual *Regenerate fingerprint* button that already warns about the cost.

## What is schedulable

- **`launch`** — open a profile's browser, with an optional *close after N minutes* so a warming session ends itself.
- **`refresh_browser`** — move the pin onto the installed browser version, hardware and seeds untouched. This is the honest "rotation": it imitates a real machine updating its browser, which real machines do.

## Decisions

**Missed runs: skip, never replay.** A schedule whose time passed while the process was down gets **one** `missed` history row — however many occurrences fell in the gap — and is replanned from now. Replaying a night's backlog would open every missed browser at once. The gap is visible in history rather than silently absorbed.

**Interval / daily-at-time, not cron.** "Every N minutes" or "daily at HH:MM on chosen weekdays". Cron is syntax to get wrong; these two cover warming and maintenance, store as plain columns and compute a next run unambiguously. **Times are the server's clock**, stated in the form subtitle, the API docs and `scheduling.md` — a single-machine tool with no timezone bookkeeping to get wrong.

**Overlap and failure.** A launch whose browser is already running records `skipped`. Each schedule executes in its own try/except, so a raise records `error` and the next schedule still runs. `next_run_at` advances *before* executing, so a crash mid-run cannot leave a past due time that re-fires forever. A schedule whose profile vanished disables itself. History is capped at 20 rows per schedule.

**One process.** The scheduler calls `profile_manager.launch_browser` / `refresh_browser_version` / `close_browser` — the same path as a manual click, so `browsers/active`, close-on-window-close and the usage log behave identically.

## Verified by me on a running app, not taken from the agent's report

The two properties that unit tests cannot prove:

**Restart with a pending run** — killed the process at 21:12:50 with a run due 21:13:37, restarted at 21:14:05:
```
history rows: 1
  missed | Due 2026-08-08 21:13 while the app was not running; waiting for the next occurrence
browsers launched on startup: 0        <- no backlog stampede
next_run recomputed:          21:15:06 <- forward from now
```

**A failing task does not stop the loop** — a `refresh_browser` on an unpinned profile is guaranteed to fail:
```
error | This profile has no pinned machine yet; launch it once first.
next: 21:16:06 | enabled: True         <- scheduler alive, next run planned
tracebacks in log: 0
```

## Gates — verified independently in a fresh worktree

I re-ran the `HOME=$(mktemp -d)` form the agent's sandbox had refused:

```
ruff / format / mypy (32 files)   clean
HOME=$(mktemp -d) pytest -m "not browser"   312 passed, 20 deselected
tsc / next lint / next build      clean, /schedules 5.5 kB
```

Seven routes under `/api/v1` with typed models, stable operation ids and the standard error shape — the contract test that sweeps the OpenAPI schema passes. New tables via `CREATE TABLE IF NOT EXISTS` in the same init path as the `fingerprint` migration, with a test that opens a hand-built 0.1.0-shape database and proves existing rows survive. The scheduler's clock is injected, so "what runs when" is tested with a hand-moved clock and no sleeps.

## Merge order

Branched from main before the auth PR. Both touch `routes/__init__.py`, `database.py`, `main.py` and `dependencies.py`. Best merged **after** #14, rebased onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)