### PR TITLE
Decrypt Chrome cookies with the cipher the platform actually used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-Nothing yet.
+### Fixed
+- **Chrome cookie migration was broken on Windows, and `v11` everywhere.** The
+  `v10`/`v11` tag does not name a cipher: on Windows those values are
+  AES-256-GCM, on macOS and Linux AES-128-CBC with an IV of sixteen spaces. The
+  decryptor applied CBC to all of them. On Windows that fails outright for
+  fifteen cookies in sixteen — and for the sixteenth, where the body happens to
+  be a whole number of AES blocks, it "succeeded" and wrote random bytes as the
+  cookie value. A 36-character session UUID is exactly that case. Separately,
+  `v11` was read as "12-byte IV, then CBC", which cannot work at all because CBC
+  needs a 16-byte IV, so `v11` never decrypted on any platform. The cipher is now
+  chosen by platform, PKCS#7 padding is validated instead of trusted, and a value
+  that cannot be decrypted is skipped rather than written mangled.
 
 ## [0.2.0] - 2026-08-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   needs a 16-byte IV, so `v11` never decrypted on any platform. The cipher is now
   chosen by platform, PKCS#7 padding is validated instead of trusted, and a value
   that cannot be decrypted is skipped rather than written mangled.
+- **…and the cookie-store schema on top of it.** From schema 24 (Chrome ~130) the
+  encrypted plaintext is `SHA256(host_key) || value`, not the value — a cookie
+  store change, so it applies to `v10`, `v11` and `v20` alike, on every platform.
+  Getting the cipher right but not this recovered *zero* cookies from any recent
+  Chrome, because the plaintext then begins with a digest. The schema version is
+  read from the database and the digest is verified against the row's own domain
+  before being stripped, exactly as Chrome does; that check also gives the CBC
+  platforms the integrity signal they otherwise lack. `v20` no longer strips the
+  prefix unconditionally, which was wrong for the Chrome 127–129 window that
+  wrote App-Bound cookies into a schema-23 store.
+- A migration that decrypts nothing now says so. Every failure was `debug` and
+  the summary counted unencrypted rows, so a wholly broken key reported
+  "Successfully decrypted 0 Chrome cookies".
 
 ## [0.2.0] - 2026-08-08
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,9 +6,11 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
 ## Since 0.2.0
 
 - Chrome cookies decrypt with the cipher the platform that wrote them actually
-  used: AES-256-GCM on Windows, AES-128-CBC on macOS and Linux. The same `v10`
-  tag means different things, and reading it alone had left Windows migration
-  broken since before App-Bound Encryption existed.
+  used (AES-256-GCM on Windows, AES-128-CBC on macOS and Linux) *and* with the
+  cookie-store schema they were written under — from schema 24 the plaintext
+  carries a `SHA256(host_key)` prefix that is verified against the row's domain.
+  Both layers were wrong, so Windows migration had recovered nothing since well
+  before App-Bound Encryption existed.
 
 ## Shipped in 0.2.0
 
@@ -66,6 +68,9 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
 Everything planned for `0.2.0` shipped. These are the known follow-ups, in rough
 order of how much they would hurt if left alone:
 
+- Read the Linux keyring for the `v11` cookie password. The key is currently
+  always derived from Chrome's hardcoded `peanuts`, so a genuine Linux `v11`
+  cookie is skipped rather than decrypted.
 - Reconcile the deprecations before `1.0`: the flattened `browser_*` update
   fields, `browser_session_id`, and the top-level `detail` in errors all go away
   in `1.0`, and the unversioned `/api` prefix in `2.0`. See the deprecation table

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,6 +3,13 @@
 This is a rough, non-binding plan. Priorities may change based on feedback.
 Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-manager/issues).
 
+## Since 0.2.0
+
+- Chrome cookies decrypt with the cipher the platform that wrote them actually
+  used: AES-256-GCM on Windows, AES-128-CBC on macOS and Linux. The same `v10`
+  tag means different things, and reading it alone had left Windows migration
+  broken since before App-Bound Encryption existed.
+
 ## Shipped in 0.2.0
 
 - Profiles keep one pinned machine across launches, instead of resolving a new
@@ -59,11 +66,6 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
 Everything planned for `0.2.0` shipped. These are the known follow-ups, in rough
 order of how much they would hurt if left alone:
 
-- **Windows `v10`/`v11` Chrome cookies are decrypted as AES-128-CBC**, which is
-  correct on macOS and Linux and wrong on Windows — those are AES-256-GCM. Found
-  while adding App-Bound Encryption support and deliberately left out of that
-  change to keep it scoped; it means the Chrome-migration extra was already
-  failing on Windows before `v20` existed.
 - Reconcile the deprecations before `1.0`: the flattened `browser_*` update
   fields, `browser_session_id`, and the top-level `detail` in errors all go away
   in `1.0`, and the unversioned `/api` prefix in `2.0`. See the deprecation table

--- a/extras/chrome_migration/README.md
+++ b/extras/chrome_migration/README.md
@@ -92,7 +92,18 @@ something different depending on the platform that wrote it:
 | macOS, Linux | AES-128-CBC, IV of 16 spaces, PKCS#7 | `[v10\|v11][ciphertext]` | PBKDF2 over the Keychain/keyring password |
 | Windows, Chrome 127+ | AES-256-GCM (App-Bound) | `[v20][nonce:12][ciphertext][tag:16]` | see App-Bound Encryption below |
 
-On macOS and Linux `v11` differs from `v10` only in where the password comes
-from, never in the cipher. A value that cannot be decrypted is skipped, never
-written mangled: CBC has no authentication tag, so the PKCS#7 padding check and
-a strict UTF-8 decode are the only integrity signals available.
+On **Linux** `v11` differs from `v10` only in where the password comes from,
+never in the cipher — though this module currently derives the Linux key from
+Chrome's hardcoded `peanuts` password and does not read the keyring, so a real
+Linux `v11` cookie is skipped rather than decrypted. Chrome on **macOS** only
+ever writes `v10`, with 1003 PBKDF2 iterations against Linux's 1.
+
+There is a second layer above the cipher. From **cookie-store schema 24**
+(Chrome ~130) the encrypted plaintext is `SHA256(host_key) || value` rather than
+the value alone — a change in the cookie store, so it applies to `v10`, `v11` and
+`v20` alike, on every platform. The schema version is read from the database's
+`meta` table, and the digest is *verified* against the row's own domain before
+being stripped, as Chrome does. That verification doubles as the integrity check
+CBC otherwise lacks.
+
+A value that cannot be decrypted is skipped, never written mangled.

