### PR TITLE
Keep major bumps out of the grouped web update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,8 +19,14 @@ updates:
     commit-message:
       prefix: "build"
     groups:
-      # One pull request per ecosystem rather than per package: the web UI has a
-      # small, tightly-coupled dependency set, and reviewing Next, React and
-      # Tailwind bumps separately means three builds proving the same thing.
+      # Minor and patch bumps travel together: the web UI has a small, tightly
+      # coupled dependency set, and reviewing them separately means several
+      # builds proving the same thing.
+      #
+      # Majors are deliberately left out of the group and arrive one at a time.
+      # Grouping everything produced a single pull request carrying Next 15→16,
+      # ESLint 9→10 and TypeScript 5→7, which failed CI and could not be split —
+      # Next 16 removes `next lint`, so that bump is a migration, not an upgrade.
       web-dependencies:
         patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -71,6 +71,11 @@ order of how much they would hurt if left alone:
 - The browser test suite depends on reaching `example.com` and `iana.org`, so a
   full run can flake on a rate limit rather than a real fault. Serving the two
   origins locally would make it deterministic.
+- **Next 16 migration.** The web UI is on Next 15. Next 16 removes `next lint`,
+  which the CI job calls, so the bump needs the move to the ESLint CLI and comes
+  with ESLint 10 and TypeScript 7 alongside it. It is a migration with its own
+  verification, not a dependency bump, which is why the grouped Dependabot pull
+  request for it could not simply be merged.
 - Proxy health at a glance in the profiles list, so a dead proxy is visible
   without opening each profile and pressing *Check proxy*.
 


### PR DESCRIPTION
The grouping I added yesterday was wrong, and the first Dependabot run proved it.

`patterns: ["*"]` with no `update-types` filter produced **one** pull request carrying fourteen updates, including three majors at once: Next 15.3.3 → 16.3.0, ESLint 9 → 10 and TypeScript 5 → 7. It failed the Frontend check:

```
> next lint
Invalid project directory provided, no such directory: .../web/lint
```

Next 16 removes `next lint`, so `next lint` is now parsed as "build the directory `lint`". That bump is a migration — move to the ESLint CLI, then absorb ESLint 10 and TypeScript 7 — not something to review as a dependency bump. And because the updates were grouped, there was no way to take the twelve harmless ones without it.

Minors and patches still travel together, which is the useful part of grouping. Majors now arrive one at a time.

The Next 16 migration is recorded in the roadmap rather than left as a recurring red pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)