### PR TITLE
Bump TypeScript to 6.0.3 (and why not 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 ### Changed
-- **TypeScript 5.9 → 6.0.3**, the last release with a JavaScript compiler API.
+- **TypeScript 5.9 → 6.0.3**, the last TypeScript line with a JavaScript compiler API.
   TypeScript 7 is the Go rewrite and ships no API, which is what
   `typescript-eslint` and Next's build-time type check both run on, so 6.0 is as
   far as the toolchain goes for now. See the roadmap for the detail.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-Nothing yet.
+### Changed
+- **TypeScript 5.9 → 6.0.3**, the last release with a JavaScript compiler API.
+  TypeScript 7 is the Go rewrite and ships no API, which is what
+  `typescript-eslint` and Next's build-time type check both run on, so 6.0 is as
+  far as the toolchain goes for now. See the roadmap for the detail.
 
 ## [0.3.0] - 2026-08-14
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -81,12 +81,15 @@ order of how much they would hurt if left alone:
 - The browser test suite depends on reaching `example.com` and `iana.org`, so a
   full run can flake on a rate limit rather than a real fault. Serving the two
   origins locally would make it deterministic.
-- **TypeScript 7 is blocked upstream, not by us.** `typescript-eslint` declares
-  `typescript: >=4.8.4 <6.1.0` and refuses to load under TypeScript 7, so the
-  bump would break `npm run lint` on its own. Worth retrying when it publishes
-  support. (ESLint 10 was the same story until the config stopped asking
-  `eslint-plugin-react` to detect the React version — see the note in
-  [web/eslint.config.mjs](../web/eslint.config.mjs).)
+- **TypeScript 7 waits on the tools, not on us.** The UI is on TypeScript 6.0.3,
+  the last release with a JavaScript compiler API. TypeScript 7 is the Go
+  rewrite: its package ships a `tsc` binary and no API — `require("typescript")`
+  has no `createProgram` — and both `typescript-eslint` and Next's build-time
+  type check need that API. TypeScript documents a side-by-side install that
+  keeps the 6.0 API for tooling, but here it would buy only a faster standalone
+  `tsc` that CI never runs, for ~30 MB of platform binaries. Worth revisiting
+  when `typescript-eslint` supports TS 7 (their issue #10940) and Next type-checks
+  through it.
 - Proxy health at a glance in the profiles list, so a dead proxy is visible
   without opening each profile and pressing *Check proxy*.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -82,7 +82,7 @@ order of how much they would hurt if left alone:
   full run can flake on a rate limit rather than a real fault. Serving the two
   origins locally would make it deterministic.
 - **TypeScript 7 waits on the tools, not on us.** The UI is on TypeScript 6.0.3,
-  the last release with a JavaScript compiler API. TypeScript 7 is the Go
+  the last TypeScript line with a JavaScript compiler API. TypeScript 7 is the Go
   rewrite: its package ships a `tsc` binary and no API — `require("typescript")`
   has no `createProgram` — and both `typescript-eslint` and Next's build-time
   type check need that API. TypeScript documents a side-by-side install that

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web-interface",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web-interface",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "lucide-react": "^1.31.0",
         "next": "16.3.1",
@@ -22,7 +22,7 @@
         "eslint-config-next": "16.3.1",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -6578,9 +6578,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -22,7 +22,7 @@
         "eslint-config-next": "16.3.1",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^6.0.3"
+        "typescript": "~6.0.3"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,6 @@
     "eslint-config-next": "16.3.1",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^6.0.3"
+    "typescript": "~6.0.3"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -24,6 +24,6 @@
     "eslint-config-next": "16.3.1",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
Dependabot's TypeScript 7 PR (#26) was closed as blocked upstream. This is the part of it that can actually land — and the evidence for why the rest cannot.

## TypeScript 7 cannot do the job here

TS 7 is the Go rewrite. Its npm package ships a compiler binary and no JavaScript API:

```
$ node -e "const ts=require('typescript'); console.log(ts.version, typeof ts.createProgram)"
7.0.2 undefined
```

Two things in this project run on that API:

- **typescript-eslint** throws rather than degrades — `typescript-eslint does not support TS 7.0.` is a hard `throw` at import time in three of its packages, pointing at [their issue #10940](https://github.com/typescript-eslint/typescript-eslint/issues/10940) for TS >= 7.1 support.
- **Next's build-time type check** — Next 16 recognises a native compiler and says it itself: *"Some Next.js TypeScript features (like type checking during build) require the standard `typescript` package."*

## The documented side-by-side install, tried

TypeScript's 7.0 announcement documents keeping the 6.0 API for tooling while `tsc` is 7, via npm aliases. I set it up and installed it:

```json
"typescript": "npm:@typescript/typescript6@^6.0.2",
"typescript-7": "npm:typescript@^7.0.2"
```

After a clean `npm install`, `npx tsc --version` reported **6.0.3** — the aliased 6.0 package won the `tsc` bin, so the single thing the arrangement exists to provide was not reliable. And `tsc --noEmit` is not part of the CI Frontend job (which runs lint + both builds), so the prize was a faster local command nobody runs in automation, for ~30 MB of platform binaries and a package.json that needs a paragraph of explanation.

Reverted. TS 6 is where this toolchain ends for now.

## What lands

`typescript` 5.9.3 → **6.0.3**, the last release with the JS API. Everything supports it: `typescript-eslint` peers at `>=4.8.4 <6.1.0`, Next 16 type-checks with it, and `tsconfig.json` needed no changes.

## Verified

From a clean `node_modules`: `npm ci`, `eslint . --max-warnings=0`, `tsc --noEmit`, `next build`, `NEXT_EXPORT=1 next build` — all pass, no diagnostics. Then the built UI served by the app: profiles load, zero console errors or warnings.