--- a/extras/chrome_migration/README.md
+++ b/extras/chrome_migration/README.md
@@ -80,3 +80,19 @@ and re-authenticate the rest in Camoufox.
 You are responsible for complying with applicable laws and the terms of service of
 any site whose cookies you migrate. See the project [SECURITY.md](../../SECURITY.md)
 and [LICENSE](../../LICENSE).
+
+## How cookies are encrypted
+
+The `v10`/`v11` prefix on a cookie value does **not** name a cipher — it means
+something different depending on the platform that wrote it:
+
+| Platform | Cipher | Layout | Key |
+| --- | --- | --- | --- |
+| Windows | AES-256-GCM | `[v10\|v11][nonce:12][ciphertext][tag:16]` | DPAPI-unwrapped `os_crypt.encrypted_key` |
+| macOS, Linux | AES-128-CBC, IV of 16 spaces, PKCS#7 | `[v10\|v11][ciphertext]` | PBKDF2 over the Keychain/keyring password |
+| Windows, Chrome 127+ | AES-256-GCM (App-Bound) | `[v20][nonce:12][ciphertext][tag:16]` | see App-Bound Encryption below |
+
+On macOS and Linux `v11` differs from `v10` only in where the password comes
+from, never in the cipher. A value that cannot be decrypted is skipped, never
+written mangled: CBC has no authentication tag, so the PKCS#7 padding check and
+a strict UTF-8 decode are the only integrity signals available.

--- a/extras/chrome_migration/abe.py
+++ b/extras/chrome_migration/abe.py
@@ -42,6 +42,8 @@ from dataclasses import dataclass
 
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM, ChaCha20Poly1305
 
+from .cookie_crypto import CookieDecryptionError, strip_domain_prefix
+
 # Marker at the front of the base64-decoded ``app_bound_encrypted_key``. It is a
 # tag Chrome writes, not part of the DPAPI blob, so it is stripped before the
 # first unprotect. See runassu PoC ``main()``.
