### PR TITLE
Bump lucide-react to 1.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
+- **Icons are on lucide-react 1.** Nothing the UI imports was dropped in the
+  major, but four of the names had been legacy aliases and now use the ones
+  lucide actually ships: `TriangleAlert`, `LoaderCircle`, `Ellipsis`, and
+  `RotateCcwClock` (kept locally as `History`, which is what it means beside a
+  History button). Five icons were redrawn upstream — the play triangle and the
+  pause bars are heavier and now match each other, and the gear, trash, and
+  calendar-clock are near-identical at the sizes the UI uses.
 - **The web UI is on Next 16.** Next 16 removes `next lint`, so linting now calls
   the ESLint CLI directly; `eslint-config-next` 16 ships real flat configs, so the
   `FlatCompat` shim and `@eslint/eslintrc` are gone. Next 16's rule set flagged

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,7 +8,7 @@
       "name": "web-interface",
       "version": "0.2.1",
       "dependencies": {
-        "lucide-react": "^0.516.0",
+        "lucide-react": "^1.31.0",
         "next": "16.3.1",
         "react": "^19.2.8",
         "react-dom": "^19.2.8"
@@ -5282,9 +5282,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.516.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.516.0.tgz",
-      "integrity": "sha512-aybBJzLHcw1CIn3rUcRkztB37dsJATtpffLNX+0/w+ws2p21nYIlOwX/B5fqxq8F/BjqVemnJX8chKwRidvROg==",
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.31.0.tgz",
+      "integrity": "sha512-G8u2eEtoHUnUa9f8lbvqDhCiORMnYLdUEo06EEG9MQvHQrInKcX3Pa2TH39MM5qyzRcWETxB0+aOwAPI1g1kEg==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
     "build:static": "next build"
   },
   "dependencies": {
-    "lucide-react": "^0.516.0",
+    "lucide-react": "^1.31.0",
     "next": "16.3.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8"

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -8,8 +8,8 @@ import {
   ChevronRight,
   Copy,
   Download,
+  Ellipsis,
   Globe,
-  MoreHorizontal,
   PackageOpen,
   Pencil,
   Play,
@@ -719,7 +719,7 @@ export default function ProfilesPage() {
                             setMenuFor(menuFor === profile.id ? null : profile.id)
                           }}
                         >
-                          <MoreHorizontal size={15} />
+                          <Ellipsis size={15} />
                         </button>
 
                         {menuFor === profile.id && (

--- a/web/src/app/schedules/page.tsx
+++ b/web/src/app/schedules/page.tsx
@@ -3,11 +3,13 @@
 import { useCallback, useEffect, useState } from 'react'
 import {
   CalendarClock,
-  History,
   Pause,
   Pencil,
   Play,
   Plus,
+  // lucide 1.0 renamed History to RotateCcwClock. The old name is the one that
+  // means anything next to a History button, so keep it locally.
+  RotateCcwClock as History,
   Trash2,
 } from 'lucide-react'
 

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { AlertTriangle, Check, Minus, Settings as SettingsIcon } from 'lucide-react'
+import { Check, Minus, Settings as SettingsIcon, TriangleAlert } from 'lucide-react'
 
 import { EmptyState } from '@/components/empty-state'
 import { useToast } from '@/components/toast'
@@ -217,7 +217,7 @@ function Toggle({
         {on ? (
           <Check size={14} className="mt-0.5 shrink-0 text-ok" />
         ) : warn ? (
-          <AlertTriangle size={14} className="mt-0.5 shrink-0 text-danger" />
+          <TriangleAlert size={14} className="mt-0.5 shrink-0 text-danger" />
         ) : (
           <Minus size={14} className="mt-0.5 shrink-0 text-ink-faint" />
         )}

--- a/web/src/components/profile-form.tsx
+++ b/web/src/components/profile-form.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useState } from 'react'
-import { AlertTriangle, Check, Info, Loader2, RefreshCw, X } from 'lucide-react'
+import { Check, Info, LoaderCircle, RefreshCw, TriangleAlert, X } from 'lucide-react'
 
 import { Modal } from '@/components/modal'
 import { useToast } from '@/components/toast'
@@ -376,7 +376,7 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
             Cancel
           </button>
           <button type="submit" form="profile-form" className="btn btn-primary" disabled={saving}>
-            {saving && <Loader2 size={13} className="animate-spin" />}
+            {saving && <LoaderCircle size={13} className="animate-spin" />}
             {isEdit ? 'Save changes' : 'Create profile'}
           </button>
         </>
@@ -558,7 +558,7 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
               disabled={checkingProxy}
             >
               {checkingProxy ? (
-                <Loader2 size={13} className="animate-spin" />
+                <LoaderCircle size={13} className="animate-spin" />
               ) : (
                 <RefreshCw size={13} />
               )}
@@ -784,7 +784,7 @@ export function ProfileForm({ open, profile, groups, onClose, onSaved }: Props) 
                   onClick={handleClearGeography}
                   disabled={clearingGeography}
                 >
-                  {clearingGeography && <Loader2 size={13} className="animate-spin" />}
+                  {clearingGeography && <LoaderCircle size={13} className="animate-spin" />}
                   Clear both, follow the proxy
                 </button>
               </div>
@@ -880,7 +880,7 @@ function PinnedMachine({
           so offer the update a real machine would have taken. */}
       {fingerprint.browser_outdated && (
         <div className="mt-2 flex items-start gap-2.5 rounded-md border border-line bg-raised p-2.5">
-          <AlertTriangle size={14} className="mt-0.5 shrink-0 text-signal" />
+          <TriangleAlert size={14} className="mt-0.5 shrink-0 text-signal" />
           <div className="flex-1">
             <p className="text-ink">
               This profile still reports Firefox {fingerprint.browser_major}; the installed browser
@@ -897,7 +897,7 @@ function PinnedMachine({
             onClick={onRefreshBrowser}
             disabled={refreshing}
           >
-            {refreshing && <Loader2 size={13} className="animate-spin" />}
+            {refreshing && <LoaderCircle size={13} className="animate-spin" />}
             Update
           </button>
         </div>
@@ -910,7 +910,7 @@ function PinnedMachine({
       {fingerprint.os_mismatch && (
         <div className="mt-2 rounded-md border border-line bg-raised p-2.5">
           <div className="flex items-start gap-2.5">
-            <AlertTriangle size={14} className="mt-0.5 shrink-0 text-warn" />
+            <TriangleAlert size={14} className="mt-0.5 shrink-0 text-warn" />
             <div>
               <p className="text-ink">
                 This profile is set to {osLabel(fingerprint.settings_os)}, but its pinned machine is
@@ -932,7 +932,7 @@ function PinnedMachine({
               onClick={() => onReconcileOs(true)}
               disabled={reconciling}
             >
-              {reconciling && <Loader2 size={13} className="animate-spin" />}
+              {reconciling && <LoaderCircle size={13} className="animate-spin" />}
               Keep this machine
             </button>
             <button
@@ -1023,7 +1023,7 @@ function ProxyCheckResult({ result }: { result: ProxyCheck | null }) {
           {finding.level === 'info' ? (
             <Info size={13} className="mt-0.5 shrink-0" />
           ) : (
-            <AlertTriangle size={13} className="mt-0.5 shrink-0" />
+            <TriangleAlert size={13} className="mt-0.5 shrink-0" />
           )}
           <span>{finding.message}</span>
         </p>

--- a/web/src/components/toast.tsx
+++ b/web/src/components/toast.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { createContext, useCallback, useContext, useEffect, useState } from 'react'
-import { AlertTriangle, Check, Info, X } from 'lucide-react'
+import { Check, Info, TriangleAlert, X } from 'lucide-react'
 
 type ToastKind = 'ok' | 'error' | 'info'
 
@@ -53,7 +53,7 @@ function ToastRow({ toast, onDismiss }: { toast: Toast; onDismiss: () => void })
     return () => clearTimeout(timer)
   }, [onDismiss, toast.kind])
 
-  const Icon = toast.kind === 'ok' ? Check : toast.kind === 'error' ? AlertTriangle : Info
+  const Icon = toast.kind === 'ok' ? Check : toast.kind === 'error' ? TriangleAlert : Info
   const tone =
     toast.kind === 'ok' ? 'text-ok' : toast.kind === 'error' ? 'text-danger' : 'text-ink-dim'
 


### PR DESCRIPTION
Takes Dependabot #35, plus the rename work the major implies.

## What the major actually changes here

Every one of the 30 icons the UI imports still resolves in 1.31.0 — nothing was removed. Verified by rendering all 30 in both versions with `renderToStaticMarkup` and diffing the SVG output: 24 are byte-identical, 6 differ.

**Four imports were legacy aliases.** lucide kept them from before its renames, and they still work, but a major that exists to clean up the export surface is where that debt comes due:

| was | now |
| --- | --- |
| `AlertTriangle` | `TriangleAlert` |
| `Loader2` | `LoaderCircle` |
| `MoreHorizontal` | `Ellipsis` |
| `History` | `RotateCcwClock as History` |

`History` keeps its local name — `RotateCcwClock` says nothing beside a History button.

**Five icons were redrawn upstream** (`Play`, `Pause`, `Settings`, `Trash2`, `CalendarClock`). Play went from a `<polygon>` to a rounded path and Pause from 4×16 to 5×18 bars: both are heavier and now agree with each other, which is what you want from a pair that sits side by side in the schedules row. The gear, trash and calendar-clock are near-identical at the 13–16px the UI uses.

## Verified

- `npm ci`, `eslint . --max-warnings=0`, `tsc --noEmit`, `next build`, `NEXT_EXPORT=1 next build` — all pass
- Ran the built UI from the app: profiles table, row menu (Ellipsis trigger, Pencil/Copy/Globe/PackageOpen/Trash2 items), Run button, schedules row (Play/Pause/History/Pencil/Trash2), sidebar. Zero console errors or warnings.

Closes #35.