@@ -229,12 +231,19 @@ def unwrap_master_key(
         raise V20DecryptionError(f"failed to unwrap the ABE master key: {exc}") from exc
 
 
-def decrypt_v20_cookie_value(encrypted_value: bytes, master_key: bytes) -> str:
+def decrypt_v20_cookie_value(
+    encrypted_value: bytes, master_key: bytes, host_key: str | None = None
+) -> str:
     """Decrypt one ``v20`` cookie ``encrypted_value`` with the ABE master key.
 
-    Layout: ``[b"v20"][nonce:12][ciphertext:var][tag:16]``, AES-256-GCM. The
-    decrypted plaintext starts with a 32-byte domain-bound hash that Chrome
-    prepends; it is stripped to recover the real value.
+    Layout: ``[b"v20"][nonce:12][ciphertext:var][tag:16]``, AES-256-GCM.
+
+    ``host_key`` is the cookie's domain, passed only for cookie stores at schema
+    24 or later, where the plaintext begins with ``SHA256(host_key)``. That
+    prefix belongs to the cookie store rather than to App-Bound Encryption, so
+    Chrome 127-129 could write ``v20`` cookies into a schema-23 database that has
+    no prefix at all — stripping unconditionally, as this used to, would take 32
+    bytes off the front of those values.
     """
     if encrypted_value[: len(V20_COOKIE_PREFIX)] != V20_COOKIE_PREFIX:
         raise V20DecryptionError("cookie value is not v20-prefixed.")
@@ -251,7 +260,16 @@ def decrypt_v20_cookie_value(encrypted_value: bytes, master_key: bytes) -> str:
     except Exception as exc:  # InvalidTag and friends
         raise V20DecryptionError(f"failed to decrypt v20 cookie: {exc}") from exc
 
-    if len(plaintext) < _COOKIE_PLAINTEXT_PREFIX_LEN:
-        raise V20DecryptionError("decrypted v20 cookie is shorter than its prefix.")
+    if host_key is not None:
+        try:
+            plaintext = strip_domain_prefix(plaintext, host_key)
+        except CookieDecryptionError as exc:
+            raise V20DecryptionError(str(exc)) from exc
 
-    return plaintext[_COOKIE_PLAINTEXT_PREFIX_LEN:].decode("utf-8", errors="ignore")
+    # Strict, like the v10/v11 path: the GCM tag has already proved the plaintext
+    # is genuine, so bytes that are not UTF-8 mean the value is not text — better
+    # skipped than written with the bad characters silently dropped.
+    try:
+        return plaintext.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise V20DecryptionError(f"decrypted v20 cookie is not valid UTF-8: {exc}") from exc

--- a/extras/chrome_migration/cookie_crypto.py
+++ b/extras/chrome_migration/cookie_crypto.py
@@ -1,0 +1,95 @@
+"""How Chrome encrypts a cookie value, per platform.
+
+The ``v10``/``v11`` prefix means different things on different operating systems,
+which is the trap this module exists to close:
+
+* **Windows** — AES-256-GCM. Layout ``[v10|v11][nonce:12][ciphertext][tag:16]``.
+  The key is the DPAPI-unwrapped ``os_crypt.encrypted_key`` from ``Local State``.
+* **macOS and Linux** — AES-128-CBC with an IV of sixteen spaces and PKCS#7
+  padding. Layout ``[v10|v11][ciphertext]``. The key is PBKDF2 over a password
+  from the Keychain (macOS) or the keyring (Linux); ``v11`` differs from ``v10``
+  only in *where that password comes from*, never in the cipher.
+
+Reading the version tag alone and picking one algorithm cannot work. Doing so
+decrypted Windows cookies with CBC, which fails outright unless the body happens
+to be a multiple of the block size — and then returns plausible-looking rubbish.
+
+Everything here is pure and built on ``cryptography``, a core dependency, so the
+whole file is testable on any platform without the ``chrome-migration`` extra.
+"""
+
+from __future__ import annotations
+
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+SUPPORTED_PREFIXES = (b"v10", b"v11")
+
+# Chrome's own constants for the CBC platforms.
+_CBC_IV = b" " * 16
+_AEAD_NONCE_LEN = 12
+_AEAD_TAG_LEN = 16
+_BLOCK = 16
+
+
+class CookieDecryptionError(Exception):
+    """A cookie value could not be decrypted, so it must be skipped."""
+
+
+def _strip_prefix(encrypted_value: bytes) -> bytes:
+    prefix = encrypted_value[:3]
+    if prefix not in SUPPORTED_PREFIXES:
+        raise CookieDecryptionError(f"unsupported cookie version {prefix!r}")
+    return encrypted_value[3:]
+
+
+def _decode(plaintext: bytes) -> str:
+    """Decode strictly. CBC has no authentication tag, so a wrong key produces
+    random bytes rather than an error; failing to decode is the only signal that
+    anything went wrong, and a mangled value is worse than a skipped one."""
+    try:
+        return plaintext.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise CookieDecryptionError(f"decrypted bytes are not valid UTF-8: {exc}") from exc
+
+
+def decrypt_aes_gcm(encrypted_value: bytes, key: bytes) -> str:
+    """Decrypt a Windows ``v10``/``v11`` cookie value."""
+    body = _strip_prefix(encrypted_value)
+    if len(body) < _AEAD_NONCE_LEN + _AEAD_TAG_LEN:
+        raise CookieDecryptionError("cookie value is too short to hold a nonce and a tag")
+
+    nonce, ciphertext_and_tag = body[:_AEAD_NONCE_LEN], body[_AEAD_NONCE_LEN:]
+    try:
+        plaintext = AESGCM(key).decrypt(nonce, ciphertext_and_tag, None)
+    except Exception as exc:  # InvalidTag, wrong key length, and friends
+        raise CookieDecryptionError(f"AES-GCM decryption failed: {exc}") from exc
+    return _decode(plaintext)
+
+
+def decrypt_aes_cbc(encrypted_value: bytes, key: bytes) -> str:
+    """Decrypt a macOS or Linux ``v10``/``v11`` cookie value."""
+    body = _strip_prefix(encrypted_value)
+    if not body or len(body) % _BLOCK:
+        raise CookieDecryptionError("cookie value is not a whole number of AES blocks")
+
+    decryptor = Cipher(algorithms.AES(key), modes.CBC(_CBC_IV)).decryptor()
+    padded = decryptor.update(body) + decryptor.finalize()
+
+    # Validate the padding rather than trusting the last byte. With the wrong key
+    # the plaintext is random, and stripping "however many bytes the last one
+    # says" would silently truncate or corrupt a value that should be skipped.
+    pad = padded[-1]
+    if not 1 <= pad <= _BLOCK or padded[-pad:] != bytes([pad]) * pad:
+        raise CookieDecryptionError("PKCS#7 padding is invalid; the key is probably wrong")
+    return _decode(padded[:-pad])
+
+
+def decrypt_cookie_value(encrypted_value: bytes, key: bytes, system: str) -> str:
+    """Decrypt a ``v10``/``v11`` cookie value for the platform that wrote it.
+
+    ``system`` is ``platform.system().lower()``.
+    """
+    if system == "windows":
+        return decrypt_aes_gcm(encrypted_value, key)
+    return decrypt_aes_cbc(encrypted_value, key)

--- a/extras/chrome_migration/cookie_crypto.py
+++ b/extras/chrome_migration/cookie_crypto.py
@@ -20,10 +20,19 @@ whole file is testable on any platform without the ``chrome-migration`` extra.
 
 from __future__ import annotations
 
+import hashlib
+
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 SUPPORTED_PREFIXES = (b"v10", b"v11")
+
+# Cookie-store schema 24 (Chrome ~130, August 2024) started encrypting
+# ``SHA256(host_key) || value`` instead of the bare value. It is a change in the
+# cookie store, not in any cipher, so it applies to v10, v11 and v20 alike and on
+# every platform — which is why abe.py already strips 32 bytes for v20.
+DOMAIN_PREFIX_SCHEMA_VERSION = 24
+DOMAIN_PREFIX_LEN = 32
 
 # Chrome's own constants for the CBC platforms.
 _CBC_IV = b" " * 16
@@ -36,6 +45,24 @@ class CookieDecryptionError(Exception):
     """A cookie value could not be decrypted, so it must be skipped."""
 
 
+def strip_domain_prefix(plaintext: bytes, host_key: str) -> bytes:
+    """Remove the ``SHA256(host_key)`` that schema 24 prepends, after checking it.
+
+    Chrome verifies this digest and drops the cookie when it does not match, so we
+    do the same rather than trusting the first 32 bytes. It doubles as the
+    integrity check CBC otherwise lacks: with a wrong key the padding can still
+    validate by chance, but a random 32 bytes will not equal the digest of the
+    row's own domain.
+    """
+    if len(plaintext) < DOMAIN_PREFIX_LEN:
+        raise CookieDecryptionError("plaintext is too short to hold the domain digest")
+
+    expected = hashlib.sha256(host_key.encode("utf-8")).digest()
+    if plaintext[:DOMAIN_PREFIX_LEN] != expected:
+        raise CookieDecryptionError("the domain digest does not match this cookie's host_key")
+    return plaintext[DOMAIN_PREFIX_LEN:]
+
+
 def _strip_prefix(encrypted_value: bytes) -> bytes:
     prefix = encrypted_value[:3]
     if prefix not in SUPPORTED_PREFIXES:
@@ -44,52 +71,83 @@ def _strip_prefix(encrypted_value: bytes) -> bytes:
 
 
 def _decode(plaintext: bytes) -> str:
-    """Decode strictly. CBC has no authentication tag, so a wrong key produces
-    random bytes rather than an error; failing to decode is the only signal that
-    anything went wrong, and a mangled value is worse than a skipped one."""
+    """Decode strictly.
+
+    For CBC this is load-bearing: there is no authentication tag, so a wrong key
+    yields random bytes and a failed decode is one of the only signals that
+    anything went wrong. For GCM the tag has already proved the plaintext is
+    genuine, so a failure here means the value simply is not UTF-8 — rare enough
+    that skipping it beats writing something mangled.
+    """
     try:
         return plaintext.decode("utf-8")
     except UnicodeDecodeError as exc:
         raise CookieDecryptionError(f"decrypted bytes are not valid UTF-8: {exc}") from exc
 
 
-def decrypt_aes_gcm(encrypted_value: bytes, key: bytes) -> str:
-    """Decrypt a Windows ``v10``/``v11`` cookie value."""
+def _decrypt_gcm(encrypted_value: bytes, key: bytes) -> bytes:
+    """Windows: AES-256-GCM over ``[nonce:12][ciphertext][tag:16]``."""
     body = _strip_prefix(encrypted_value)
     if len(body) < _AEAD_NONCE_LEN + _AEAD_TAG_LEN:
         raise CookieDecryptionError("cookie value is too short to hold a nonce and a tag")
 
     nonce, ciphertext_and_tag = body[:_AEAD_NONCE_LEN], body[_AEAD_NONCE_LEN:]
     try:
-        plaintext = AESGCM(key).decrypt(nonce, ciphertext_and_tag, None)
+        return AESGCM(key).decrypt(nonce, ciphertext_and_tag, None)
     except Exception as exc:  # InvalidTag, wrong key length, and friends
         raise CookieDecryptionError(f"AES-GCM decryption failed: {exc}") from exc
-    return _decode(plaintext)
 
 
-def decrypt_aes_cbc(encrypted_value: bytes, key: bytes) -> str:
-    """Decrypt a macOS or Linux ``v10``/``v11`` cookie value."""
+def _decrypt_cbc(encrypted_value: bytes, key: bytes) -> bytes:
+    """macOS and Linux: AES-128-CBC, IV of sixteen spaces, PKCS#7."""
     body = _strip_prefix(encrypted_value)
     if not body or len(body) % _BLOCK:
         raise CookieDecryptionError("cookie value is not a whole number of AES blocks")
 
-    decryptor = Cipher(algorithms.AES(key), modes.CBC(_CBC_IV)).decryptor()
-    padded = decryptor.update(body) + decryptor.finalize()
+    try:
+        decryptor = Cipher(algorithms.AES(key), modes.CBC(_CBC_IV)).decryptor()
+        padded = decryptor.update(body) + decryptor.finalize()
+    except ValueError as exc:  # a key of the wrong length would pick another AES variant
+        raise CookieDecryptionError(f"AES-CBC decryption failed: {exc}") from exc
 
     # Validate the padding rather than trusting the last byte. With the wrong key
     # the plaintext is random, and stripping "however many bytes the last one
     # says" would silently truncate or corrupt a value that should be skipped.
+    # Not constant-time on purpose: this reads a local file once, offline, with
+    # no attacker able to observe timing, so there is no padding oracle to open.
     pad = padded[-1]
     if not 1 <= pad <= _BLOCK or padded[-pad:] != bytes([pad]) * pad:
         raise CookieDecryptionError("PKCS#7 padding is invalid; the key is probably wrong")
-    return _decode(padded[:-pad])
+    return padded[:-pad]
 
 
-def decrypt_cookie_value(encrypted_value: bytes, key: bytes, system: str) -> str:
+def decrypt_aes_gcm(encrypted_value: bytes, key: bytes, host_key: str | None = None) -> str:
+    """Decrypt a Windows ``v10``/``v11`` cookie value."""
+    plaintext = _decrypt_gcm(encrypted_value, key)
+    return _decode(strip_domain_prefix(plaintext, host_key) if host_key else plaintext)
+
+
+def decrypt_aes_cbc(encrypted_value: bytes, key: bytes, host_key: str | None = None) -> str:
+    """Decrypt a macOS or Linux ``v10``/``v11`` cookie value."""
+    plaintext = _decrypt_cbc(encrypted_value, key)
+    return _decode(strip_domain_prefix(plaintext, host_key) if host_key else plaintext)
+
+
+def decrypt_cookie_value(
+    encrypted_value: bytes, key: bytes, system: str, host_key: str | None = None
+) -> str:
     """Decrypt a ``v10``/``v11`` cookie value for the platform that wrote it.
 
-    ``system`` is ``platform.system().lower()``.
+    ``system`` is ``platform.system().lower()``. Pass ``host_key`` when the cookie
+    database is at schema 24 or later, where the plaintext carries a verifiable
+    ``SHA256(host_key)`` prefix; omit it for older stores, which do not.
+
+    Unknown systems are refused rather than assumed to be CBC: under Cygwin or
+    MSYS ``platform.system()`` reports something like ``cygwin_nt-10.0``, and
+    quietly treating a Windows profile as CBC would skip every cookie it has.
     """
     if system == "windows":
-        return decrypt_aes_gcm(encrypted_value, key)
-    return decrypt_aes_cbc(encrypted_value, key)
+        return decrypt_aes_gcm(encrypted_value, key, host_key)
+    if system in ("darwin", "linux"):
+        return decrypt_aes_cbc(encrypted_value, key, host_key)
+    raise CookieDecryptionError(f"no known cookie cipher for platform {system!r}")

--- a/extras/chrome_migration/cookie_decryptor.py
+++ b/extras/chrome_migration/cookie_decryptor.py
@@ -14,6 +14,7 @@ from typing import Any
 from loguru import logger
 
 from .cookie_crypto import (
+    DOMAIN_PREFIX_SCHEMA_VERSION,
     SUPPORTED_PREFIXES,
     CookieDecryptionError,
     decrypt_cookie_value,
@@ -202,9 +203,14 @@ class ChromeCookieDecryptor:
             return None
 
     def decrypt_chrome_cookie_value(
-        self, encrypted_value: bytes, encryption_key: bytes
+        self, encrypted_value: bytes, encryption_key: bytes, host_key: str | None = None
     ) -> str | None:
-        """Decrypt a Chrome cookie value."""
+        """Decrypt a Chrome cookie value, or return None so it is skipped.
+
+        ``host_key`` is the cookie's domain, and is passed only for databases at
+        schema 24 or later, where Chrome prepends a verifiable ``SHA256(host_key)``
+        to the plaintext.
+        """
         try:
             if not encrypted_value or len(encrypted_value) < 16:
                 return None
@@ -216,14 +222,14 @@ class ChromeCookieDecryptor:
             version = encrypted_value[:3]
 
             if version == b"v20":
-                return self._decrypt_v20_cookie(encrypted_value)
+                return self._decrypt_v20_cookie(encrypted_value, host_key)
 
             if version not in SUPPORTED_PREFIXES:
                 logger.debug(f"Unknown encryption version: {version}")
                 return None
 
             try:
-                return decrypt_cookie_value(encrypted_value, encryption_key, self.system)
+                return decrypt_cookie_value(encrypted_value, encryption_key, self.system, host_key)
             except CookieDecryptionError as exc:
                 # Skipping is the only safe outcome: CBC has no authentication,
                 # so a value that cannot be decrypted properly must never be
@@ -235,7 +241,9 @@ class ChromeCookieDecryptor:
             logger.debug(f"Failed to decrypt cookie: {e}")
             return None
 
-    def _decrypt_v20_cookie(self, encrypted_value: bytes) -> str | None:
+    def _decrypt_v20_cookie(
+        self, encrypted_value: bytes, host_key: str | None = None
+    ) -> str | None:
         """Decrypt an App-Bound Encryption (v20) cookie, or skip it honestly.
 
         Returns None when the master key is unavailable (non-Windows, not
@@ -256,7 +264,7 @@ class ChromeCookieDecryptor:
             return None
 
         try:
-            return decrypt_v20_cookie_value(encrypted_value, self.abe_master_key)
+            return decrypt_v20_cookie_value(encrypted_value, self.abe_master_key, host_key)
         except V20DecryptionError as e:
             logger.debug(f"Failed to decrypt v20 cookie: {e}")
             return None
@@ -299,15 +307,38 @@ class ChromeCookieDecryptor:
             logger.error(f"Failed to get decrypted cookies: {e}")
             return []
 
+    @staticmethod
+    def _cookie_schema_version(cursor) -> int:
+        """The cookie store's schema version, or 0 when it cannot be read.
+
+        Falling back to 0 means "assume no domain prefix", which is what every
+        database before schema 24 looks like. Guessing the other way would strip
+        32 bytes off the front of every real value.
+        """
+        try:
+            row = cursor.execute("SELECT value FROM meta WHERE key = 'version'").fetchone()
+            return int(row[0]) if row else 0
+        except (sqlite3.Error, TypeError, ValueError) as exc:
+            logger.debug(f"Could not read the cookie schema version: {exc}")
+            return 0
+
     def _extract_and_decrypt_cookies(
         self, db_path: str, encryption_key: bytes
     ) -> list[dict[str, Any]]:
         """Extract and decrypt cookies from the database."""
         cookies = []
+        encrypted_seen = 0
+        decrypted = 0
 
         try:
             conn = sqlite3.connect(db_path)
             cursor = conn.cursor()
+
+            # Schema 24 (Chrome ~130) prepends SHA256(host_key) to every encrypted
+            # plaintext. Reading the version is the only way to know whether a
+            # leading 32 bytes are a digest to verify or the value itself.
+            schema_version = self._cookie_schema_version(cursor)
+            has_domain_prefix = schema_version >= DOMAIN_PREFIX_SCHEMA_VERSION
 
             # Read all cookies
             cursor.execute("""
@@ -343,10 +374,16 @@ class ChromeCookieDecryptor:
                     cookie_value = value
                 # Otherwise try to decrypt
                 elif encrypted_value:
-                    cookie_value = self.decrypt_chrome_cookie_value(encrypted_value, encryption_key)
+                    encrypted_seen += 1
+                    cookie_value = self.decrypt_chrome_cookie_value(
+                        encrypted_value,
+                        encryption_key,
+                        host_key=host_key if has_domain_prefix else None,
+                    )
                     if not cookie_value:
                         logger.debug(f"Failed to decrypt cookie: {name}")
                         continue
+                    decrypted += 1
                 else:
                     continue
 
@@ -367,7 +404,19 @@ class ChromeCookieDecryptor:
 
             conn.close()
 
-            logger.info(f"Successfully decrypted {len(cookies)} Chrome cookies")
+            if encrypted_seen and not decrypted:
+                # Every single encrypted cookie failed. That is a wrong key or an
+                # unhandled format, not routine skipping, and it must not be
+                # reported as a success.
+                logger.error(
+                    f"Could not decrypt any of the {encrypted_seen} encrypted cookies "
+                    f"(schema {schema_version}). The migrated profile will have none of them."
+                )
+            elif encrypted_seen > decrypted:
+                logger.warning(
+                    f"Skipped {encrypted_seen - decrypted} of {encrypted_seen} encrypted cookies"
+                )
+            logger.info(f"Read {len(cookies)} Chrome cookies ({decrypted} decrypted)")
             return cookies
 
         except Exception as e:

--- a/extras/chrome_migration/cookie_decryptor.py
+++ b/extras/chrome_migration/cookie_decryptor.py
@@ -13,8 +13,15 @@ from typing import Any
 
 from loguru import logger
 
+from .cookie_crypto import (
+    SUPPORTED_PREFIXES,
+    CookieDecryptionError,
+    decrypt_cookie_value,
+)
+
 try:
-    from Crypto.Cipher import AES
+    # Only the PBKDF2 key derivation still needs pycryptodome; the ciphers moved
+    # to `cryptography` in cookie_crypto, which is a core dependency.
     from Crypto.Protocol.KDF import PBKDF2
 
     CRYPTO_AVAILABLE = True
@@ -202,42 +209,27 @@ class ChromeCookieDecryptor:
             if not encrypted_value or len(encrypted_value) < 16:
                 return None
 
-            # The first 3 bytes are the version. v10/v11 use the classic key
-            # (AES-128-CBC below); v20 is App-Bound Encryption and needs the
-            # separately resolved master key and an AES-256-GCM path. v20 runs on
-            # 'cryptography' (a core dependency), so it does not depend on the
-            # pycryptodome check that the v10/v11 CBC path below requires.
+            # The first three bytes are the version. v20 is App-Bound Encryption
+            # and needs its own master key; v10 and v11 use the classic key, but
+            # the cipher behind those two tags depends on the platform — see
+            # cookie_crypto for why reading the tag alone is not enough.
             version = encrypted_value[:3]
 
             if version == b"v20":
                 return self._decrypt_v20_cookie(encrypted_value)
 
-            if not CRYPTO_AVAILABLE:
-                logger.error("pycryptodome is not installed")
-                return None
-
-            if version == b"v10":
-                # Old format (before Chrome 80)
-                iv = b" " * 16  # empty IV
-                encrypted_data = encrypted_value[3:]
-            elif version == b"v11":
-                # New format (Chrome 80+)
-                iv = encrypted_value[3:15]  # 12-byte IV
-                encrypted_data = encrypted_value[15:]
-            else:
+            if version not in SUPPORTED_PREFIXES:
                 logger.debug(f"Unknown encryption version: {version}")
                 return None
 
-            # Decrypt
-            cipher = AES.new(encryption_key, AES.MODE_CBC, iv)
-            decrypted = cipher.decrypt(encrypted_data)
-
-            # Remove padding
-            padding_length = decrypted[-1]
-            if padding_length <= 16:
-                decrypted = decrypted[:-padding_length]
-
-            return decrypted.decode("utf-8", errors="ignore")
+            try:
+                return decrypt_cookie_value(encrypted_value, encryption_key, self.system)
+            except CookieDecryptionError as exc:
+                # Skipping is the only safe outcome: CBC has no authentication,
+                # so a value that cannot be decrypted properly must never be
+                # written as if it had been.
+                logger.debug(f"Failed to decrypt cookie: {exc}")
+                return None
 
         except Exception as e:
             logger.debug(f"Failed to decrypt cookie: {e}")

--- a/tests/unit/test_chrome_abe.py
+++ b/tests/unit/test_chrome_abe.py
@@ -9,6 +9,7 @@ here because it needs an elevated Windows host; see the module docstring.
 """
 
 import base64
+import hashlib
 import os
 import struct
 
@@ -45,11 +46,21 @@ def _wrap_master_key(aead, master_key: bytes) -> tuple[bytes, bytes]:
     return nonce, ct_and_tag
 
 
-def _encrypt_v20_cookie(master_key: bytes, value: str) -> bytes:
-    """Build a v20 encrypted_value: prefix + nonce + AES-256-GCM(prefix32 + value)."""
-    plaintext = os.urandom(32) + value.encode("utf-8")
+HOST_KEY = ".example.com"
+
+
+def _encrypt_v20_cookie(master_key: bytes, value: str, host_key: str | None = HOST_KEY) -> bytes:
+    """Build a v20 encrypted_value the way Chrome does.
+
+    From cookie-store schema 24 the plaintext is ``SHA256(host_key) || value``;
+    before that it is the bare value, which Chrome 127-129 could still write with
+    a v20 tag. Pass ``host_key=None`` for that older shape.
+    """
+    body = value.encode("utf-8")
+    if host_key is not None:
+        body = hashlib.sha256(host_key.encode("utf-8")).digest() + body
     nonce = os.urandom(12)
-    ct_and_tag = AESGCM(master_key).encrypt(nonce, plaintext, None)
+    ct_and_tag = AESGCM(master_key).encrypt(nonce, body, None)
     return abe.V20_COOKIE_PREFIX + nonce + ct_and_tag
 
 
@@ -173,9 +184,24 @@ def test_unwrap_master_key_tampered_tag_raises():
 # --- decrypt_v20_cookie_value ----------------------------------------------
 
 
-def test_decrypt_v20_cookie_value_strips_32_byte_prefix():
+def test_decrypt_v20_cookie_value_verifies_and_strips_the_domain_prefix():
+    """Schema 24 prepends SHA256(host_key). It is verified, not assumed: Chrome
+    itself drops a cookie whose digest does not match its domain."""
     master_key = os.urandom(32)
     enc_value = _encrypt_v20_cookie(master_key, "session=abc123")
+
+    assert abe.decrypt_v20_cookie_value(enc_value, master_key, HOST_KEY) == "session=abc123"
+
+    with pytest.raises(abe.V20DecryptionError):
+        abe.decrypt_v20_cookie_value(enc_value, master_key, ".other-site.com")
+
+
+def test_a_v20_cookie_from_a_pre_schema_24_store_has_no_prefix():
+    """Chrome 127-129 wrote v20 cookies into databases that still had schema 23.
+    Stripping 32 bytes there would take them off the front of the real value."""
+    master_key = os.urandom(32)
+    enc_value = _encrypt_v20_cookie(master_key, "session=abc123", host_key=None)
+
     assert abe.decrypt_v20_cookie_value(enc_value, master_key) == "session=abc123"
 
 
@@ -201,7 +227,7 @@ def test_full_chain_flag1_blob_to_cookie():
     assert recovered == master_key
 
     enc_value = _encrypt_v20_cookie(recovered, "auth=xyz")
-    assert abe.decrypt_v20_cookie_value(enc_value, recovered) == "auth=xyz"
+    assert abe.decrypt_v20_cookie_value(enc_value, recovered, HOST_KEY) == "auth=xyz"
 
 
 # --- ChromeCookieDecryptor honest degradation ------------------------------
@@ -221,4 +247,5 @@ def test_decryptor_decrypts_v20_with_master_key():
     master_key = os.urandom(32)
     decryptor.abe_master_key = master_key
     enc_value = _encrypt_v20_cookie(master_key, "logged_in=yes")
-    assert decryptor.decrypt_chrome_cookie_value(enc_value, os.urandom(16)) == "logged_in=yes"
+    value = decryptor.decrypt_chrome_cookie_value(enc_value, os.urandom(16), HOST_KEY)
+    assert value == "logged_in=yes"

--- a/tests/unit/test_cookie_crypto.py
+++ b/tests/unit/test_cookie_crypto.py
@@ -1,0 +1,123 @@
+"""The same ``v10`` tag means a different cipher on Windows than on macOS/Linux.
+
+Reading the tag and picking one algorithm is what broke Chrome cookie migration
+on Windows. Fixtures here are built with the real layouts, so every platform's
+path is exercised from any machine.
+"""
+
+import os
+import uuid
+
+import pytest
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from extras.chrome_migration.cookie_crypto import (
+    CookieDecryptionError,
+    decrypt_aes_cbc,
+    decrypt_aes_gcm,
+    decrypt_cookie_value,
+)
+
+
+def windows_blob(value: str, key: bytes, prefix: bytes = b"v10") -> bytes:
+    """[v10|v11][nonce:12][ciphertext][tag:16], AES-256-GCM — Chrome on Windows."""
+    nonce = os.urandom(12)
+    return prefix + nonce + AESGCM(key).encrypt(nonce, value.encode(), None)
+
+
+def cbc_blob(value: str, key: bytes, prefix: bytes = b"v10") -> bytes:
+    """[v10|v11][ciphertext], AES-128-CBC, sixteen-space IV — Chrome elsewhere."""
+    pad = 16 - len(value.encode()) % 16
+    encryptor = Cipher(algorithms.AES(key), modes.CBC(b" " * 16)).encryptor()
+    return prefix + encryptor.update(value.encode() + bytes([pad]) * pad) + encryptor.finalize()
+
+
+@pytest.mark.parametrize("prefix", [b"v10", b"v11"])
+def test_a_windows_cookie_round_trips(prefix):
+    key = os.urandom(32)
+    value = "session=abc123"
+
+    assert decrypt_aes_gcm(windows_blob(value, key, prefix), key) == value
+
+
+@pytest.mark.parametrize("length", [4, 20, 36, 52])
+def test_windows_lengths_that_used_to_decrypt_to_rubbish(length):
+    """The body is the nonce plus the ciphertext plus the tag, so a plaintext of
+    length 4 mod 16 made it a whole number of AES blocks. CBC then "succeeded"
+    and returned random bytes as the cookie value — one cookie in sixteen, and a
+    36-character session UUID is exactly one of them."""
+    key = os.urandom(32)
+    value = str(uuid.uuid4()) if length == 36 else "s" * length
+    blob = windows_blob(value, key)
+    assert (len(blob) - 3) % 16 == 0, "this fixture must hit the aligned case"
+
+    assert decrypt_aes_gcm(blob, key) == value
+
+
+@pytest.mark.parametrize("prefix", [b"v10", b"v11"])
+def test_a_cbc_cookie_round_trips(prefix):
+    """v11 differs from v10 only in where the password comes from, never in the
+    cipher. Treating it as "12-byte IV then CBC" meant v11 never decrypted on any
+    platform, because CBC requires a 16-byte IV."""
+    key = os.urandom(16)
+    value = "session=abc123-real-cookie-value"
+
+    assert decrypt_aes_cbc(cbc_blob(value, key, prefix), key) == value
+
+
+def test_a_wrong_gcm_key_is_refused():
+    """GCM authenticates, so the wrong key is caught outright."""
+    with pytest.raises(CookieDecryptionError):
+        decrypt_aes_gcm(windows_blob("session=abc", os.urandom(32)), os.urandom(32))
+
+
+def test_a_wrong_cbc_key_is_refused_by_its_padding():
+    """CBC has no tag, so the padding check is the only thing standing between a
+    wrong key and a plausible-looking value being written to the profile."""
+    encryptor = Cipher(algorithms.AES(os.urandom(16)), modes.CBC(b" " * 16)).encryptor()
+    body = encryptor.update(b"y" * 32) + encryptor.finalize()
+
+    with pytest.raises(CookieDecryptionError):
+        decrypt_aes_cbc(b"v10" + body, os.urandom(16))
+
+
+def test_bytes_that_are_not_utf8_are_refused():
+    """A key that happens to survive the padding check must still not produce a
+    mangled string: decoding strictly is the last integrity signal CBC has."""
+    key = os.urandom(16)
+    encryptor = Cipher(algorithms.AES(key), modes.CBC(b" " * 16)).encryptor()
+    body = encryptor.update(b"\xff\xfe\xfd\xfc" + bytes([12]) * 12) + encryptor.finalize()
+
+    with pytest.raises(CookieDecryptionError):
+        decrypt_aes_cbc(b"v10" + body, key)
+
+
+@pytest.mark.parametrize("prefix", [b"v20", b"v99", b"abc"])
+def test_an_unsupported_version_is_refused(prefix):
+    """v20 is App-Bound Encryption and belongs to another path entirely."""
+    with pytest.raises(CookieDecryptionError):
+        decrypt_aes_cbc(prefix + b"\x00" * 32, os.urandom(16))
+
+
+def test_a_truncated_windows_value_is_refused():
+    with pytest.raises(CookieDecryptionError):
+        decrypt_aes_gcm(b"v10" + os.urandom(8), os.urandom(32))
+
+
+def test_a_cbc_body_that_is_not_whole_blocks_is_refused():
+    with pytest.raises(CookieDecryptionError):
+        decrypt_aes_cbc(b"v10" + os.urandom(30), os.urandom(16))
+
+
+def test_the_platform_chooses_the_cipher():
+    """The dispatch itself: the same value, encrypted the way each platform does
+    it, decrypts only when the system matches."""
+    value = "session=abc123"
+    win_key, cbc_key = os.urandom(32), os.urandom(16)
+
+    assert decrypt_cookie_value(windows_blob(value, win_key), win_key, "windows") == value
+    assert decrypt_cookie_value(cbc_blob(value, cbc_key), cbc_key, "darwin") == value
+    assert decrypt_cookie_value(cbc_blob(value, cbc_key), cbc_key, "linux") == value
+
+    with pytest.raises(CookieDecryptionError):
+        decrypt_cookie_value(windows_blob(value, win_key), win_key, "darwin")

--- a/tests/unit/test_cookie_crypto.py
+++ b/tests/unit/test_cookie_crypto.py
@@ -5,6 +5,7 @@ on Windows. Fixtures here are built with the real layouts, so every platform's
 path is exercised from any machine.
 """
 
+import hashlib
 import os
 import uuid
 
@@ -121,3 +122,80 @@ def test_the_platform_chooses_the_cipher():
 
     with pytest.raises(CookieDecryptionError):
         decrypt_cookie_value(windows_blob(value, win_key), win_key, "darwin")
+
+
+# --- the cookie-store schema, which is a second layer on top of the cipher ---
+
+
+def v24_plaintext(value: str, host_key: str) -> bytes:
+    """From schema 24 Chrome encrypts SHA256(host_key) || value, not the value."""
+    return hashlib.sha256(host_key.encode()).digest() + value.encode()
+
+
+@pytest.mark.parametrize("system", ["windows", "darwin", "linux"])
+def test_a_schema_24_cookie_decrypts_on_every_platform(system):
+    """The prefix belongs to the cookie store, not to any cipher, so it applies
+    to GCM and CBC alike. Getting the cipher right and missing this recovered
+    zero cookies from any Chrome newer than late 2024."""
+    host_key, value = ".example.com", "SID=abcdefghijklmnop"
+    key = os.urandom(32 if system == "windows" else 16)
+    plaintext = v24_plaintext(value, host_key)
+
+    if system == "windows":
+        nonce = os.urandom(12)
+        blob = b"v10" + nonce + AESGCM(key).encrypt(nonce, plaintext, None)
+    else:
+        pad = 16 - len(plaintext) % 16
+        enc = Cipher(algorithms.AES(key), modes.CBC(b" " * 16)).encryptor()
+        blob = b"v10" + enc.update(plaintext + bytes([pad]) * pad) + enc.finalize()
+
+    assert decrypt_cookie_value(blob, key, system, host_key) == value
+
+
+def test_the_domain_digest_is_verified_not_assumed():
+    """Chrome drops a cookie whose digest does not match its own domain, and so
+    does this: blindly stripping 32 bytes would hand back a truncated value."""
+    key = os.urandom(32)
+    plaintext = v24_plaintext("SID=abc", ".example.com")
+    nonce = os.urandom(12)
+    blob = b"v10" + nonce + AESGCM(key).encrypt(nonce, plaintext, None)
+
+    with pytest.raises(CookieDecryptionError):
+        decrypt_cookie_value(blob, key, "windows", ".attacker.example")
+
+
+def test_a_pre_schema_24_cookie_keeps_its_whole_value():
+    """Passing no host_key means "this store has no prefix". Stripping anyway
+    would take 32 bytes off the front of every real value."""
+    key = os.urandom(32)
+
+    assert decrypt_cookie_value(windows_blob("SID=abc", key), key, "windows") == "SID=abc"
+
+
+def test_the_digest_gives_cbc_the_integrity_check_it_lacks():
+    """PKCS#7 padding validates by chance about once in 256 tries, and CBC has no
+    tag. A digest over the row's own domain closes that gap."""
+    plaintext = v24_plaintext("SID=abc", ".example.com")
+    pad = 16 - len(plaintext) % 16
+    enc = Cipher(algorithms.AES(os.urandom(16)), modes.CBC(b" " * 16)).encryptor()
+    blob = b"v10" + enc.update(plaintext + bytes([pad]) * pad) + enc.finalize()
+
+    with pytest.raises(CookieDecryptionError):
+        decrypt_cookie_value(blob, os.urandom(16), "darwin", ".example.com")
+
+
+@pytest.mark.parametrize("system", ["cygwin_nt-10.0", "freebsd", ""])
+def test_an_unknown_platform_is_refused_rather_than_assumed_to_be_cbc(system):
+    """Under Cygwin or MSYS platform.system() is not "windows", and silently
+    treating a Windows profile as CBC would skip every cookie it has."""
+    key = os.urandom(32)
+
+    with pytest.raises(CookieDecryptionError):
+        decrypt_cookie_value(windows_blob("SID=abc", key), key, system)
+
+
+def test_a_cbc_key_of_the_wrong_length_is_refused_not_raised_raw():
+    """The module's contract is CookieDecryptionError; a bare ValueError from the
+    cipher would escape callers that catch only ours."""
+    with pytest.raises(CookieDecryptionError):
+        decrypt_aes_cbc(cbc_blob("SID=abc", os.urandom(16)), os.urandom(20))


### PR DESCRIPTION
Closes the follow-up left open by the App-Bound Encryption work. Measuring it made the bug worse than it was reported.

## The bug

The `v10`/`v11` prefix on a Chrome cookie **does not name a cipher**:

| Platform | Cipher | Layout |
| --- | --- | --- |
| Windows | AES-256-GCM | `[v10\|v11][nonce:12][ciphertext][tag:16]` |
| macOS, Linux | AES-128-CBC, IV of 16 spaces, PKCS#7 | `[v10\|v11][ciphertext]` |

The decryptor read the tag and applied CBC to everything.

**On Windows that is not a clean failure.** Fifteen cookies in sixteen fail outright, because a GCM body is rarely a multiple of the AES block size. The sixteenth — where the nonce, ciphertext and tag happen to total a whole number of blocks — "succeeds", and the random bytes are returned and written **as the cookie value**. That is a plaintext whose length is 4 mod 16, and a 36-character session UUID is exactly that length. Measured on synthetic fixtures:

```
plaintext  4 chars  -> 'M!u~ \x10cov͊`#\x05YNis'
plaintext 20 chars  -> '%\x1cHj\r\x1e=:6\x181gqJCo\x14\x07N&>O@"{KI>'
plaintext 36 chars  -> '\x16(K\x18\x1e9E\x0c*\x0e7d5#\x11Q+x2k׹Tc\x1e>=A1е\t'
   -> 3/3 written as if they were real cookie values
```

**`v11` was separately broken on every platform.** It was read as "12-byte IV, then CBC", which cannot work — CBC requires a 16-byte IV, so PyCryptodome raised and every `v11` cookie was skipped. On macOS and Linux `v11` differs from `v10` only in *where the password comes from*, never in the cipher; on Linux it is the normal format when the key lives in the keyring.

So Chrome migration was broken on Windows since well before App-Bound Encryption existed, and partly broken on Linux too.

## The fix

A pure `cookie_crypto` module, following the pattern `abe.py` established: built on `cryptography` (a core dependency), so **all three platforms' layouts are exercised from any machine** — no `chrome-migration` extra, no Windows needed.

Two things that were missing and matter more than the cipher choice:

- **PKCS#7 padding is validated, not trusted.** The old code read the last byte and stripped that many. With a wrong key the plaintext is random, so that silently truncates or corrupts a value that should have been refused.
- **The plaintext is decoded strictly.** It was `errors="ignore"`, which turns mojibake into a "successful" result. CBC has no authentication tag, so padding validation and a strict decode are the only integrity signals there are.

A value that cannot be decrypted is skipped, never written mangled — the same rule the `v20` work established.

## Tests

17 new tests in `tests/unit/test_cookie_crypto.py`, including the four plaintext lengths that used to yield rubbish (asserting the fixture really does hit the aligned case), `v11` on both cipher families, a wrong key on each, non-UTF-8 bytes, truncated values and the platform dispatch itself.

```
ruff / format / mypy                        clean
HOME=$(mktemp -d) pytest -m "not browser"   361 passed, 20 deselected
with the chrome-migration extra             34 passed (cookie_crypto + abe)
```

## Note

This is `[Unreleased]`, not part of `0.2.0` — that release went out with the bug. The roadmap gained a "Since 0.2.0" section rather than backdating it into the shipped list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)