### PR TITLE
feat: PostgreSQL backend with row-level profile leases (multi-instance safety)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,20 @@ CPM_SECURE_COOKIES=0
 # SQLite database path
 CPM_DB_PATH=data/profiles.db
 
+# PostgreSQL DSN. Leave empty for SQLite. Set it and every instance pointed at
+# the same database shares profiles, which the row-level leases below make safe.
+# Needs the postgres extra: pip install 'camoufox-pm[postgres]'
+CPM_DB_URL=
+
+# Where profile browser data lives. Defaults to CPM_DB_PATH's directory, so it
+# MUST be set when CPM_DB_URL is: a DSN has no directory to derive it from.
+CPM_DATA_DIR=
+
+# Seconds a lease survives without a heartbeat — how long a crashed instance's
+# profiles stay locked to the fleet. Minimum 60; the heartbeat renews every 30s,
+# so a shorter TTL would expire leases under live browsers.
+CPM_LEASE_TTL=120
+
 # Override where the bundled web UI is served from. Leave empty to use the
 # package's own webui/ directory, then web/out when running from source.
 CPM_WEBUI_DIR=

--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ Settings come from environment variables (prefix `CPM_`). Copy `.env.example` to
 | `CPM_HOST`         | `127.0.0.1`             | Bind address                                    |
 | `CPM_PORT`         | `8000`                  | Port                                            |
 | `CPM_DB_PATH`      | `data/profiles.db`      | SQLite database path                            |
+| `CPM_DB_URL`       | *(empty)*               | PostgreSQL DSN. Set it and every instance pointed at the same database shares profiles; unset keeps the SQLite file above. Requires the `postgres` extra |
+| `CPM_DATA_DIR`     | *(dirname of `CPM_DB_PATH`)* | Where profile browser data lives. Required with `CPM_DB_URL`, which has no path to derive it from |
+| `CPM_LEASE_TTL`    | `120`                   | Seconds a profile's lease survives without a heartbeat — how long a crashed instance's profiles stay locked. Minimum 60; the heartbeat renews every 30s |
 | `CPM_SECRET_KEY`   | *(empty)*               | Fernet key; encrypts proxy passwords at rest    |
 | `CPM_API_KEY`      | *(empty)*               | If set, required as the `X-API-Key` header (machine clients) |
 | `CPM_SESSION_TTL_HOURS` | `168`              | Login session lifetime, in hours                |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+# psycopg is imported lazily and guarded; only Postgres (CPM_DB_URL) users need it.
+postgres = ["psycopg[binary]>=3.1"]
 chrome-migration = [
     "pycryptodome>=3.19",
     "pyyaml>=6.0",
@@ -124,6 +126,7 @@ asyncio_mode = "auto"
 testpaths = ["tests"]
 markers = [
     "browser: real Camoufox launch (opt-in, slow, requires 'camoufox fetch')",
+    "postgres: real PostgreSQL backend (opt-in; needs CPM_TEST_DB_URL, see tests/conftest.py)",
 ]
 
 [tool.mypy]

--- a/src/camoufox_pm/api/routes/profiles.py
+++ b/src/camoufox_pm/api/routes/profiles.py
@@ -38,6 +38,7 @@ from camoufox_pm.api.models.profiles import (
 )
 from camoufox_pm.api.models.system import ApiResponse, ExcelImportData
 from camoufox_pm.core import proxy_check
+from camoufox_pm.core.errors import ProfileLocked
 from camoufox_pm.core.excel_manager import ExcelManager
 from camoufox_pm.core.models import BrowserSettings, ProfileStatus, ProxyConfig
 
@@ -322,6 +323,11 @@ async def launch_profile(profile_id: str, request: ProfileLaunchRequest):
             },
         )
 
+    except ProfileLocked as e:
+        # Another instance holds the lease. That is a conflict, not a server
+        # fault: a client can retry once the holder closes the browser, and a
+        # 500 would read as "we broke" for an outcome the design intends.
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e)) from e
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except Exception as e:

--- a/src/camoufox_pm/api/routes/system.py
+++ b/src/camoufox_pm/api/routes/system.py
@@ -37,10 +37,13 @@ def _cleanup_manager() -> ProfileCleanupManager:
     ``./data/profiles.db`` whatever ``CPM_DB_PATH`` says. With the database
     configured under any other name, the cleanup opened an empty one beside it,
     concluded that every profile directory on disk was an orphan, and deleted
-    them all.
+    them all. With PostgreSQL there is no database file at all, so the data
+    directory (explicit, or the SQLite path's parent for compatibility) is
+    what cleanup reconciles.
     """
-    db_path = Path(get_settings().db_path)
-    return ProfileCleanupManager(str(db_path.parent), str(db_path))
+    settings = get_settings()
+    data_dir = settings.data_dir or str(Path(settings.db_path).parent)
+    return ProfileCleanupManager(data_dir, settings.db_path)
 
 
 @router.get(

--- a/src/camoufox_pm/cli.py
+++ b/src/camoufox_pm/cli.py
@@ -18,6 +18,7 @@ from typing import NoReturn
 import uvicorn
 
 from camoufox_pm.config import get_settings
+from camoufox_pm.core.database import StorageManager
 
 
 def main() -> None:
@@ -68,10 +69,35 @@ def main() -> None:
 
     user_commands.add_parser("list", help="List accounts (never shows password hashes)")
 
+    # Shell-only on purpose. A "force unlock" behind the HTTP API would be a
+    # button, and a button is the fastest route to two machines driving one
+    # identity — the exact corruption the lease exists to prevent. Reaching for
+    # it here means deliberate shell access to the host.
+    unlock = subcommands.add_parser(
+        "unlock",
+        help="Force-release a profile's lease (Postgres backend)",
+        description=(
+            "Clear the lease holding a profile, whatever it says. Only needed when "
+            "a machine died in a way its lease cannot notice, or the operator has "
+            "verified the holder is really gone — a live lease means another "
+            "machine may be driving the profile right now."
+        ),
+    )
+    unlock.add_argument("profile_id")
+    unlock.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the confirmation prompt",
+    )
+
     args = parser.parse_args()
 
     if args.command == "user":
         asyncio.run(_run_user_command(args))
+        return
+
+    if args.command == "unlock":
+        asyncio.run(_run_unlock_command(args))
         return
 
     # Make the settings match what we are about to bind, so everything that reads
@@ -116,6 +142,33 @@ def _read_password(args: argparse.Namespace) -> str:
     if len(password) < MIN_PASSWORD_LENGTH:
         _fail(f"Password must be at least {MIN_PASSWORD_LENGTH} characters.")
     return password
+
+
+async def _run_unlock_command(args: argparse.Namespace) -> None:
+    """Force-release one profile's lease; shell-only (see the parser above)."""
+    storage = StorageManager(get_settings().db_path)
+    await storage.initialize()
+    try:
+        lease = await storage.get_lease(args.profile_id)
+        if lease is None:
+            _fail(f"No profile with ID '{args.profile_id}'.")
+        if lease[0] is None:
+            print(f"Profile {args.profile_id} is not leased.")
+            return
+        holder, expires = lease
+        print(
+            f"Profile {args.profile_id} is leased by {holder}"
+            + (f" until {expires}" if expires else " (no expiry)")
+        )
+        if not args.yes:
+            answer = input("Force-release this lease? (yes/no): ").lower()
+            if answer not in ("yes", "y"):
+                print("Cancelled; the lease stands.")
+                return
+        previous = await storage.force_release_lease(args.profile_id)
+        print(f"Lease released (was held by {previous}).")
+    finally:
+        await storage.close()
 
 
 async def _run_user_command(args: argparse.Namespace) -> None:

--- a/src/camoufox_pm/config.py
+++ b/src/camoufox_pm/config.py
@@ -17,6 +17,17 @@ class Settings(BaseSettings):
     cors_origins: Annotated[list[str], NoDecode] = ["http://localhost:3000"]
     api_key: str | None = None
     db_path: str = "data/profiles.db"
+    # PostgreSQL connection URL. Unset (the default) keeps the SQLite file above;
+    # set, every instance pointed at the same database shares profiles — which
+    # is what the row-level leases (CPM_LEASE_TTL) exist to make safe.
+    db_url: str | None = None
+    # Where profile browser data lives. Only derived from db_path's directory
+    # when this is not set explicitly: with Postgres there is no db_path, and
+    # deriving from it would put profile storage at "/".
+    data_dir: str | None = None
+    # How long a lease lasts without a heartbeat. The heartbeat renews every 30s,
+    # so this is the time a crashed instance's leases take to free themselves.
+    lease_ttl: int = 120
     secret_key: str | None = None
     webui_dir: str | None = None
     # Lifetime of a login session. Sessions are stored server-side, so shortening

--- a/src/camoufox_pm/config.py
+++ b/src/camoufox_pm/config.py
@@ -27,6 +27,8 @@ class Settings(BaseSettings):
     data_dir: str | None = None
     # How long a lease lasts without a heartbeat. The heartbeat renews every 30s,
     # so this is the time a crashed instance's leases take to free themselves.
+    # Floored well above that interval: a TTL at or below it expires leases under
+    # live browsers, and 0 or negative turns mutual exclusion off silently.
     lease_ttl: int = 120
     secret_key: str | None = None
     webui_dir: str | None = None
@@ -37,6 +39,18 @@ class Settings(BaseSettings):
     # when the request itself arrived over HTTPS, but behind a TLS-terminating
     # proxy the app sees plain HTTP — set this there.
     secure_cookies: bool = False
+
+    @field_validator("lease_ttl")
+    @classmethod
+    def _lease_ttl_outlives_the_heartbeat(cls, value: int) -> int:
+        # 60s is two heartbeat intervals: anything at or below one interval
+        # expires a lease the owning instance is still renewing, so a browser
+        # keeps running while another machine is free to take its profile.
+        if value < 60:
+            raise ValueError(
+                "CPM_LEASE_TTL must be at least 60 seconds (heartbeat renews every 30s)"
+            )
+        return value
 
     @field_validator("cors_origins", mode="before")
     @classmethod

--- a/src/camoufox_pm/core/browser_session.py
+++ b/src/camoufox_pm/core/browser_session.py
@@ -18,6 +18,9 @@ from typing import Any
 import psutil
 from loguru import logger
 
+from ..config import get_settings
+from .database import StorageManager
+
 try:
     from camoufox.async_api import AsyncCamoufox
 
@@ -118,16 +121,99 @@ class BrowserSession:
 class BrowserSessionManager:
     """Track and control the browsers currently running."""
 
-    def __init__(self) -> None:
+    def __init__(self, storage: StorageManager | None = None, holder: str | None = None) -> None:
         self.active_sessions: dict[str, BrowserSession] = {}
+        # Profile id -> number of launches currently inside camoufox.start().
+        # A count, not a set: concurrent launches of one profile must not clear
+        # each other's mark. Held from before start() until the session is
+        # registered or that launch fails.
+        self._starting: dict[str, int] = {}
         # The event loop only holds weak references to tasks, so a teardown
         # suspended inside camoufox.__aexit__ could be garbage-collected and take
         # the primary cleanup path with it. Hold a strong reference until done.
         self._exit_tasks: set[asyncio.Task[None]] = set()
+        # Lease renewal. Without a storage backend and holder id (unit tests,
+        # tools that only watch processes) the manager behaves exactly as before.
+        self._storage = storage
+        self._holder = holder
+        self._heartbeat_task: asyncio.Task[None] | None = None
+
+    def start_heartbeat(self, interval: float = 30.0) -> None:
+        """Begin renewing this instance's leases in the background.
+
+        The heartbeat is what keeps a lease alive while a browser runs; when it
+        stops (crash, kill -9), the lease outlives the browser by at most its
+        TTL and then frees itself. A stolen lease closes the browser instead of
+        being fought over: the other machine is already driving that identity.
+        """
+        if self._storage is None or self._holder is None:
+            return
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop(interval))
+
+    async def stop_heartbeat(self) -> None:
+        """Stop the renewal loop. Renewal must not race shutdown."""
+        if self._heartbeat_task is not None:
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except asyncio.CancelledError:
+                pass
+            self._heartbeat_task = None
+
+    async def _heartbeat_loop(self, interval: float) -> None:
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                await self._renew_leases()
+            except Exception as exc:  # noqa: BLE001 - one failed beat must not kill the loop
+                logger.warning(f"Lease heartbeat failed: {exc}")
+
+    async def _renew_leases(self) -> None:
+        """Renew every active lease; close any browser whose lease was lost."""
+        if self._storage is None or self._holder is None or not self.active_sessions:
+            return
+        profile_ids = list(self.active_sessions)
+        # Same TTL source as launch (settings.lease_ttl / CPM_LEASE_TTL): a
+        # hardcoded beat here would collapse a longer lease and let it expire
+        # under a live browser.
+        ttl_seconds = get_settings().lease_ttl
+        renewed = await self._storage.renew_lease(
+            profile_ids, self._holder, ttl_seconds=ttl_seconds
+        )
+        if renewed == len(profile_ids):
+            return
+        # Single-profile renewal to learn exactly which leases survive; the
+        # bulk update above already extended the ones that did.
+        renewed_ids = set()
+        for profile_id in profile_ids:
+            if (
+                await self._storage.renew_lease([profile_id], self._holder, ttl_seconds=ttl_seconds)
+                > 0
+            ):
+                renewed_ids.add(profile_id)
+        for profile_id in profile_ids:
+            if profile_id in renewed_ids:
+                continue
+            logger.warning(
+                f"Lease on profile {profile_id} was taken over or expired — "
+                "another machine may be driving this identity; closing the browser."
+            )
+            # Not recovering: the identity is being driven elsewhere.
+            await self.close(profile_id)
 
     def is_running(self, profile_id: str) -> bool:
         """Return whether a browser is currently tracked for the profile."""
         return profile_id in self.active_sessions
+
+    def is_live(self, profile_id: str) -> bool:
+        """Whether a browser is running OR starting up for the profile.
+
+        is_running() alone is false while camoufox.start() is still being
+        awaited, so a lease released on that answer can be taken from a browser
+        that is coming up. Lease decisions must use this; user-facing "is it
+        open" answers stay on is_running().
+        """
+        return profile_id in self.active_sessions or profile_id in self._starting
 
     def list_active(self) -> list[dict[str, Any]]:
         """Return summaries of the active sessions.
@@ -153,16 +239,30 @@ class BrowserSessionManager:
         if profile_id in self.active_sessions:
             return self.active_sessions[profile_id]
 
+        # Counted, not a set membership: two concurrent launches of one profile
+        # both mark it, and whichever leaves first would otherwise clear the
+        # marker for the other — the loser raises first, so it would erase the
+        # winner's mark while the winner is still inside start().
+        self._starting[profile_id] = self._starting.get(profile_id, 0) + 1
         try:
-            camoufox = AsyncCamoufox(**launch_options)
-            browser = await camoufox.start()
-        except Exception as exc:  # noqa: BLE001
-            raise BrowserLaunchError(f"Failed to launch browser: {exc}") from exc
+            try:
+                camoufox = AsyncCamoufox(**launch_options)
+                browser = await camoufox.start()
+            except Exception as exc:  # noqa: BLE001
+                raise BrowserLaunchError(f"Failed to launch browser: {exc}") from exc
 
-        process_id = _resolve_process_id(browser) or _resolve_process_id(camoufox)
-        session = BrowserSession(profile_id, camoufox, process_id)
-        session.on_exit = on_exit
-        self.active_sessions[profile_id] = session
+            process_id = _resolve_process_id(browser) or _resolve_process_id(camoufox)
+            session = BrowserSession(profile_id, camoufox, process_id)
+            session.on_exit = on_exit
+            self.active_sessions[profile_id] = session
+        finally:
+            # Decremented only once the session is registered (or this launch
+            # died), so is_live() stays true while any launch is still starting.
+            remaining = self._starting.get(profile_id, 1) - 1
+            if remaining > 0:
+                self._starting[profile_id] = remaining
+            else:
+                self._starting.pop(profile_id, None)
 
         # Primary signal: the browser/context closing (e.g. the user closes the window).
         self._register_close_handler(browser, profile_id)
@@ -194,6 +294,14 @@ class BrowserSessionManager:
         if session is None:
             return
         await session.terminate()
+        # Our browser is gone, so the lease should not outlive it — unless it
+        # was already taken over, in which case the holder guard keeps the new
+        # holder's lease intact.
+        if self._storage is not None and self._holder is not None:
+            try:
+                await self._storage.release_lease(profile_id, self._holder)
+            except Exception as exc:  # noqa: BLE001 - teardown must not fail on the lease
+                logger.warning(f"Could not release the lease for {profile_id}: {exc}")
         if session.on_exit is not None:
             try:
                 await session.on_exit(profile_id)
@@ -208,11 +316,18 @@ class BrowserSessionManager:
         await session.terminate()
         return True
 
+    async def close_and_release(self, profile_id: str) -> bool:
+        """Close a browser and hand its lease back, only if we still hold it."""
+        closed = await self.close(profile_id)
+        if closed and self._storage is not None and self._holder is not None:
+            await self._storage.release_lease(profile_id, self._holder)
+        return closed
+
     async def close_all(self) -> int:
         """Close every active browser and return how many were closed."""
         count = 0
         for profile_id in list(self.active_sessions.keys()):
-            if await self.close(profile_id):
+            if await self.close_and_release(profile_id):
                 count += 1
         return count
 

--- a/src/camoufox_pm/core/database.py
+++ b/src/camoufox_pm/core/database.py
@@ -55,17 +55,37 @@ def _default_db_url() -> str | None:
 def _mask_dsn(db_url: str) -> str:
     """Redact the password in a DSN before logging (CWE-532).
 
-    A password-less URL passes through unchanged.
+    A password-less URL passes through unchanged. psycopg also accepts libpq
+    keyword/value DSNs ("host=... password=..."), which urlparse cannot read at
+    all, so those are redacted by key before the URL path is tried.
     """
+    if "://" not in db_url and "=" in db_url:
+        return " ".join(
+            f"{token.split('=', 1)[0]}=***"
+            if token.split("=", 1)[0].strip().lower() == "password"
+            else token
+            for token in db_url.split()
+        )
     parts = urlparse(db_url)
+    # libpq also reads the password from the query string
+    # ("postgresql:///db?password=..."), where urlparse leaves parts.password
+    # None — masking only the netloc would log it verbatim.
+    query = parts.query
+    if query:
+        query = "&".join(
+            f"{pair.split('=', 1)[0]}=***"
+            if pair.split("=", 1)[0].lower() == "password" and "=" in pair
+            else pair
+            for pair in query.split("&")
+        )
     if parts.password is None:
-        return db_url
+        return db_url if query == parts.query else urlunparse(parts._replace(query=query))
     netloc = parts.hostname or ""
     if parts.username:
         netloc = f"{unquote(parts.username)}@{netloc}"
     if parts.port:
         netloc = f"{netloc}:{parts.port}"
-    return urlunparse(parts._replace(netloc=netloc))
+    return urlunparse(parts._replace(netloc=netloc, query=query))
 
 
 def _sqlite_expiry_passed(lock_expires: str | None) -> bool:

--- a/src/camoufox_pm/core/database.py
+++ b/src/camoufox_pm/core/database.py
@@ -6,11 +6,20 @@ import json
 import sqlite3
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from urllib.parse import unquote, urlparse, urlunparse
 
 from loguru import logger
 from pydantic import ValidationError
 
+from camoufox_pm.config import get_settings
+
+if TYPE_CHECKING:
+    # Import cycle: storage.py imports StorageManager from this module.
+    from .storage import PostgresDatabaseManager
+
 from .crypto import decrypt, encrypt
+from .errors import StaleWriteError
 from .models import (
     Profile,
     ProfileGroup,
@@ -36,6 +45,51 @@ def _deserialize_proxy(data: dict) -> ProxyConfig:
     if data.get("password"):
         data["password"] = decrypt(data["password"])
     return ProxyConfig(**data)
+
+
+def _default_db_url() -> str | None:
+    """The PostgreSQL DSN when ``CPM_DB_URL`` is configured, else ``None``."""
+    return get_settings().db_url
+
+
+def _mask_dsn(db_url: str) -> str:
+    """Redact the password in a DSN before logging (CWE-532).
+
+    A password-less URL passes through unchanged.
+    """
+    parts = urlparse(db_url)
+    if parts.password is None:
+        return db_url
+    netloc = parts.hostname or ""
+    if parts.username:
+        netloc = f"{unquote(parts.username)}@{netloc}"
+    if parts.port:
+        netloc = f"{netloc}:{parts.port}"
+    return urlunparse(parts._replace(netloc=netloc))
+
+
+def _sqlite_expiry_passed(lock_expires: str | None) -> bool:
+    """Whether a stored SQLite lock expiry is in the past.
+
+    ``datetime('now', ...)`` stores UTC; a value written by a different path
+    may carry Python's isoformat shape, local time. An unparseable value counts
+    as unexpired — refusing a launch because of an unreadable expiry is the
+    safe direction.
+    """
+    if not lock_expires:
+        return False
+    text = str(lock_expires)
+    parsed = None
+    for candidate in (text, text.replace(" ", "T", 1) + "+00:00"):
+        try:
+            parsed = datetime.fromisoformat(candidate)
+            break
+        except ValueError:
+            continue
+    if parsed is None:
+        return False
+    now = datetime.now(parsed.tzinfo) if parsed.tzinfo else datetime.utcnow()
+    return parsed < now
 
 
 class DatabaseManager:
@@ -68,7 +122,17 @@ class DatabaseManager:
         never touches existing rows.
         """
         added_columns = {
-            "profiles": [("fingerprint", "TEXT"), ("proxy_check", "TEXT")],
+            "profiles": [
+                ("fingerprint", "TEXT"),
+                ("proxy_check", "TEXT"),
+                # Lease columns. SQLite cannot express "add if missing", so each
+                # is added only when the PRAGMA scan above does not find it.
+                # Unused on this backend: the lease calls are Postgres-only, and
+                # the columns exist so a database is shaped the same everywhere.
+                ("locked_by", "TEXT"),
+                ("lock_expires", "TIMESTAMP"),
+                ("row_version", "BIGINT NOT NULL DEFAULT 0"),
+            ],
         }
         for table, columns in added_columns.items():
             cursor = self._connection.execute(f"PRAGMA table_info({table})")
@@ -98,7 +162,10 @@ class DatabaseManager:
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 last_used TIMESTAMP,
                 fingerprint TEXT,
-                proxy_check TEXT
+                proxy_check TEXT,
+                locked_by TEXT,
+                lock_expires TIMESTAMP,
+                row_version BIGINT NOT NULL DEFAULT 0
             )
         """)
 
@@ -199,15 +266,99 @@ class DatabaseManager:
 
     # --- Profiles ---
 
-    async def save_profile(self, profile: Profile):
-        """Save a profile to the database."""
+    async def save_profile(self, profile: Profile, expected_row_version: int | None = None):
+        """Save a profile to the database.
+
+        With ``expected_row_version`` the write lands only when the stored
+        ``row_version`` still matches what the caller read, and bumps it; zero
+        rows updated raises ``StaleWriteError`` rather than clobbering the
+        winner. That is what makes editing one profile from two machines (or
+        two web UIs) safe. Without a version the row is replaced as before.
+
+        Either way the lease columns survive: a save must never break or take
+        another holder's lease, and must not reset a version a concurrent
+        editor is relying on.
+        """
+        profile.updated_at = datetime.now()
+        if expected_row_version is None:
+            await self._save_profile_unversioned(profile)
+        else:
+            # One guarded statement: an UPDATE whose guard compares the stored
+            # row_version with the one the caller read, and bumps the counter
+            # when it still matches. Zero rows means the stored version had
+            # already moved on. Unlike the unversioned path this never
+            # creates a row — there is nothing to guard on a row that does
+            # not exist.
+            cursor = self._connection.execute(
+                """
+                UPDATE profiles SET
+                    name = ?, group_id = ?, status = ?, browser_settings = ?,
+                    proxy_config = ?, extensions = ?, storage_path = ?, notes = ?,
+                    created_at = ?, updated_at = ?, last_used = ?, fingerprint = ?,
+                    proxy_check = ?, row_version = row_version + 1
+                WHERE id = ? AND row_version = ?
+                """,
+                (
+                    profile.name,
+                    profile.group,
+                    profile.status.value if hasattr(profile.status, "value") else profile.status,
+                    json.dumps(profile.browser_settings.model_dump()),
+                    json.dumps(_serialize_proxy(profile.proxy)) if profile.proxy else None,
+                    json.dumps(profile.extensions),
+                    profile.storage_path,
+                    profile.notes,
+                    profile.created_at.isoformat(),
+                    profile.updated_at.isoformat(),
+                    profile.last_used.isoformat() if profile.last_used else None,
+                    json.dumps(profile.fingerprint) if profile.fingerprint else None,
+                    profile.proxy_check.model_dump_json() if profile.proxy_check else None,
+                    profile.id,
+                    expected_row_version,
+                ),
+            )
+            if cursor.rowcount == 0:
+                raise StaleWriteError(profile.id, expected_row_version)
+            # Keep the caller's copy in step with the row: the next edit reads
+            # its row_version, and it must be the one this write produced.
+            profile.row_version = expected_row_version + 1
+
+        self._connection.commit()
+        logger.debug(f"Profile {profile.name} saved")
+
+    async def _save_profile_unversioned(self, profile: Profile) -> None:
+        """Insert or replace the whole row, preserving the lease columns.
+
+        The SQLite translation of the old INSERT OR REPLACE. The lease and
+        row-version columns survive via a re-read of the existing row: a save
+        must never break or take another holder's lease, and must not reset a
+        version a concurrent editor is relying on. A creation reads those
+        subselects as NULL — the defaults — because the row does not exist
+        yet.
+        """
         self._connection.execute(
             """
-            INSERT OR REPLACE INTO profiles (
+            INSERT INTO profiles (
                 id, name, group_id, status, browser_settings, proxy_config,
                 extensions, storage_path, notes, created_at, updated_at, last_used,
-                fingerprint, proxy_check
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                fingerprint, proxy_check, locked_by, lock_expires, row_version
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                      (SELECT locked_by FROM profiles WHERE id = ?),
+                      (SELECT lock_expires FROM profiles WHERE id = ?),
+                      COALESCE((SELECT row_version FROM profiles WHERE id = ?), 0))
+            ON CONFLICT(id) DO UPDATE SET
+                name = excluded.name,
+                group_id = excluded.group_id,
+                status = excluded.status,
+                browser_settings = excluded.browser_settings,
+                proxy_config = excluded.proxy_config,
+                extensions = excluded.extensions,
+                storage_path = excluded.storage_path,
+                notes = excluded.notes,
+                created_at = excluded.created_at,
+                updated_at = excluded.updated_at,
+                last_used = excluded.last_used,
+                fingerprint = excluded.fingerprint,
+                proxy_check = excluded.proxy_check
         """,
             (
                 profile.id,
@@ -224,10 +375,11 @@ class DatabaseManager:
                 profile.last_used.isoformat() if profile.last_used else None,
                 json.dumps(profile.fingerprint) if profile.fingerprint else None,
                 profile.proxy_check.model_dump_json() if profile.proxy_check else None,
+                profile.id,
+                profile.id,
+                profile.id,
             ),
         )
-        self._connection.commit()
-        logger.debug(f"Profile {profile.name} saved")
 
     async def get_profile(self, profile_id: str) -> Profile | None:
         """Get a profile by ID."""
@@ -238,11 +390,11 @@ class DatabaseManager:
             return self._row_to_profile(row)
         return None
 
-    async def update_profile(self, profile: Profile):
-        """Update a profile."""
-        profile.updated_at = datetime.now()
-        await self.save_profile(profile)
-        logger.debug(f"Profile {profile.name} updated")
+    async def update_profile(self, profile: Profile, expected_row_version: int | None = None):
+        """Update a profile, optionally guarded by optimistic concurrency."""
+        await self.save_profile(profile, expected_row_version)
+        if expected_row_version is None:
+            logger.debug(f"Profile {profile.name} updated")
 
     async def set_proxy_check(self, profile_id: str, record: ProxyCheckRecord | None) -> None:
         """Write only the proxy check, leaving every other column alone.
@@ -620,6 +772,129 @@ class DatabaseManager:
 
     # --- Utilities ---
 
+    # -- Leases --------------------------------------------------------------
+
+    async def acquire_lease(self, profile_id: str, holder: str, ttl_seconds: int) -> bool:
+        """Try to lease a profile in one atomic statement.
+
+        The same conditional UPDATE the Postgres backend runs; SQLite
+        serialises writers on the database, which is a stronger guarantee than
+        the row lock Postgres needs for it. Re-acquiring with the same holder
+        id succeeds: a restart on the same host must be able to pick its lease
+        up again rather than wait out its own TTL.
+
+        Returns ``False`` — without touching the row — when it is held
+        elsewhere and not expired; callers turn that into ``ProfileLocked``.
+        """
+        cursor = self._connection.execute(
+            """
+            UPDATE profiles
+               SET locked_by = ?,
+                   lock_expires = datetime('now', '+' || ? || ' seconds')
+             WHERE id = ?
+               AND (locked_by IS NULL
+                    OR julianday(lock_expires) < julianday('now')
+                    OR locked_by = ?)
+            RETURNING id
+            """,
+            (holder, ttl_seconds, profile_id, holder),
+        )
+        acquired = cursor.fetchone() is not None
+        # Commit or the lease stays inside this connection's open transaction,
+        # invisible to every other process — the opposite of its purpose.
+        self._connection.commit()
+        return acquired
+
+    async def renew_lease(self, profile_ids: list[str], holder: str, ttl_seconds: int) -> int:
+        """Push the expiry of this holder's leases out; returns how many held.
+
+        A profile missing from the result has been taken over (or expired) —
+        the caller treats the lease as lost rather than trying to win it back.
+        """
+        placeholders = ",".join("?" for _ in profile_ids)
+        cursor = self._connection.execute(
+            f"""
+            UPDATE profiles
+               SET lock_expires = datetime('now', '+' || ? || ' seconds')
+             WHERE id IN ({placeholders}) AND locked_by = ?
+            """,
+            (ttl_seconds, *profile_ids, holder),
+        )
+        renewed = cursor.rowcount
+        self._connection.commit()
+        return renewed
+
+    async def release_lease(self, profile_id: str, holder: str) -> bool:
+        """Clear the lease, but only if we still hold it.
+
+        Guarded by the holder id: after a stolen lease the new holder's lease
+        must not be broken by this holder's slow teardown.
+        """
+        cursor = self._connection.execute(
+            "UPDATE profiles SET locked_by = NULL, lock_expires = NULL "
+            "WHERE id = ? AND locked_by = ?",
+            (profile_id, holder),
+        )
+        released = cursor.rowcount > 0
+        self._connection.commit()
+        return released
+
+    async def force_release_lease(self, profile_id: str) -> str | None:
+        """Clear the lease whatever it says; returns the holder it was taken from.
+
+        Read then clear: SQLite's RETURNING sees the new row, so the cleared
+        column would come back NULL. Single-writer, so the two statements
+        cannot interleave.
+
+        Deliberately absent from the HTTP API: a "force unlock" button is the
+        fastest route to the two-machines-one-identity corruption the lease
+        exists to prevent. It lives behind the CLI, where using it is a
+        deliberate act on the host itself.
+        """
+        row = self._connection.execute(
+            "SELECT locked_by FROM profiles WHERE id = ? AND locked_by IS NOT NULL",
+            (profile_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        self._connection.execute(
+            "UPDATE profiles SET locked_by = NULL, lock_expires = NULL WHERE id = ?",
+            (profile_id,),
+        )
+        self._connection.commit()
+        return row["locked_by"]
+
+    async def get_lease(self, profile_id: str) -> tuple[str | None, str | None] | None:
+        """Return ``(locked_by, lock_expires)`` for a profile, or ``None``."""
+        cursor = self._connection.execute(
+            "SELECT locked_by, lock_expires FROM profiles WHERE id = ?", (profile_id,)
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return row["locked_by"], row["lock_expires"]
+
+    async def get_lease_holders(self) -> list[dict]:
+        """Every lease in the store, expired ones included, for inspection tools."""
+        cursor = self._connection.execute(
+            """
+            SELECT id, name, locked_by, lock_expires
+            FROM profiles
+            WHERE locked_by IS NOT NULL
+            ORDER BY id
+            """
+        )
+        return [
+            {
+                "id": row["id"],
+                "name": row["name"],
+                "locked_by": row["locked_by"],
+                "lock_expires": row["lock_expires"],
+                "expired": _sqlite_expiry_passed(row["lock_expires"]),
+            }
+            for row in cursor.fetchall()
+        ]
+
     def _row_to_schedule(self, row) -> Schedule:
         """Convert a database row into a Schedule object."""
         return Schedule(
@@ -686,6 +961,7 @@ class DatabaseManager:
             last_used=datetime.fromisoformat(row["last_used"]) if row["last_used"] else None,
             fingerprint=fingerprint,
             proxy_check=stored_check,
+            row_version=row["row_version"],
         )
 
     async def close(self):
@@ -697,25 +973,44 @@ class DatabaseManager:
 
 
 class StorageManager:
-    """StorageManager backed by the SQLite database."""
+    """The storage façade: SQLite by default, PostgreSQL when ``CPM_DB_URL`` is set.
+
+    Every caller talks to this class; ``DatabaseManager`` (SQLite) and
+    ``PostgresDatabaseManager`` (storage.py) are the only backend-coupled
+    pieces.
+    """
 
     def __init__(self, db_path: str = "data/profiles.db"):
-        self.db = DatabaseManager(db_path)
-        logger.info(f"StorageManager initialized with database: {db_path}")
+        # One attribute, two backends: mypy sees only the last assignment's
+        # type, so the union is asserted here rather than at every call site.
+        self.db: DatabaseManager | PostgresDatabaseManager
+        db_url = _default_db_url()
+        self.db_url: str | None = db_url
+        if db_url:
+            # Deferred: storage.py imports StorageManager from this module at
+            # its top level, so importing it here would be a cycle.
+            from .storage import PostgresDatabaseManager as _PostgresBackend
+
+            self.db = _PostgresBackend(db_url)
+            # Redacted: the URL carries the DSN password (CWE-532).
+            logger.info(f"StorageManager initialized with PostgreSQL: {_mask_dsn(db_url)}")
+        else:
+            self.db = DatabaseManager(db_path)
+            logger.info(f"StorageManager initialized with database: {db_path}")
 
     async def initialize(self):
         """Initialize the database."""
         await self.db.initialize()
 
     # Profile methods
-    async def save_profile(self, profile: Profile):
-        await self.db.save_profile(profile)
+    async def save_profile(self, profile: Profile, expected_row_version: int | None = None):
+        await self.db.save_profile(profile, expected_row_version)
 
     async def get_profile(self, profile_id: str) -> Profile | None:
         return await self.db.get_profile(profile_id)
 
-    async def update_profile(self, profile: Profile):
-        await self.db.update_profile(profile)
+    async def update_profile(self, profile: Profile, expected_row_version: int | None = None):
+        await self.db.update_profile(profile, expected_row_version)
 
     async def set_proxy_check(self, profile_id: str, record: ProxyCheckRecord | None) -> None:
         await self.db.set_proxy_check(profile_id, record)
@@ -797,6 +1092,25 @@ class StorageManager:
 
     async def list_schedule_runs(self, schedule_id: str, limit: int = 20) -> list[ScheduleRun]:
         return await self.db.list_schedule_runs(schedule_id, limit)
+
+    # Lease methods
+    async def acquire_lease(self, profile_id: str, holder: str, ttl_seconds: int) -> bool:
+        return await self.db.acquire_lease(profile_id, holder, ttl_seconds)
+
+    async def renew_lease(self, profile_ids: list[str], holder: str, ttl_seconds: int) -> int:
+        return await self.db.renew_lease(profile_ids, holder, ttl_seconds)
+
+    async def release_lease(self, profile_id: str, holder: str) -> bool:
+        return await self.db.release_lease(profile_id, holder)
+
+    async def force_release_lease(self, profile_id: str) -> str | None:
+        return await self.db.force_release_lease(profile_id)
+
+    async def get_lease(self, profile_id: str) -> tuple[str | None, Any] | None:
+        return await self.db.get_lease(profile_id)
+
+    async def get_lease_holders(self) -> list[dict]:
+        return await self.db.get_lease_holders()
 
     async def close(self):
         """Close the database."""

--- a/src/camoufox_pm/core/errors.py
+++ b/src/camoufox_pm/core/errors.py
@@ -1,0 +1,54 @@
+"""Shared storage-layer exceptions and lease holder ids.
+
+Raised by the backends (SQLite and Postgres) behind the ``StorageManager``
+façade, so callers can catch one name regardless of which backend runs.
+"""
+
+import os
+import socket
+import uuid
+
+
+class ProfileLocked(Exception):
+    """Another holder's lease on a profile is still alive.
+
+    ``holder`` is the id currently holding it. This is the two-machine safety
+    mechanism speaking: launching the profile now would drive one identity and
+    one cookie set from two browsers at once, which is the exact failure the
+    lease exists to prevent. An expired lease raises nothing — it simply
+    acquires.
+    """
+
+    def __init__(self, profile_id: str, holder: str | None = None):
+        self.profile_id = profile_id
+        self.holder = holder
+        super().__init__(
+            f"Profile {profile_id} is leased by another holder" + (f" ({holder})" if holder else "")
+        )
+
+
+class StaleWriteError(Exception):
+    """A save built on an older row version than the one in the database.
+
+    Raised when a version-checked update matched no rows: someone else saved
+    first. The edit is lost loudly rather than silently overwriting theirs.
+    """
+
+    def __init__(self, profile_id: str, expected_row_version: int | None = None):
+        self.profile_id = profile_id
+        self.expected_row_version = expected_row_version
+        super().__init__(
+            f"Profile {profile_id} was modified elsewhere "
+            "(stale row_version); reload it before saving again"
+        )
+
+
+def make_lease_holder() -> str:
+    """A lease holder id: ``"<hostname>:<pid>:<uuid4>"``.
+
+    The uuid distinguishes holders that would otherwise collide — two app
+    processes on the same host, or a restart that reused the pid. The caller
+    mints it once per holder and keeps it, so re-acquisition stays idempotent
+    for the holder that owns the lease.
+    """
+    return f"{socket.gethostname()}:{os.getpid()}:{uuid.uuid4()}"

--- a/src/camoufox_pm/core/models.py
+++ b/src/camoufox_pm/core/models.py
@@ -245,6 +245,13 @@ class Profile(BaseModel):
     # old proxy says nothing about the new one.
     proxy_check: ProxyCheckRecord | None = None
 
+    # Optimistic-concurrency counter, bumped by every version-checked save.
+    # Storage-only: a caller reads a profile, edits it, and writes back against
+    # the version it read; a concurrent save in between makes the write fail
+    # (StaleWriteError) instead of silently clobbering it. Not part of the API
+    # model on purpose — it is storage bookkeeping, not profile data.
+    row_version: int = 0
+
     def get_storage_path(self, base_path: str = "data/profiles") -> str:
         """Return (and lazily assign) the on-disk path for this profile's data."""
         if not self.storage_path:

--- a/src/camoufox_pm/core/profile_manager.py
+++ b/src/camoufox_pm/core/profile_manager.py
@@ -1,15 +1,19 @@
 """Browser profile manager."""
 
+import asyncio
 import shutil
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from loguru import logger
 
+from camoufox_pm.config import get_settings
+
 from . import fingerprint_store, profile_archive, proxy_check
 from .browser_session import BrowserSessionManager
 from .database import StorageManager
+from .errors import ProfileLocked, StaleWriteError, make_lease_holder
 from .fingerprint_generator import FingerprintGenerator
 from .models import (
     BrowserSettings,
@@ -21,6 +25,18 @@ from .models import (
 )
 
 
+def _utcnow_with_tz(template: Any) -> datetime:
+    """Now as a datetime in the same mode as ``template``.
+
+    ``lock_expires`` arrives from Postgres timezone-aware and from SQLite
+    naive; comparing across the two modes raises. The template supplies the
+    mode so both backends compare cleanly.
+    """
+    if template.tzinfo is not None:
+        return datetime.now(timezone.utc)
+    return datetime.now()
+
+
 class ProfileManager:
     """Manage browser profiles: CRUD, cloning, export/import, groups."""
 
@@ -30,8 +46,13 @@ class ProfileManager:
         self.profiles_dir = self.data_dir / "profiles"
         self.fingerprint_generator = FingerprintGenerator()
 
-        # Active browser sessions are owned by a dedicated manager.
-        self.browser_sessions = BrowserSessionManager()
+        # Active browser sessions are owned by a dedicated manager. With a
+        # lease-capable backend it also renews this instance's leases; without
+        # one (SQLite, unit tests) the manager behaves exactly as before.
+        self.lease_holder = make_lease_holder() if storage_manager.db_url else None
+        self.browser_sessions = BrowserSessionManager(
+            storage_manager if self.lease_holder else None, self.lease_holder
+        )
 
         self.profiles_dir.mkdir(parents=True, exist_ok=True)
         logger.info(f"Initialized ProfileManager with data directory: {self.data_dir}")
@@ -39,6 +60,7 @@ class ProfileManager:
     async def initialize(self):
         """Initialize the profile manager and its database."""
         await self.storage.initialize()
+        self.browser_sessions.start_heartbeat()
         logger.info("ProfileManager initialized")
 
     async def create_profile(
@@ -175,6 +197,7 @@ class ProfileManager:
         if not profile:
             return None
 
+        expected_version = profile.row_version
         proxy_before = profile.proxy
 
         # Update profile fields
@@ -232,9 +255,13 @@ class ProfileManager:
 
         profile.updated_at = datetime.now()
 
-        # Persist the update
-        await self.storage.update_profile(profile)
-
+        # Persist the update against the version read at the top of this
+        # method: a concurrent save (another web UI, another machine) makes
+        # this write fail loudly instead of silently reverting theirs.
+        try:
+            await self.storage.update_profile(profile, expected_row_version=expected_version)
+        except StaleWriteError:
+            raise
         # Log the update
         await self.storage.log_usage(
             UsageStats(
@@ -245,7 +272,7 @@ class ProfileManager:
         )
 
         logger.info(f"Profile {profile_id} updated")
-        return profile
+        return await self.get_profile(profile_id)
 
     async def delete_profile(self, profile_id: str, remove_data: bool = True) -> bool:
         """Delete a profile."""
@@ -716,12 +743,23 @@ class ProfileManager:
 
         Refuses while the browser is open: the databases would be copied
         mid-write and the restored profile could come back corrupted.
+
+        The lease is the fleet-wide part of that check. The in-process dict
+        only knows about browsers this instance started, so exporting on one
+        machine while the profile runs on another would copy a live profile.
+        An expired lease reads as free: the other machine is gone.
         """
         profile = await self.get_profile(profile_id)
         if not profile:
             raise ValueError(f"Profile with ID {profile_id} not found")
         if self.browser_sessions.is_running(profile_id):
             raise ValueError("Close the browser before exporting this profile")
+        if self.lease_holder is not None:
+            lease = await self.storage.get_lease(profile_id)
+            if lease is not None and lease[0] is not None and lease[0] != self.lease_holder:
+                locked_by, lock_expires = lease
+                if lock_expires is None or lock_expires > _utcnow_with_tz(lock_expires):
+                    raise ProfileLocked(profile_id, locked_by)
 
         data_dir = Path(profile.get_storage_path(str(self.profiles_dir)))
         profile_archive.export_profile(profile, data_dir, destination)
@@ -777,70 +815,130 @@ class ProfileManager:
         window_size: str | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """Launch a Camoufox browser for a profile."""
-        profile = await self.get_profile(profile_id)
-        if not profile:
-            raise ValueError(f"Profile with ID {profile_id} not found")
+        """Launch a Camoufox browser for a profile.
 
-        if self.browser_sessions.is_running(profile_id):
-            session = self.browser_sessions.active_sessions[profile_id]
-            return {
-                "status": "already_running",
-                "profile_id": profile_id,
-                "message": "Browser is already running for this profile",
-                "process_id": session.process_id,
-            }
-
-        options = profile.to_camoufox_launch_options()
-        options["headless"] = headless
-        if window_size:
-            # Camoufox expects a (width, height) tuple, not a "1280x720" string.
-            try:
-                width, height = (int(part) for part in window_size.lower().split("x"))
-                options["window"] = (width, height)
-            except ValueError:
-                logger.warning(f"Ignoring invalid window_size {window_size!r} (expected WxH)")
-        options.update(kwargs)
-
-        # Pin the machine on the first launch and replay it on every one after,
-        # so the profile is the same computer each session instead of new
-        # hardware every time. The profile's own overrides still win, and geo,
-        # timezone and WebRTC stay dynamic so they follow the proxy.
-        pinned = profile.fingerprint
-        if not pinned:
-            # Deliberately synchronous. There is no await between reading the
-            # profile above and writing it below, which is what makes this
-            # read-modify-write atomic: save_profile rewrites the whole row, so
-            # an await here would let a concurrent rename be silently reverted.
-            # resolve() can do network I/O (it fetches the uBlock addon on a
-            # fresh install), so offloading it to a thread is tempting — do that
-            # only together with row-level concurrency control.
-            pinned = fingerprint_store.resolve(options)
-            if pinned:
-                profile.fingerprint = pinned
-        if pinned:
-            options["config"] = {**pinned, **options.get("config", {})}
-
-        # One write for both the pin and the timestamp, after the options are
-        # built, so neither can be clobbered by a stale copy of the profile.
-        profile.last_used = datetime.now()
-        profile.updated_at = datetime.now()
-        await self.storage.update_profile(profile)
-
-        await self.storage.log_usage(
-            UsageStats(
-                profile_id=profile_id, action="launch_browser", details={"headless": headless}
+        With a lease-capable backend, the lease is taken first and is the
+        authority on "is this profile already running": the in-process dict
+        below is only a fast local path, invisible to every other machine.
+        Two instances answering "free" at once would drive one identity and
+        one cookie set from two browsers — the exact failure the lease
+        prevents. While we hold it, the whole read-modify-write below is
+        ours.
+        """
+        we_hold_lease = False
+        if self.lease_holder is not None:
+            acquired = await self.storage.acquire_lease(
+                profile_id, self.lease_holder, get_settings().lease_ttl
             )
-        )
+            if not acquired:
+                lease = await self.storage.get_lease(profile_id)
+                raise ProfileLocked(profile_id, lease[0] if lease else None)
+            we_hold_lease = True
 
-        # After the write on purpose: this only touches the launch options, so it
-        # cannot clobber the row, and it is the first await that is allowed to run
-        # between reading the profile and saving it.
-        await proxy_check.fill_what_geoip_would_have(profile.proxy, options)
+        # Everything from here to a successful launch runs on our lease. If any
+        # of it raises, the lease must go back before the error escapes —
+        # otherwise the profile is locked on every machine (including this one)
+        # for the whole TTL with no browser running anywhere, which is worse
+        # than not having leases at all. On success (and on the early
+        # already_running return) it is deliberately kept: the session owns it
+        # until close_browser runs (or the process exits, which the API's
+        # lifespan shutdown clears via release_all_leases).
+        #
+        # The lease is keyed by the process-wide holder id, so a second
+        # concurrent launch_browser for the same profile re-acquires it
+        # idempotently and passes the is_running check below. Releasing on any
+        # failure would then tear down the lease under the surviving call's
+        # live browser (release_lease guards the holder id, not the call). So
+        # the release is additionally guarded on "no browser session for this
+        # profile is running": only a failure that leaves nothing live may
+        # hand the lease back.
+        try:
+            profile = await self.get_profile(profile_id)
+            if not profile:
+                raise ValueError(f"Profile with ID {profile_id} not found")
 
-        session = await self.browser_sessions.launch(
-            profile_id, options, on_exit=self._on_browser_exit
-        )
+            if self.browser_sessions.is_running(profile_id):
+                # Same process, so same holder id: the acquire above re-took our
+                # own lease (idempotent) and the running browser still owns it;
+                # releasing here would open a window where another machine
+                # acquires while our browser is alive.
+                session = self.browser_sessions.active_sessions[profile_id]
+                return {
+                    "status": "already_running",
+                    "profile_id": profile_id,
+                    "message": "Browser is already running for this profile",
+                    "process_id": session.process_id,
+                }
+
+            options = profile.to_camoufox_launch_options()
+            options["headless"] = headless
+            if window_size:
+                # Camoufox expects a (width, height) tuple, not a "1280x720" string.
+                try:
+                    width, height = (int(part) for part in window_size.lower().split("x"))
+                    options["window"] = (width, height)
+                except ValueError:
+                    logger.warning(f"Ignoring invalid window_size {window_size!r} (expected WxH)")
+            options.update(kwargs)
+
+            # Pin the machine on the first launch and replay it on every one after,
+            # so the profile is the same computer each session instead of new
+            # hardware every time. The profile's own overrides still win, and geo,
+            # timezone and WebRTC stay dynamic so they follow the proxy.
+            pinned = profile.fingerprint
+            if not pinned:
+                # resolve() may do network I/O (it fetches the uBlock addon on a
+                # fresh install). It can be awaited now: the lease makes the
+                # read-modify-write below safe against other instances, and this
+                # call only builds launch options, which cannot clobber the row.
+                pinned = await asyncio.to_thread(fingerprint_store.resolve, options)
+                if pinned:
+                    profile.fingerprint = pinned
+            if pinned:
+                options["config"] = {**pinned, **options.get("config", {})}
+
+            # One write for both the pin and the timestamp, after the options are
+            # built, so neither can be clobbered by a stale copy of the profile.
+            # Version-checked: another instance (or a web UI edit) winning the row
+            # in the meantime must surface here, not be overwritten.
+            profile.last_used = datetime.now()
+            profile.updated_at = datetime.now()
+            await self.storage.update_profile(profile, expected_row_version=profile.row_version)
+
+            await self.storage.log_usage(
+                UsageStats(
+                    profile_id=profile_id, action="launch_browser", details={"headless": headless}
+                )
+            )
+
+            # After the write on purpose: this only touches the launch options, so it
+            # cannot clobber the row, and it is the first await that is allowed to run
+            # between reading the profile and saving it.
+            await proxy_check.fill_what_geoip_would_have(profile.proxy, options)
+
+            session = await self.browser_sessions.launch(
+                profile_id, options, on_exit=self._on_browser_exit
+            )
+        except (Exception, asyncio.CancelledError) as exc:
+            # CancelledError derives from BaseException, not Exception: a
+            # client disconnecting mid-launch cancels this coroutine, and the
+            # lease must not outlive a launch that never produced a browser.
+            # Re-raised after the release, per cancellation semantics.
+            # we_hold_lease is only ever set inside the `lease_holder is not
+            # None` branch above, so the holder is a str here.
+            if (
+                we_hold_lease
+                and self.lease_holder is not None
+                and not self.browser_sessions.is_live(profile_id)
+            ):
+                try:
+                    await self.storage.release_lease(profile_id, self.lease_holder)
+                except Exception as release_exc:  # noqa: BLE001 - never mask the launch error
+                    logger.warning(
+                        f"Failed to release lease for {profile_id} after a failed launch "
+                        f"({exc}): {release_exc}"
+                    )
+            raise
         return {
             "status": "launched",
             "profile_id": profile_id,
@@ -859,8 +957,8 @@ class ProfileManager:
             logger.warning(f"Failed to log browser exit for {profile_id}: {exc}")
 
     async def close_browser(self, profile_id: str) -> dict[str, Any]:
-        """Close the browser running for a profile."""
-        closed = await self.browser_sessions.close(profile_id)
+        """Close the browser running for a profile, and hand its lease back."""
+        closed = await self.browser_sessions.close_and_release(profile_id)
         if not closed:
             return {
                 "status": "not_running",
@@ -889,3 +987,32 @@ class ProfileManager:
             "errors": [],
             "message": f"Closed {count} browsers",
         }
+
+    async def release_all_leases(self) -> None:
+        """Hand back every lease this process holds; the exit-path counterpart
+        to launch_browser's acquire.
+
+        Without this, a clean shutdown leaves the leases standing for their
+        full TTL, locking every profile this instance had open against the
+        whole fleet — including itself, after a restart. Guarded by the holder
+        id, so another holder's lease is never touched, and never raises: one
+        stuck profile must not keep the rest locked.
+        """
+        if self.lease_holder is None:
+            return
+        try:
+            holders = await self.storage.get_lease_holders()
+        except Exception as exc:  # noqa: BLE001 - shutdown must not raise
+            logger.warning(f"Could not enumerate leases for shutdown release: {exc}")
+            return
+        for entry in holders:
+            if entry.get("locked_by") != self.lease_holder:
+                continue
+            # A browser still up owns its lease: releasing here would let
+            # another machine take an identity this process is still driving.
+            if self.browser_sessions.is_live(entry["id"]):
+                continue
+            try:
+                await self.storage.release_lease(entry["id"], self.lease_holder)
+            except Exception as exc:  # noqa: BLE001 - release the rest regardless
+                logger.warning(f"Failed to release lease for {entry['id']} on shutdown: {exc}")

--- a/src/camoufox_pm/core/storage.py
+++ b/src/camoufox_pm/core/storage.py
@@ -1,0 +1,991 @@
+"""Storage backend selection, lease errors, and the PostgreSQL backend.
+
+Two backends live behind one ``StorageManager`` façade:
+
+- ``CPM_DB_URL`` unset — SQLite, exactly as before, in the file named by
+  ``CPM_DB_PATH``. This is the default and keeps single-machine installs and
+  the test suite unchanged.
+- ``CPM_DB_URL`` set — PostgreSQL (psycopg3), so several CFPM instances on
+  different machines can share one database.
+
+The database is the only state two machines sharing profiles must agree on.
+The SQLite backend has no answer to "is this profile running?" beyond the
+current process's memory, so the Postgres backend adds row-level leases:
+
+- ``locked_by`` — holder id, ``"<hostname>:<pid>:<uuid4>"``; NULL means free.
+- ``lock_expires`` — absolute expiry; an expired lease is as good as no lease,
+  which is how a crashed machine releases its profiles without operator action.
+- ``row_version`` — bumped on every save; a save that expected an older
+  version is refused instead of silently clobbering a concurrent edit.
+
+Only ``DatabaseManager`` is backend-coupled; everything else talks to the
+``StorageManager`` façade.
+"""
+
+import asyncio
+import json
+from datetime import datetime
+from typing import Any
+
+from loguru import logger
+from pydantic import ValidationError
+
+from .crypto import decrypt, encrypt
+from .errors import StaleWriteError
+from .models import (
+    BrowserSettings,
+    Profile,
+    ProfileGroup,
+    ProfileStatus,
+    ProxyCheckRecord,
+    ProxyConfig,
+    Schedule,
+    ScheduleRun,
+    UsageStats,
+)
+
+try:
+    import psycopg
+    from psycopg import Error as PsycopgError
+    from psycopg.rows import dict_row
+
+    PSYCOPG_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only without psycopg installed
+    psycopg = None  # type: ignore[assignment]
+    PsycopgError = None  # type: ignore[assignment,misc]
+    dict_row = None  # type: ignore[assignment,misc]
+    PSYCOPG_AVAILABLE = False
+
+
+def _serialize_proxy(proxy: ProxyConfig) -> dict:
+    """Serialize a proxy for storage, encrypting the password."""
+    data = proxy.model_dump()
+    if data.get("password"):
+        data["password"] = encrypt(data["password"])
+    return data
+
+
+def _deserialize_proxy(data: dict) -> ProxyConfig:
+    """Rebuild a proxy from storage, decrypting the password."""
+    if data.get("password"):
+        data["password"] = decrypt(data["password"])
+    return ProxyConfig(**data)
+
+
+class PostgresDatabaseManager:
+    """PostgreSQL storage backend, shaped like the SQLite ``DatabaseManager``.
+
+    psycopg matches that manager's shape closely (``connect``, ``row_factory``,
+    ``cursor.execute``), so this mirrors its method set and semantics without
+    an ORM.
+    """
+
+    def __init__(self, db_url: str):
+        if not PSYCOPG_AVAILABLE:
+            raise RuntimeError(
+                "PostgreSQL support requires psycopg; "
+                "install camoufox-pm[postgres] or set CPM_DB_URL back to SQLite"
+            )
+        self.db_url = db_url
+        self._connection: Any = None
+        logger.info("DatabaseManager initialized with PostgreSQL backend")
+
+    async def initialize(self):
+        """Connect and create tables; existing tables are left as they are.
+
+        One connection, like the SQLite backend: all calls run through one
+        event loop, and psycopg serialises concurrent statements on a single
+        connection, which one CFPM instance per machine never comes near
+        saturating.
+
+        ``client_encoding=UTF8`` is forced because a cluster initialised with
+        ``SQL_ASCII`` (a common default for throwaway containers) otherwise
+        hands every text column back as ``bytes``.
+        """
+        self._connection = psycopg.connect(
+            self.db_url, row_factory=dict_row, client_encoding="UTF8"
+        )
+        self._connection.autocommit = True
+
+        await self._create_tables()
+        await self._migrate()
+        await self._create_indexes()
+        logger.info("Database initialized")
+
+    async def _migrate(self):
+        """Bring an existing database up to the current schema.
+
+        The SQLite ``_migrate`` scans ``PRAGMA table_info`` because SQLite
+        cannot express "add this column if missing". PostgreSQL can:
+        ``ADD COLUMN IF NOT EXISTS`` is itself re-runnable, so each entry here
+        is one statement and never touches existing rows.
+        """
+        added_columns = {
+            "profiles": [("fingerprint", "JSONB"), ("proxy_check", "TEXT")],
+        }
+        for table, columns in added_columns.items():
+            for name, column_type in columns:
+                self._connection.execute(
+                    f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {name} {column_type}"
+                )
+                logger.info(f"Migrated {table}: ensured column {name}")
+
+    async def _create_tables(self):
+        """Create the database tables."""
+        # Profiles table. JSONB for fingerprint and browser_settings — the two
+        # columns with plausible structured queries (e.g.
+        # fingerprint->>'navigator.platform'). proxy_config stays TEXT: it holds
+        # Fernet ciphertext whenever CPM_SECRET_KEY is set, not JSON, so a
+        # JSONB column there would corrupt the secrets.
+        self._connection.execute("""
+            CREATE TABLE IF NOT EXISTS profiles (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                group_id TEXT,
+                status TEXT DEFAULT 'active',
+                browser_settings JSONB NOT NULL,
+                proxy_config TEXT,
+                extensions TEXT,
+                storage_path TEXT,
+                notes TEXT,
+                created_at TIMESTAMP NOT NULL,
+                updated_at TIMESTAMP NOT NULL,
+                last_used TIMESTAMP,
+                fingerprint JSONB,
+                proxy_check TEXT,
+                locked_by TEXT,
+                lock_expires TIMESTAMPTZ,
+                row_version BIGINT NOT NULL DEFAULT 0
+            )
+        """)
+
+        # Profile groups table
+        self._connection.execute("""
+            CREATE TABLE IF NOT EXISTS profile_groups (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL UNIQUE,
+                description TEXT,
+                profile_count INTEGER DEFAULT 0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+
+        # Usage statistics table
+        self._connection.execute("""
+            CREATE TABLE IF NOT EXISTS usage_stats (
+                id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                profile_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                timestamp TIMESTAMP DEFAULT now(),
+                duration INTEGER,
+                success BOOLEAN DEFAULT TRUE,
+                details TEXT
+            )
+        """)
+
+        # User accounts for the web UI. Their mere existence turns login on, so a
+        # database without rows here behaves exactly as before the table existed.
+        self._connection.execute("""
+            CREATE TABLE IF NOT EXISTS users (
+                id TEXT PRIMARY KEY,
+                username TEXT NOT NULL,
+                password_hash TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT now()
+            )
+        """)
+        # SQLite kept usernames unique case-insensitively via COLLATE NOCASE;
+        # the equivalent Postgres shape is a unique index on a lowercased
+        # expression, which also backs the lower(username) lookups below.
+        self._connection.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username_lower ON users (lower(username))"
+        )
+
+        # Login sessions, keyed by the SHA-256 of the cookie token — the token
+        # itself is never stored, so this table cannot be replayed if leaked.
+        self._connection.execute("""
+            CREATE TABLE IF NOT EXISTS sessions (
+                token_hash TEXT PRIMARY KEY,
+                user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                created_at TIMESTAMP DEFAULT now(),
+                expires_at TIMESTAMP NOT NULL
+            )
+        """)
+
+        # Scheduled tasks. New tables need no _migrate entry: IF NOT EXISTS adds
+        # them to an existing database without touching what is already there.
+        self._connection.execute("""
+            CREATE TABLE IF NOT EXISTS schedules (
+                id TEXT PRIMARY KEY,
+                profile_id TEXT NOT NULL,
+                action TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                interval_minutes INTEGER,
+                at_time TEXT,
+                days TEXT,
+                run_minutes INTEGER,
+                enabled BOOLEAN DEFAULT TRUE,
+                next_run_at TIMESTAMP,
+                created_at TIMESTAMP DEFAULT now(),
+                updated_at TIMESTAMP DEFAULT now()
+            )
+        """)
+
+        self._connection.execute("""
+            CREATE TABLE IF NOT EXISTS schedule_runs (
+                id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+                schedule_id TEXT NOT NULL,
+                started_at TIMESTAMP NOT NULL,
+                finished_at TIMESTAMP,
+                outcome TEXT NOT NULL,
+                message TEXT
+            )
+        """)
+
+    async def _create_indexes(self):
+        """Create indexes to optimize queries."""
+        indexes = [
+            "CREATE INDEX IF NOT EXISTS idx_profiles_group ON profiles(group_id)",
+            "CREATE INDEX IF NOT EXISTS idx_profiles_status ON profiles(status)",
+            "CREATE INDEX IF NOT EXISTS idx_profiles_created ON profiles(created_at)",
+            "CREATE INDEX IF NOT EXISTS idx_usage_stats_profile ON usage_stats(profile_id)",
+            "CREATE INDEX IF NOT EXISTS idx_usage_stats_timestamp ON usage_stats(timestamp)",
+            "CREATE INDEX IF NOT EXISTS idx_schedules_profile ON schedules(profile_id)",
+            "CREATE INDEX IF NOT EXISTS idx_schedule_runs_schedule ON schedule_runs(schedule_id)",
+        ]
+
+        for index_sql in indexes:
+            self._connection.execute(index_sql)
+
+    # --- Profiles ---
+
+    async def save_profile(self, profile: Profile, expected_row_version: int | None = None):
+        """Insert or update a profile.
+
+        The SQLite backend replaces the whole row (INSERT OR REPLACE), which
+        two machines sharing this database would use to clobber each other's
+        edits — and its lease columns. Here a creation is a plain insert, and
+        replacing an existing row preserves the lease columns.
+
+        With ``expected_row_version`` the update carries
+        ``AND row_version = <expected>`` and bumps the counter; zero rows
+        updated raises ``StaleWriteError`` rather than clobbering the winner.
+        That is what makes editing one profile from two instances safe,
+        independently of the lease.
+        """
+        if expected_row_version is None:
+            await self._overwrite_profile(profile)
+        else:
+            cursor = self._connection.execute(
+                """
+                UPDATE profiles SET
+                    name = %s, group_id = %s, status = %s, browser_settings = %s,
+                    proxy_config = %s, extensions = %s, storage_path = %s, notes = %s,
+                    created_at = %s, updated_at = %s, last_used = %s, fingerprint = %s,
+                    proxy_check = %s, row_version = row_version + 1
+                WHERE id = %s AND row_version = %s
+                """,
+                (
+                    profile.name,
+                    profile.group,
+                    profile.status.value if hasattr(profile.status, "value") else profile.status,
+                    json.dumps(profile.browser_settings.model_dump()),
+                    json.dumps(_serialize_proxy(profile.proxy)) if profile.proxy else None,
+                    json.dumps(profile.extensions),
+                    profile.storage_path,
+                    profile.notes,
+                    profile.created_at,
+                    profile.updated_at,
+                    profile.last_used,
+                    json.dumps(profile.fingerprint) if profile.fingerprint else None,
+                    profile.proxy_check.model_dump_json() if profile.proxy_check else None,
+                    profile.id,
+                    expected_row_version,
+                ),
+            )
+            if cursor.rowcount == 0:
+                raise StaleWriteError(profile.id, expected_row_version)
+            profile.row_version = expected_row_version + 1
+        logger.debug(f"Profile {profile.name} saved")
+
+    async def update_profile(self, profile: Profile, expected_row_version: int | None = None):
+        """Update a profile.
+
+        With ``expected_row_version`` this is the optimistic-concurrency write:
+        it lands only when the stored version still matches what the caller
+        read, and bumps the counter. Without one the row is overwritten as the
+        SQLite backend did, for callers that re-read immediately before
+        writing. See ``save_profile`` for the details.
+        """
+        await self.save_profile(profile, expected_row_version)
+
+    async def _overwrite_profile(self, profile: Profile) -> None:
+        """Insert or replace the whole row, preserving the lease columns.
+
+        The Postgres translation of SQLite's INSERT OR REPLACE. The lease and
+        row-version columns survive via a re-read of the existing row: a save
+        must never break or take another holder's lease, and must not reset a
+        row version a concurrent editor is relying on. Creation inserts read
+        those subselects as NULL — the defaults — because the row does not
+        exist yet.
+        """
+        self._connection.execute(
+            """
+            INSERT INTO profiles (
+                id, name, group_id, status, browser_settings, proxy_config,
+                extensions, storage_path, notes, created_at, updated_at, last_used,
+                fingerprint, proxy_check, locked_by, lock_expires, row_version
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                      (SELECT locked_by FROM profiles WHERE id = %s),
+                      (SELECT lock_expires FROM profiles WHERE id = %s),
+                      COALESCE((SELECT row_version FROM profiles WHERE id = %s), 0))
+            ON CONFLICT (id) DO UPDATE SET
+                name = EXCLUDED.name,
+                group_id = EXCLUDED.group_id,
+                status = EXCLUDED.status,
+                browser_settings = EXCLUDED.browser_settings,
+                proxy_config = EXCLUDED.proxy_config,
+                extensions = EXCLUDED.extensions,
+                storage_path = EXCLUDED.storage_path,
+                notes = EXCLUDED.notes,
+                created_at = EXCLUDED.created_at,
+                updated_at = EXCLUDED.updated_at,
+                last_used = EXCLUDED.last_used,
+                fingerprint = EXCLUDED.fingerprint,
+                proxy_check = EXCLUDED.proxy_check
+            """,
+            (
+                profile.id,
+                profile.name,
+                profile.group,
+                profile.status.value if hasattr(profile.status, "value") else profile.status,
+                json.dumps(profile.browser_settings.model_dump()),
+                json.dumps(_serialize_proxy(profile.proxy)) if profile.proxy else None,
+                json.dumps(profile.extensions),
+                profile.storage_path,
+                profile.notes,
+                profile.created_at,
+                profile.updated_at,
+                profile.last_used,
+                json.dumps(profile.fingerprint) if profile.fingerprint else None,
+                profile.proxy_check.model_dump_json() if profile.proxy_check else None,
+                profile.id,
+                profile.id,
+                profile.id,
+            ),
+        )
+
+    async def get_profile(self, profile_id: str) -> Profile | None:
+        """Get a profile by ID."""
+        cursor = self._connection.execute("SELECT * FROM profiles WHERE id = %s", (profile_id,))
+        row = cursor.fetchone()
+
+        if row:
+            return self._row_to_profile(row)
+        return None
+
+    async def set_proxy_check(self, profile_id: str, record: ProxyCheckRecord | None) -> None:
+        """Write only the proxy check, leaving every other column alone.
+
+        Mirrors the SQLite method: a check takes seconds — up to thirty against
+        a proxy that never answers — and writing back a Profile read before
+        that wait would revert anything edited during it. It also keeps a check
+        from touching ``updated_at``: asking a proxy a question is not an edit,
+        and a bulk check should not make a selection look modified.
+        """
+        self._connection.execute(
+            "UPDATE profiles SET proxy_check = %s WHERE id = %s",
+            (record.model_dump_json() if record else None, profile_id),
+        )
+
+    async def delete_profile(self, profile_id: str) -> bool:
+        """Delete a profile, and the schedules that would otherwise fire against it."""
+        self._connection.execute(
+            "DELETE FROM schedule_runs WHERE schedule_id IN "
+            "(SELECT id FROM schedules WHERE profile_id = %s)",
+            (profile_id,),
+        )
+        self._connection.execute("DELETE FROM schedules WHERE profile_id = %s", (profile_id,))
+        cursor = self._connection.execute("DELETE FROM profiles WHERE id = %s", (profile_id,))
+        deleted = cursor.rowcount > 0
+
+        if deleted:
+            logger.debug(f"Profile {profile_id} deleted")
+
+        return deleted
+
+    async def list_profiles(
+        self, filters: dict | None = None, limit: int | None = None, offset: int = 0
+    ) -> list[Profile]:
+        """List profiles with optional filtering."""
+        query = "SELECT * FROM profiles WHERE 1=1"
+        params: list[Any] = []
+
+        if filters:
+            if "group" in filters:
+                query += " AND group_id = %s"
+                params.append(filters["group"])
+            if "status" in filters:
+                query += " AND status = %s"
+                params.append(filters["status"])
+            if "name_like" in filters:
+                # ILIKE rather than LIKE: Postgres is case-sensitive here, and a
+                # search box that finds "Facebook" only when typed exactly would
+                # be a regression against SQLite's case-insensitive LIKE.
+                query += " AND name ILIKE %s"
+                params.append(f"%{filters['name_like']}%")
+
+        query += " ORDER BY created_at DESC"
+
+        if limit or offset:
+            query += " LIMIT %s"
+            params.append(limit if limit else -1)
+        if offset:
+            query += " OFFSET %s"
+            params.append(offset)
+
+        cursor = self._connection.execute(query, params)
+        rows = cursor.fetchall()
+
+        return [self._row_to_profile(row) for row in rows]
+
+    async def count_profiles(self, filters: dict | None = None) -> int:
+        """Count profiles."""
+        query = "SELECT COUNT(*) AS n FROM profiles WHERE 1=1"
+        params: list[Any] = []
+
+        if filters:
+            if "group" in filters:
+                query += " AND group_id = %s"
+                params.append(filters["group"])
+            if "status" in filters:
+                query += " AND status = %s"
+                params.append(filters["status"])
+
+        cursor = self._connection.execute(query, params)
+        return cursor.fetchone()["n"]
+
+    # --- Profile groups ---
+
+    async def save_profile_group(self, group: ProfileGroup):
+        """Save a profile group."""
+        self._connection.execute(
+            """
+            INSERT INTO profile_groups (
+                id, name, description, profile_count, created_at
+            ) VALUES (%s, %s, %s, %s, %s)
+            ON CONFLICT (id) DO UPDATE SET
+                name = EXCLUDED.name,
+                description = EXCLUDED.description,
+                profile_count = EXCLUDED.profile_count,
+                created_at = EXCLUDED.created_at
+            """,
+            (
+                group.id,
+                group.name,
+                group.description,
+                group.profile_count,
+                group.created_at,
+            ),
+        )
+        logger.debug(f"Group {group.name} saved")
+
+    async def list_profile_groups(self) -> list[ProfileGroup]:
+        """List all groups."""
+        cursor = self._connection.execute("""
+            SELECT pg.*, COUNT(p.id) as actual_count
+            FROM profile_groups pg
+            LEFT JOIN profiles p ON pg.id = p.group_id
+            GROUP BY pg.id
+            ORDER BY pg.created_at DESC
+        """)
+        rows = cursor.fetchall()
+
+        groups = []
+        for row in rows:
+            group = ProfileGroup(
+                id=row["id"],
+                name=row["name"],
+                description=row["description"],
+                profile_count=row["actual_count"],
+                created_at=row["created_at"],
+            )
+            groups.append(group)
+
+        return groups
+
+    async def delete_profile_group(self, group_id: str) -> bool:
+        """Delete a profile group."""
+        # Ungroup the profiles that belonged to this group
+        self._connection.execute(
+            "UPDATE profiles SET group_id = NULL WHERE group_id = %s", (group_id,)
+        )
+
+        # Delete the group
+        cursor = self._connection.execute("DELETE FROM profile_groups WHERE id = %s", (group_id,))
+
+        return cursor.rowcount > 0
+
+    # --- Statistics ---
+
+    async def log_usage(self, usage_stats: UsageStats):
+        """Record a usage statistic."""
+        row = self._connection.execute(
+            """
+            INSERT INTO usage_stats (
+                profile_id, action, timestamp, duration, success, details
+            ) VALUES (%s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                usage_stats.profile_id,
+                usage_stats.action,
+                usage_stats.timestamp,
+                usage_stats.duration,
+                usage_stats.success,
+                json.dumps(usage_stats.details) if usage_stats.details else None,
+            ),
+        ).fetchone()
+        usage_stats.id = row["id"]
+
+    async def get_profile_usage_stats(self, profile_id: str, limit: int = 100) -> list[UsageStats]:
+        """Get usage statistics for a profile."""
+        cursor = self._connection.execute(
+            """
+            SELECT * FROM usage_stats
+            WHERE profile_id = %s
+            ORDER BY timestamp DESC
+            LIMIT %s
+        """,
+            (profile_id, limit),
+        )
+
+        return [
+            UsageStats(
+                id=row["id"],
+                profile_id=row["profile_id"],
+                action=row["action"],
+                timestamp=row["timestamp"],
+                duration=row["duration"],
+                success=bool(row["success"]),
+                details=row["details"] if row["details"] else None,
+            )
+            for row in cursor.fetchall()
+        ]
+
+    # --- Users and sessions ---
+
+    async def create_user(self, user_id: str, username: str, password_hash: str) -> None:
+        """Create a user; raises ``ValueError`` when the username is taken."""
+        try:
+            self._connection.execute(
+                "INSERT INTO users (id, username, password_hash, created_at) "
+                "VALUES (%s, %s, %s, %s)",
+                (user_id, username, password_hash, datetime.now()),
+            )
+        except PsycopgError as exc:
+            if not self._is_unique_violation(exc):
+                raise
+            raise ValueError(f"User {username!r} already exists") from exc
+        # Deliberately logs the name only, never the hash.
+        logger.info(f"User {username} created")
+
+    @staticmethod
+    def _is_unique_violation(exc: Exception) -> bool:
+        """Whether this database error is a unique-constraint violation.
+
+        Matched by SQLSTATE rather than exception type: unlike SQLite, psycopg
+        raises one error class for every server-side failure.
+        """
+        return getattr(exc, "sqlstate", None) == "23505"
+
+    async def get_user_by_username(self, username: str) -> dict | None:
+        cursor = self._connection.execute(
+            "SELECT id, username, password_hash FROM users WHERE lower(username) = lower(%s)",
+            (username,),
+        )
+        row = cursor.fetchone()
+        return dict(row) if row else None
+
+    async def update_user_password(self, username: str, password_hash: str) -> bool:
+        cursor = self._connection.execute(
+            "UPDATE users SET password_hash = %s WHERE lower(username) = lower(%s)",
+            (password_hash, username),
+        )
+        return cursor.rowcount > 0
+
+    async def delete_user(self, username: str) -> bool:
+        """Delete a user; the foreign key cascades their open sessions away."""
+        cursor = self._connection.execute(
+            "DELETE FROM users WHERE lower(username) = lower(%s)", (username,)
+        )
+        return cursor.rowcount > 0
+
+    async def count_users(self) -> int:
+        cursor = self._connection.execute("SELECT COUNT(*) AS n FROM users")
+        return cursor.fetchone()["n"]
+
+    async def list_users(self) -> list[dict]:
+        """Usernames and creation times only — hashes stay in the table."""
+        cursor = self._connection.execute(
+            "SELECT username, created_at FROM users ORDER BY created_at"
+        )
+        return [dict(row) for row in cursor.fetchall()]
+
+    async def create_session(self, token_hash: str, user_id: str, expires_at: datetime) -> None:
+        self._connection.execute(
+            "INSERT INTO sessions (token_hash, user_id, created_at, expires_at) "
+            "VALUES (%s, %s, %s, %s)",
+            (token_hash, user_id, datetime.now(), expires_at),
+        )
+
+    async def get_session(self, token_hash: str) -> dict | None:
+        cursor = self._connection.execute(
+            """
+            SELECT s.token_hash, s.user_id, s.expires_at, u.username
+            FROM sessions s JOIN users u ON u.id = s.user_id
+            WHERE s.token_hash = %s
+            """,
+            (token_hash,),
+        )
+        row = cursor.fetchone()
+        return dict(row) if row else None
+
+    async def delete_session(self, token_hash: str) -> bool:
+        cursor = self._connection.execute(
+            "DELETE FROM sessions WHERE token_hash = %s", (token_hash,)
+        )
+        return cursor.rowcount > 0
+
+    async def delete_expired_sessions(self) -> int:
+        cursor = self._connection.execute(
+            "DELETE FROM sessions WHERE expires_at <= %s", (datetime.now(),)
+        )
+        return cursor.rowcount
+
+    # --- Schedules ---
+
+    async def save_schedule(self, schedule: Schedule):
+        """Insert or replace a schedule."""
+        self._connection.execute(
+            """
+            INSERT INTO schedules (
+                id, profile_id, action, kind, interval_minutes, at_time, days,
+                run_minutes, enabled, next_run_at, created_at, updated_at
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (id) DO UPDATE SET
+                profile_id = EXCLUDED.profile_id,
+                action = EXCLUDED.action,
+                kind = EXCLUDED.kind,
+                interval_minutes = EXCLUDED.interval_minutes,
+                at_time = EXCLUDED.at_time,
+                days = EXCLUDED.days,
+                run_minutes = EXCLUDED.run_minutes,
+                enabled = EXCLUDED.enabled,
+                next_run_at = EXCLUDED.next_run_at,
+                updated_at = EXCLUDED.updated_at
+            """,
+            (
+                schedule.id,
+                schedule.profile_id,
+                schedule.action,
+                schedule.kind,
+                schedule.interval_minutes,
+                schedule.at_time,
+                json.dumps(schedule.days) if schedule.days else None,
+                schedule.run_minutes,
+                schedule.enabled,
+                schedule.next_run_at,
+                schedule.created_at,
+                schedule.updated_at,
+            ),
+        )
+
+    async def get_schedule(self, schedule_id: str) -> Schedule | None:
+        """Get a schedule by ID."""
+        cursor = self._connection.execute("SELECT * FROM schedules WHERE id = %s", (schedule_id,))
+        row = cursor.fetchone()
+        return self._row_to_schedule(row) if row else None
+
+    async def list_schedules(self, profile_id: str | None = None) -> list[Schedule]:
+        """List schedules, oldest first so the UI order is stable."""
+        if profile_id:
+            cursor = self._connection.execute(
+                "SELECT * FROM schedules WHERE profile_id = %s ORDER BY created_at",
+                (profile_id,),
+            )
+        else:
+            cursor = self._connection.execute("SELECT * FROM schedules ORDER BY created_at")
+        return [self._row_to_schedule(row) for row in cursor.fetchall()]
+
+    async def delete_schedule(self, schedule_id: str) -> bool:
+        """Delete a schedule and its run history."""
+        self._connection.execute("DELETE FROM schedule_runs WHERE schedule_id = %s", (schedule_id,))
+        cursor = self._connection.execute("DELETE FROM schedules WHERE id = %s", (schedule_id,))
+        return cursor.rowcount > 0
+
+    async def log_schedule_run(self, run: ScheduleRun, keep: int = 20) -> ScheduleRun:
+        """Record one firing and prune the history to the newest ``keep`` rows.
+
+        Bounded per schedule rather than by age: an every-five-minutes schedule
+        would otherwise write hundreds of rows a day into a database that also
+        holds the profiles.
+        """
+        row = self._connection.execute(
+            """
+            INSERT INTO schedule_runs (schedule_id, started_at, finished_at, outcome, message)
+            VALUES (%s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                run.schedule_id,
+                run.started_at,
+                run.finished_at,
+                run.outcome,
+                run.message,
+            ),
+        ).fetchone()
+        run.id = row["id"]
+        self._connection.execute(
+            """
+            DELETE FROM schedule_runs WHERE schedule_id = %s AND id NOT IN (
+                SELECT id FROM schedule_runs WHERE schedule_id = %s ORDER BY id DESC LIMIT %s
+            )
+            """,
+            (run.schedule_id, run.schedule_id, keep),
+        )
+        return run
+
+    async def list_schedule_runs(self, schedule_id: str, limit: int = 20) -> list[ScheduleRun]:
+        """Get the newest runs of a schedule, newest first."""
+        cursor = self._connection.execute(
+            "SELECT * FROM schedule_runs WHERE schedule_id = %s ORDER BY id DESC LIMIT %s",
+            (schedule_id, limit),
+        )
+        return [
+            ScheduleRun(
+                id=row["id"],
+                schedule_id=row["schedule_id"],
+                started_at=row["started_at"],
+                finished_at=row["finished_at"],
+                outcome=row["outcome"],
+                message=row["message"],
+            )
+            for row in cursor.fetchall()
+        ]
+
+    # --- Leases -------------------------------------------------------------
+
+    async def acquire_lease(self, profile_id: str, holder: str, ttl_seconds: int) -> bool:
+        """Try to lease a profile in one atomic statement.
+
+        The conditional UPDATE takes the row lock and re-evaluates the guard
+        under it, so two machines racing on a free profile produce exactly one
+        winner even under READ COMMITTED. Re-acquiring with the same holder id
+        succeeds: a restart on the same host must be able to pick its lease up
+        again rather than wait out its own TTL.
+
+        Returns ``False`` — without touching the row — when it is held
+        elsewhere and not expired; callers turn that into ``ProfileLocked``.
+        """
+        cursor = self._connection.execute(
+            """
+            UPDATE profiles
+               SET locked_by = %s,
+                   lock_expires = now() + %s * interval '1 second'
+             WHERE id = %s
+               AND (locked_by IS NULL OR lock_expires < now() OR locked_by = %s)
+            RETURNING id
+            """,
+            (holder, ttl_seconds, profile_id, holder),
+        )
+        return cursor.fetchone() is not None
+
+    async def renew_lease(self, profile_ids: list[str], holder: str, ttl_seconds: int) -> int:
+        """Push the expiry of this holder's leases out; returns how many held.
+
+        One heartbeat statement for all of the instance's active sessions. A
+        profile missing from the result has been taken over (or expired) — the
+        caller treats the lease as lost rather than trying to win it back.
+        """
+        cursor = self._connection.execute(
+            """
+            UPDATE profiles
+               SET lock_expires = now() + %s * interval '1 second'
+             WHERE id = ANY(%s) AND locked_by = %s
+            """,
+            (ttl_seconds, profile_ids, holder),
+        )
+        return cursor.rowcount
+
+    async def acquire_concurrently(
+        self, profile_id: str, holders: list[str], ttl_seconds: int
+    ) -> list[str]:
+        """Race ``acquire_lease`` from one real connection per holder.
+
+        Exists for the concurrency test: the whole point of the conditional
+        UPDATE is that two machines racing on one row produce one winner, and
+        that claim is only worth its test output if it is executed with
+        genuine contention. Returns the holder ids that won.
+        """
+
+        async def one(holder: str) -> str | None:
+            conn = psycopg.connect(self.db_url, row_factory=dict_row)
+            conn.autocommit = True
+            try:
+                cursor = conn.execute(
+                    """
+                    UPDATE profiles
+                       SET locked_by = %s,
+                           lock_expires = now() + %s * interval '1 second'
+                     WHERE id = %s
+                       AND (locked_by IS NULL OR lock_expires < now() OR locked_by = %s)
+                    RETURNING id
+                    """,
+                    (holder, ttl_seconds, profile_id, holder),
+                )
+                return holder if cursor.fetchone() is not None else None
+            finally:
+                conn.close()
+
+        results = await asyncio.gather(*(one(holder) for holder in holders))
+        return [holder for holder in results if holder is not None]
+
+    async def release_lease(self, profile_id: str, holder: str) -> bool:
+        """Clear the lease, but only if we still hold it.
+
+        Guarded by the holder id: after a stolen lease the new holder's lease
+        must not be broken by this holder's slow teardown.
+        """
+        cursor = self._connection.execute(
+            """
+            UPDATE profiles
+               SET locked_by = NULL, lock_expires = NULL
+             WHERE id = %s AND locked_by = %s
+            """,
+            (profile_id, holder),
+        )
+        return cursor.rowcount > 0
+
+    async def force_release_lease(self, profile_id: str) -> str | None:
+        """Clear the lease whatever it says; returns the holder it was taken from.
+
+        Deliberately absent from the HTTP API: a "force unlock" button is the
+        fastest route to the two-machines-one-identity corruption the lease
+        exists to prevent. It lives behind the CLI, where using it is a
+        deliberate act on the host itself.
+
+        Read then clear, like the SQLite sibling: Postgres's RETURNING also
+        sees the new row, so the cleared column would come back NULL. The
+        statements share one connection, so nothing can interleave.
+        """
+        row = self._connection.execute(
+            "SELECT locked_by FROM profiles WHERE id = %s AND locked_by IS NOT NULL",
+            (profile_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        self._connection.execute(
+            "UPDATE profiles SET locked_by = NULL, lock_expires = NULL WHERE id = %s",
+            (profile_id,),
+        )
+        return row["locked_by"]
+
+    async def get_lease(self, profile_id: str) -> tuple[str | None, datetime | None] | None:
+        """Return ``(locked_by, lock_expires)`` for a profile, or ``None``."""
+        cursor = self._connection.execute(
+            "SELECT locked_by, lock_expires FROM profiles WHERE id = %s", (profile_id,)
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return row["locked_by"], row["lock_expires"]
+
+    async def get_lease_holders(self) -> list[dict[str, Any]]:
+        """Every lease in the store, expired ones included, for inspection tools."""
+        cursor = self._connection.execute(
+            """
+            SELECT id, name, locked_by, lock_expires
+            FROM profiles
+            WHERE locked_by IS NOT NULL
+            ORDER BY id
+            """
+        )
+        return [
+            {
+                "id": row["id"],
+                "name": row["name"],
+                "locked_by": row["locked_by"],
+                "lock_expires": row["lock_expires"],
+                "expired": row["lock_expires"] is not None
+                and row["lock_expires"] < datetime.now(row["lock_expires"].tzinfo),
+            }
+            for row in cursor.fetchall()
+        ]
+
+    # --- Utilities ---
+
+    def _row_to_schedule(self, row) -> Schedule:
+        """Convert a database row into a Schedule object."""
+        return Schedule(
+            id=row["id"],
+            profile_id=row["profile_id"],
+            action=row["action"],
+            kind=row["kind"],
+            interval_minutes=row["interval_minutes"],
+            at_time=row["at_time"],
+            days=json.loads(row["days"]) if row["days"] else None,
+            run_minutes=row["run_minutes"],
+            enabled=bool(row["enabled"]),
+            next_run_at=row["next_run_at"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+        )
+
+    def _row_to_profile(self, row) -> Profile:
+        """Convert a database row into a Profile object."""
+        # JSONB columns already arrive as Python objects; json.loads would be a
+        # str error. Other columns stay TEXT and parse as before.
+        browser_settings = BrowserSettings(**row["browser_settings"])
+
+        # Parse proxy_config if present (password is decrypted on read).
+        proxy = None
+        if row["proxy_config"]:
+            proxy = _deserialize_proxy(json.loads(row["proxy_config"]))
+
+        # Parse extensions
+        extensions = json.loads(row["extensions"]) if row["extensions"] else []
+
+        stored_check = None
+        if row["proxy_check"]:
+            try:
+                stored_check = ProxyCheckRecord.model_validate_json(row["proxy_check"])
+            except ValidationError as error:
+                # A cosmetic column must not be able to take down the list: this
+                # runs for every row, so raising here 500s the whole screen over
+                # one unreadable value. Losing the dot is the right cost.
+                logger.warning(f"Profile {row['id']}: unreadable proxy check, ignoring ({error})")
+
+        return Profile(
+            id=row["id"],
+            name=row["name"],
+            group=row["group_id"],
+            status=ProfileStatus(row["status"]),
+            browser_settings=browser_settings,
+            proxy=proxy,
+            extensions=extensions,
+            storage_path=row["storage_path"],
+            notes=row["notes"],
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            last_used=row["last_used"],
+            fingerprint=row["fingerprint"],
+            proxy_check=stored_check,
+            row_version=row["row_version"],
+        )
+
+    async def close(self):
+        """Close the database connection."""
+        if self._connection:
+            self._connection.close()
+            self._connection = None
+        logger.info("Database connection closed")

--- a/src/camoufox_pm/main.py
+++ b/src/camoufox_pm/main.py
@@ -36,7 +36,10 @@ async def lifespan(app: FastAPI):
     storage_manager = StorageManager(settings.db_path)
     await storage_manager.initialize()
 
-    data_dir = str(Path(settings.db_path).parent)
+    # Profile browser data is separate from the database: with PostgreSQL there
+    # is no db_path to derive a directory from (it would land at "/"), and even
+    # on SQLite an explicit CPM_DATA_DIR beats assuming the database's parent.
+    data_dir = settings.data_dir or str(Path(settings.db_path).parent)
     profile_manager = ProfileManager(storage_manager, data_dir)
     await profile_manager.initialize()
 
@@ -55,6 +58,21 @@ async def lifespan(app: FastAPI):
     finally:
         logger.info("Shutting down API...")
         await scheduler.stop()
+        # Order matters: the heartbeat renews by holder id, so a beat racing
+        # the release below reads our own cleared lease as a takeover and
+        # closes a live browser. Stop renewing first, then hand the leases back.
+        await profile_manager.browser_sessions.stop_heartbeat()
+        # Close the browsers first: their leases are released as part of the
+        # close, and release_all_leases deliberately skips profiles that are
+        # still live, so leaving them open would leak every lease we hold.
+        try:
+            await profile_manager.browser_sessions.close_all()
+        except Exception as exc:  # noqa: BLE001 - shutdown must not raise
+            logger.warning(f"Failed to close browsers on shutdown: {exc}")
+        # Then hand back anything left: a lease must not outlive the process
+        # that took it, or a normal restart locks its own profiles out for the
+        # full TTL. Best-effort per profile and never raises.
+        await profile_manager.release_all_leases()
         await storage_manager.close()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,13 @@
 """Shared pytest fixtures, and the switch that proves the suite runs offline."""
 
 import ipaddress
+import os
 import socket
+import uuid
 
 import pytest
 
+from camoufox_pm.api import dependencies  # noqa: F401  (import cost only)
 from camoufox_pm.core.database import StorageManager
 from camoufox_pm.core.profile_manager import ProfileManager
 
@@ -110,3 +113,75 @@ async def profile_manager(tmp_path):
     await manager.initialize()
     yield manager
     await storage.close()
+
+
+# -- PostgreSQL backend --------------------------------------------------------------
+
+# Selected with `-m postgres`; the URL comes from CPM_TEST_DB_URL. The Nix build
+# runs the default suite hermetically and a VM test runs these against a real
+# server, mirroring how the `browser` marker is wired.
+
+
+def _postgres_url() -> str | None:
+    return os.environ.get("CPM_TEST_DB_URL")
+
+
+def pytest_collection_modifyitems(config, items):
+    """Deselect postgres tests unless a server URL is configured."""
+    if config.getoption("-m") and "postgres" in config.getoption("-m"):
+        return
+    if _postgres_url():
+        return
+    skip = pytest.mark.skip(reason="needs a PostgreSQL server: set CPM_TEST_DB_URL")
+    for item in items:
+        if "postgres" in item.keywords:
+            item.add_marker(skip)
+
+
+@pytest.fixture
+async def postgres_backend():
+    """A PostgresDatabaseManager against a scratch schema, torn down after."""
+    # Deferred: psycopg is an optional dependency, and importing the backend at
+    # module level would make the default SQLite suite fail to collect without it.
+    from camoufox_pm.core.storage import PostgresDatabaseManager
+
+    url = _postgres_url()
+    if not url:
+        pytest.skip("needs a PostgreSQL server: set CPM_TEST_DB_URL")
+    schema = f"cfpm_test_{uuid.uuid4().hex[:12]}"
+    manager = PostgresDatabaseManager(url)
+    await manager.initialize()
+    manager._connection.execute(f"CREATE SCHEMA {schema}")
+    manager._connection.execute(f"SET search_path TO {schema}, public")
+    # The schema starts empty, so an unqualified name would still resolve to
+    # public.profiles; create the tables inside the scratch schema so every
+    # write this fixture sees lands there, never in the shared public one.
+    await manager._create_tables()
+    manager._test_schema = schema
+    yield manager
+    # pg_profile_manager closes the storage in its own teardown (fixture
+    # finalisation runs in reverse order); a dropped connection cannot execute,
+    # so fall back to a fresh connection for the schema teardown.
+    schema_dropped = False
+    if manager._connection is not None:
+        manager._connection.execute(f"DROP SCHEMA {schema} CASCADE")
+        schema_dropped = True
+    await manager.close()
+    if not schema_dropped:
+        # Deferred: psycopg is optional; this teardown path only runs when it
+        # was importable at fixture setup, so the module stays safe without it.
+        import psycopg
+
+        conn = psycopg.connect(url, client_encoding="UTF8")
+        conn.autocommit = True
+        conn.execute(f"DROP SCHEMA {schema} CASCADE")
+        conn.close()
+
+
+@pytest.fixture
+async def pg_profile_manager(postgres_backend, tmp_path, monkeypatch):
+    """A ProfileManager whose storage is the scratch Postgres backend."""
+    manager = ProfileManager(postgres_backend, str(tmp_path))
+    await manager.initialize()
+    yield manager
+    await manager.storage.close()

--- a/tests/unit/test_leases.py
+++ b/tests/unit/test_leases.py
@@ -1,0 +1,799 @@
+"""Row-level lease tests.
+
+The lease is what makes two CFPM instances (two machines, one shared
+PostgreSQL) safe: launching, exporting, and editing a profile must refuse
+while another holder's lease is alive, and must be decidable from the
+database alone — the in-process session dict is invisible to the other
+machine.
+
+Two layers live here:
+
+- backend tests (marked ``postgres``, run with ``-m postgres`` against a real
+  PostgreSQL). The concurrent-acquire test opens two real connections on two
+  threads, waits for both to be ready on a barrier, and only then races the
+  same conditional UPDATE — a mocked backend or a same-thread race would
+  prove nothing.
+- backend-free tests (run in the default suite): the same lease semantics
+  through the SQLite backend, whose conditional-UPDATE statements are the
+  same shape, plus the manager-level refusals.
+
+Timezone note: Postgres returns ``lock_expires`` as an aware datetime, SQLite
+as a naive local-time string. Every test that plants an expiry writes it with
+the backend's own clock (``now()`` on Postgres, ``datetime('now')`` on
+SQLite), so the assertion never depends on this machine's timezone.
+"""
+
+import asyncio
+import threading
+from contextlib import contextmanager
+
+import pytest
+
+from camoufox_pm.core import browser_session as browser_session_module
+from camoufox_pm.core import fingerprint_store
+from camoufox_pm.core.errors import ProfileLocked, StaleWriteError, make_lease_holder
+from camoufox_pm.core.models import Profile
+
+HOLDER_A = "desktop:100:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+HOLDER_B = "laptop:200:bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+TTL = 120
+
+
+@pytest.fixture
+def launches(pg_profile_manager, monkeypatch):
+    """Capture launch options without starting a browser.
+
+    Same shape as the fixture in test_profile_manager: fingerprint resolution
+    reads the installed browser, which CI does not have.
+    """
+    recorded: list[dict] = []
+
+    class FakeSession:
+        process_id = 4242
+
+        async def terminate(self):
+            pass
+
+    async def fake_launch(profile_id, options, on_exit=None):
+        recorded.append(options)
+        pg_profile_manager.browser_sessions.active_sessions[profile_id] = FakeSession()
+        return FakeSession()
+
+    monkeypatch.setattr(pg_profile_manager.browser_sessions, "launch", fake_launch)
+    monkeypatch.setattr(fingerprint_store, "resolve", lambda *_args, **_kw: {})
+    return recorded
+
+
+# -- Postgres backend: atomic acquire ----------------------------------------------
+
+
+@pytest.mark.postgres
+async def test_concurrent_acquire_produces_exactly_one_winner(postgres_backend):
+    """Two connections racing on a free profile: exactly one acquires.
+
+    This is the core claim of the lease — correct under READ COMMITTED because
+    the UPDATE's row lock serialises the writers — so it is executed with two
+    real connections on two threads, held on a barrier until both statements
+    are queued, then released. A same-event-loop "race" would serialise the
+    statements before the server ever sees them.
+    """
+    await postgres_backend.save_profile(Profile(id="race1", name="raced"))
+
+    with _racing_holders(
+        postgres_backend.db_url, "race1", [HOLDER_A, HOLDER_B], TTL, postgres_backend._test_schema
+    ) as winners:
+        # Exactly one, and which one is whichever statement the server ran
+        # first — both winning is the bug, not either single winner.
+        assert winners() in ([HOLDER_A], [HOLDER_B])
+
+    assert (await postgres_backend.get_lease("race1"))[0] in (HOLDER_A, HOLDER_B)
+
+
+@pytest.mark.postgres
+async def test_the_loser_of_a_race_sees_the_winners_lease(postgres_backend):
+    """Losing must leave the winner's lease standing, not take the row apart."""
+    await postgres_backend.save_profile(Profile(id="race2", name="raced"))
+    assert await postgres_backend.acquire_lease("race2", HOLDER_A, ttl_seconds=TTL) is True
+
+    with _racing_holders(
+        postgres_backend.db_url, "race2", [HOLDER_B, HOLDER_A], TTL, postgres_backend._test_schema
+    ) as winners:
+        # The holder arm of the guard makes the winner re-acquiring its own
+        # lease a second success; the other holder must still lose.
+        assert sorted(winners()) == [HOLDER_A]
+
+    assert (await postgres_backend.get_lease("race2"))[0] == HOLDER_A
+
+
+@pytest.mark.postgres
+async def test_an_expired_lease_is_acquirable_by_another_holder(postgres_backend):
+    await postgres_backend.save_profile(Profile(id="expired1", name="abandoned"))
+    assert await postgres_backend.acquire_lease("expired1", HOLDER_A, ttl_seconds=TTL)
+
+    # The holder is gone; the lease lapses. Written with the server's clock so
+    # the test does not depend on this machine's timezone or clock skew.
+    postgres_backend._connection.execute(
+        "UPDATE profiles SET lock_expires = now() - interval '1 second' WHERE id = %s",
+        ("expired1",),
+    )
+
+    assert await postgres_backend.acquire_lease("expired1", HOLDER_B, ttl_seconds=TTL)
+    assert (await postgres_backend.get_lease("expired1"))[0] == HOLDER_B
+
+
+@pytest.mark.postgres
+async def test_reacquiring_your_own_lease_is_idempotent(postgres_backend):
+    await postgres_backend.save_profile(Profile(id="mine1", name="restart"))
+    assert await postgres_backend.acquire_lease("mine1", HOLDER_A, ttl_seconds=TTL)
+    # A restart on the same host mints a new uuid, but a holder that kept its
+    # id (or re-acquired before expiry) must not lock itself out.
+    assert await postgres_backend.acquire_lease("mine1", HOLDER_A, ttl_seconds=TTL)
+    assert (await postgres_backend.get_lease("mine1"))[0] == HOLDER_A
+
+
+@pytest.mark.postgres
+async def test_a_held_lease_blocks_other_holders_until_expiry(postgres_backend):
+    await postgres_backend.save_profile(Profile(id="held1", name="busy"))
+    assert await postgres_backend.acquire_lease("held1", HOLDER_A, ttl_seconds=3600)
+    assert await postgres_backend.acquire_lease("held1", HOLDER_B, ttl_seconds=TTL) is False
+    # The refusal must not have taken the lease apart.
+    assert (await postgres_backend.get_lease("held1"))[0] == HOLDER_A
+
+
+# -- Postgres backend: optimistic-concurrency saves --------------------------------
+
+
+@pytest.mark.postgres
+async def test_saving_with_a_stale_row_version_raises(postgres_backend):
+    await postgres_backend.save_profile(Profile(id="stale1", name="orig"))
+    first = await postgres_backend.get_profile("stale1")
+
+    winner = await postgres_backend.get_profile("stale1")
+    winner.name = "winner"
+    await postgres_backend.save_profile(winner, expected_row_version=winner.row_version)
+
+    first.name = "loser"
+    with pytest.raises(StaleWriteError):
+        await postgres_backend.save_profile(first, expected_row_version=first.row_version)
+
+    # The winner's value must survive the refused write.
+    assert (await postgres_backend.get_profile("stale1")).name == "winner"
+
+
+@pytest.mark.postgres
+async def test_concurrent_versioned_saves_leave_exactly_one_standing(postgres_backend):
+    """The whole-row clobber two web UIs would produce, refused instead."""
+    await postgres_backend.save_profile(Profile(id="stale2", name="orig"))
+    left = await postgres_backend.get_profile("stale2")
+    right = await postgres_backend.get_profile("stale2")
+
+    left.name = "edited-on-desktop"
+    right.name = "edited-on-laptop"
+
+    await postgres_backend.save_profile(left, expected_row_version=left.row_version)
+    with pytest.raises(StaleWriteError):
+        await postgres_backend.save_profile(right, expected_row_version=right.row_version)
+
+    assert (await postgres_backend.get_profile("stale2")).name == "edited-on-desktop"
+
+
+# -- Postgres backend: heartbeat -----------------------------------------------------
+
+
+@pytest.mark.postgres
+async def test_the_heartbeat_renews_only_its_own_leases(postgres_backend):
+    await postgres_backend.save_profile(Profile(id="beat1", name="ours"))
+    await postgres_backend.save_profile(Profile(id="beat2", name="theirs"))
+
+    assert await postgres_backend.acquire_lease("beat1", HOLDER_A, ttl_seconds=1)
+    assert await postgres_backend.acquire_lease("beat2", HOLDER_B, ttl_seconds=3600)
+
+    renewed = await postgres_backend.renew_lease(["beat1", "beat2"], HOLDER_A, ttl_seconds=120)
+    assert renewed == 1
+
+    # Ours was pushed out well past the old expiry; theirs is untouched.
+    ours = await postgres_backend.get_lease("beat1")
+    theirs = await postgres_backend.get_lease("beat2")
+    assert theirs[0] == HOLDER_B
+    assert ours[1] is not None
+
+
+# -- Backend-free: the same semantics through SQLite ---------------------------------
+
+
+async def test_sqlite_backend_acquires_and_refuses_the_same_way(storage):
+    profile = Profile(name="held")
+    await storage.save_profile(profile)
+
+    assert await storage.acquire_lease(profile.id, HOLDER_A, ttl_seconds=TTL) is True
+    assert await storage.acquire_lease(profile.id, HOLDER_B, ttl_seconds=TTL) is False
+    assert await storage.acquire_lease(profile.id, HOLDER_A, ttl_seconds=TTL) is True
+    assert (await storage.get_lease(profile.id))[0] == HOLDER_A
+
+
+async def test_a_sqlite_lease_is_visible_to_another_connection(storage, tmp_path):
+    """A lease left uncommitted is invisible to every other process.
+
+    This is the regression test for the missing ``commit()`` in the SQLite
+    lease methods: without it the lease lived only inside this connection's
+    open transaction, so a second CFPM instance looking at the same file
+    saw the profile as free — the exact failure the lease exists to prevent.
+    """
+    profile = Profile(name="cross-conn")
+    await storage.save_profile(profile)
+    assert await storage.acquire_lease(profile.id, HOLDER_A, ttl_seconds=TTL) is True
+
+    import sqlite3
+
+    other = sqlite3.connect(str(tmp_path / "test.db"))
+    try:
+        row = other.execute("SELECT locked_by FROM profiles WHERE id = ?", (profile.id,)).fetchone()
+    finally:
+        other.close()
+    assert row is not None and row[0] == HOLDER_A
+
+
+async def test_sqlite_backend_frees_an_expired_lease(storage):
+    profile = Profile(name="abandoned")
+    await storage.save_profile(profile)
+    await storage.acquire_lease(profile.id, HOLDER_A, ttl_seconds=TTL)
+
+    # The backend's own clock, so the comparison in the acquire guard reads
+    # the same units it wrote.
+    storage.db._connection.execute(
+        "UPDATE profiles SET lock_expires = datetime('now', '-1 second') WHERE id = ?",
+        (profile.id,),
+    )
+    storage.db._connection.commit()
+
+    assert await storage.acquire_lease(profile.id, HOLDER_B, ttl_seconds=TTL) is True
+
+
+async def test_the_sqlite_backend_refuses_a_stale_row_version(storage):
+    profile = Profile(name="orig")
+    await storage.save_profile(profile)
+    first = await storage.get_profile(profile.id)
+
+    winner = await storage.get_profile(profile.id)
+    winner.name = "winner"
+    await storage.save_profile(winner, expected_row_version=winner.row_version)
+
+    first.name = "loser"
+    with pytest.raises(StaleWriteError):
+        await storage.save_profile(first, expected_row_version=first.row_version)
+
+    assert (await storage.get_profile(profile.id)).name == "winner"
+
+
+async def test_a_versioned_save_bumps_and_propagates_the_version(storage):
+    profile = Profile(name="v")
+    await storage.save_profile(profile)
+    assert profile.row_version == 0
+
+    await storage.update_profile(profile, expected_row_version=0)
+    assert profile.row_version == 1
+
+    reloaded = await storage.get_profile(profile.id)
+    assert reloaded.row_version == 1
+    await storage.update_profile(reloaded, expected_row_version=reloaded.row_version)
+    assert (await storage.get_profile(profile.id)).row_version == 2
+
+
+async def test_an_unversioned_save_never_resets_the_row_version(storage):
+    profile = Profile(name="v")
+    await storage.save_profile(profile)
+    await storage.update_profile(profile, expected_row_version=0)
+    assert (await storage.get_profile(profile.id)).row_version == 1
+
+    await storage.save_profile(profile)
+    assert (await storage.get_profile(profile.id)).row_version == 1
+
+
+async def test_a_save_never_steals_or_clears_another_holders_lease(storage):
+    profile = Profile(name="leased")
+    await storage.save_profile(profile)
+    await storage.acquire_lease(profile.id, HOLDER_A, ttl_seconds=TTL)
+
+    editor = await storage.get_profile(profile.id)
+    editor.notes = "edited while leased elsewhere"
+    await storage.save_profile(editor)
+
+    stored = await storage.get_profile(profile.id)
+    assert stored.notes == "edited while leased elsewhere"
+    assert (await storage.get_lease(profile.id))[0] == HOLDER_A
+
+
+async def test_release_only_removes_your_own_lease(storage):
+    profile = Profile(name="leased")
+    await storage.save_profile(profile)
+    await storage.acquire_lease(profile.id, HOLDER_A, ttl_seconds=TTL)
+
+    assert await storage.release_lease(profile.id, HOLDER_B) is False
+    assert (await storage.get_lease(profile.id))[0] == HOLDER_A
+
+    assert await storage.release_lease(profile.id, HOLDER_A) is True
+    assert (await storage.get_lease(profile.id))[0] is None
+
+
+async def test_the_holders_list_reports_expiry(storage):
+    profile = Profile(name="held")
+    await storage.save_profile(profile)
+    await storage.acquire_lease(profile.id, HOLDER_A, ttl_seconds=3600)
+
+    holders = await storage.get_lease_holders()
+    assert [h["id"] for h in holders] == [profile.id]
+    assert holders[0]["locked_by"] == HOLDER_A
+    assert holders[0]["expired"] is False
+
+
+async def test_the_holders_list_sees_an_expired_lease(storage):
+    profile = Profile(name="lapsed")
+    await storage.save_profile(profile)
+    await storage.acquire_lease(profile.id, HOLDER_A, ttl_seconds=3600)
+    storage.db._connection.execute(
+        "UPDATE profiles SET lock_expires = datetime('now', '-1 second') WHERE id = ?",
+        (profile.id,),
+    )
+    storage.db._connection.commit()
+
+    holders = await storage.get_lease_holders()
+    assert holders[0]["expired"] is True
+
+
+async def test_force_release_clears_a_lease(storage):
+    profile = Profile(name="stuck")
+    await storage.save_profile(profile)
+    await storage.acquire_lease(profile.id, HOLDER_A, ttl_seconds=3600)
+
+    assert await storage.force_release_lease(profile.id) == HOLDER_A
+    assert (await storage.get_lease(profile.id))[0] is None
+    assert await storage.force_release_lease(profile.id) is None
+
+
+async def test_holder_ids_are_host_pid_uuid(storage):
+    holder = make_lease_holder()
+    host, pid, uuid = holder.split(":")
+    assert host
+    assert pid.isdigit()
+    assert len(uuid) == 36 and uuid.count("-") == 4
+    assert make_lease_holder() != holder
+
+
+# -- The manager refuses to launch another holder's profile --------------------------
+
+
+@pytest.mark.postgres
+async def test_launching_a_leased_profile_raises_profile_locked(pg_profile_manager, launches):
+    profile = await pg_profile_manager.create_profile(name="theirs")
+    other = make_lease_holder()
+    assert await pg_profile_manager.storage.acquire_lease(profile.id, other, ttl_seconds=3600)
+
+    with pytest.raises(ProfileLocked):
+        await pg_profile_manager.launch_browser(profile.id)
+    # The refusal happened before anything opened.
+    assert launches == []
+
+
+@pytest.mark.postgres
+async def test_launching_a_free_profile_acquires_the_lease(pg_profile_manager, launches):
+    profile = await pg_profile_manager.create_profile(name="ours")
+    await pg_profile_manager.launch_browser(profile.id)
+    lease = await pg_profile_manager.storage.get_lease(profile.id)
+    assert lease[0] == pg_profile_manager.lease_holder
+
+
+@pytest.mark.postgres
+async def test_closing_the_browser_releases_the_lease(pg_profile_manager, launches):
+    profile = await pg_profile_manager.create_profile(name="mine")
+    await pg_profile_manager.launch_browser(profile.id)
+    assert (await pg_profile_manager.storage.get_lease(profile.id))[0] is not None
+
+    await pg_profile_manager.close_browser(profile.id)
+    assert (await pg_profile_manager.storage.get_lease(profile.id))[0] is None
+
+
+# -- A failed launch must hand the lease back ---------------------------------------
+
+
+@pytest.mark.postgres
+async def test_a_failed_launch_releases_the_lease(pg_profile_manager, launches, monkeypatch):
+    profile = await pg_profile_manager.create_profile(name="doomed")
+
+    async def boom(*_args, **_kwargs):
+        raise RuntimeError("browser exploded")
+
+    monkeypatch.setattr(pg_profile_manager.browser_sessions, "launch", boom)
+
+    with pytest.raises(RuntimeError):
+        await pg_profile_manager.launch_browser(profile.id)
+
+    # Free for anyone, not just us: another machine must be able to take it.
+    assert (await pg_profile_manager.storage.get_lease(profile.id))[0] is None
+    assert await pg_profile_manager.storage.acquire_lease(profile.id, HOLDER_B, ttl_seconds=3600)
+
+
+@pytest.mark.postgres
+async def test_a_stale_write_during_launch_releases_the_lease(pg_profile_manager, launches):
+    """StaleWriteError is this branch's own failure mode, and it fires exactly
+    in the two-machines scenario the lease exists for — so its path out of a
+    half-launch must leave the profile usable on both machines."""
+    profile = await pg_profile_manager.create_profile(name="edited-elsewhere")
+    # Another writer bumps the row version after launch_browser has read it.
+    original_update = pg_profile_manager.storage.update_profile
+
+    async def stale_update(edited, **kwargs):
+        rival = await pg_profile_manager.storage.get_profile(edited.id)
+        await original_update(rival, expected_row_version=rival.row_version)
+        return await original_update(edited, **kwargs)
+
+    pg_profile_manager.storage.update_profile = stale_update
+    try:
+        with pytest.raises(StaleWriteError):
+            await pg_profile_manager.launch_browser(profile.id)
+    finally:
+        del pg_profile_manager.storage.update_profile
+
+    assert (await pg_profile_manager.storage.get_lease(profile.id))[0] is None
+    assert await pg_profile_manager.storage.acquire_lease(profile.id, HOLDER_B, ttl_seconds=3600)
+
+
+@pytest.mark.postgres
+async def test_a_successful_launch_keeps_the_lease(pg_profile_manager, launches):
+    """The browser owns the lease until it exits; a fix that released on
+    success would race the very two-instance window the lease closes."""
+    profile = await pg_profile_manager.create_profile(name="healthy")
+    await pg_profile_manager.launch_browser(profile.id)
+
+    lease = await pg_profile_manager.storage.get_lease(profile.id)
+    assert lease[0] == pg_profile_manager.lease_holder
+
+
+@pytest.mark.postgres
+async def test_a_failed_launch_keeps_the_lease_of_a_live_session(pg_profile_manager, monkeypatch):
+    """Two concurrent launches, one profile, one process — same holder id.
+
+    The acquire is idempotent for our own holder, so both calls pass it, and
+    both pass the is_running check. When the loser then fails, its except
+    block must not clear the lease under the survivor's live browser: the
+    release is guarded on "no session for this profile is running", which is
+    decidable locally, not by the per-process holder id alone.
+    """
+    manager = pg_profile_manager
+    profile = await manager.create_profile(name="contested")
+
+    # Two launches in flight before either registers a session: both acquire
+    # (idempotent for our holder), both pass the is_running check, then the
+    # winner's browser comes up while the loser's launch fails — the
+    # reviewer's interleaving. The awaited storage calls are the yield points
+    # that let the two calls interleave.
+    real_update = manager.storage.update_profile
+    attempts: list = []
+
+    async def unversioned_update(edited, **kwargs):
+        # The two calls each read the row before the other wrote it; the
+        # version conflict is a different failure mode with its own test.
+        return await real_update(edited)
+
+    winner_started = asyncio.Event()
+    loser_failed = asyncio.Event()
+
+    # Patch the BROWSER, not launch(): the real launch() has to run so its own
+    # _starting bookkeeping and finally are exercised. A test that marks
+    # _starting itself only proves its own fake — deleting the production mark
+    # would leave such a test green.
+    class FakeCamoufox:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def start(self):
+            attempts.append(1)
+            if len(attempts) == 1:
+                # Held INSIDE start(): no session is registered yet, which is
+                # the window where the guard used to lose the lease.
+                winner_started.set()
+                await loser_failed.wait()
+                return object()
+            await winner_started.wait()
+            try:
+                raise RuntimeError("second launch exploded")
+            finally:
+                # Released after the raise, so the loser's real finally runs
+                # while the winner is still inside its own start().
+                loser_failed.set()
+
+    monkeypatch.setattr(fingerprint_store, "resolve", lambda *_a, **_kw: {})
+    monkeypatch.setattr(browser_session_module, "AsyncCamoufox", FakeCamoufox)
+    monkeypatch.setattr(browser_session_module, "CAMOUFOX_AVAILABLE", True)
+    monkeypatch.setattr(
+        browser_session_module.BrowserSessionManager, "_register_close_handler", lambda *a: None
+    )
+    monkeypatch.setattr(browser_session_module, "_resolve_process_id", lambda *_a, **_kw: None)
+    monkeypatch.setattr(manager.storage, "update_profile", unversioned_update)
+
+    results = await asyncio.gather(
+        manager.launch_browser(profile.id),
+        manager.launch_browser(profile.id),
+        return_exceptions=True,
+    )
+    outcomes = sorted(r["status"] if isinstance(r, dict) else type(r).__name__ for r in results)
+    assert outcomes == ["BrowserLaunchError", "launched"]
+    assert len(attempts) == 2
+
+    # The survivor's browser is still running and still owns its lease.
+    assert manager.browser_sessions.is_running(profile.id) is True
+    lease = await manager.storage.get_lease(profile.id)
+    assert lease[0] == manager.lease_holder
+
+
+@pytest.mark.postgres
+async def test_a_cancelled_launch_releases_the_lease(pg_profile_manager, launches, monkeypatch):
+    """A client disconnecting mid-launch cancels the coroutine; CancelledError
+    derives from BaseException, so a plain ``except Exception`` misses it and
+    the lease would outlive a launch that produced no browser."""
+    manager = pg_profile_manager
+    profile = await manager.create_profile(name="cancelled")
+
+    async def hang(profile_id, options, on_exit=None):
+        await asyncio.Event().wait()  # never completes; cancelled from outside
+
+    monkeypatch.setattr(manager.browser_sessions, "launch", hang)
+
+    task = asyncio.create_task(manager.launch_browser(profile.id))
+    # Let the task run past the acquire and into the hanging launch, so the
+    # cancellation lands where the client-disconnect would: mid-launch.
+    await asyncio.sleep(0.1)
+    assert (await manager.storage.get_lease(profile.id))[0] is not None
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert (await manager.storage.get_lease(profile.id))[0] is None
+
+
+# -- Shutdown releases every lease this process holds -------------------------------
+
+
+@pytest.mark.postgres
+async def test_shutdown_releases_leases_held_by_this_process(pg_profile_manager):
+    """The lifespan shutdown path must hand every lease back: a lease that
+    outlives its process locks the profile against the whole fleet (including
+    a restarted self) for the full TTL."""
+    manager = pg_profile_manager
+    ours = await manager.create_profile(name="ours")
+    theirs = await manager.create_profile(name="theirs")
+    await manager.storage.acquire_lease(ours.id, manager.lease_holder, ttl_seconds=3600)
+    await manager.storage.acquire_lease(theirs.id, HOLDER_B, ttl_seconds=3600)
+
+    await manager.release_all_leases()
+
+    assert (await manager.storage.get_lease(ours.id))[0] is None
+    # Another holder's lease is guarded by the holder id and must survive.
+    assert (await manager.storage.get_lease(theirs.id))[0] == HOLDER_B
+
+
+@pytest.mark.postgres
+async def test_shutdown_release_survives_one_failing_profile_and_never_raises(
+    pg_profile_manager, monkeypatch
+):
+    manager = pg_profile_manager
+    stuck = await manager.create_profile(name="stuck")
+    fine = await manager.create_profile(name="fine")
+    await manager.storage.acquire_lease(stuck.id, manager.lease_holder, ttl_seconds=3600)
+    await manager.storage.acquire_lease(fine.id, manager.lease_holder, ttl_seconds=3600)
+
+    real_release = manager.storage.release_lease
+
+    async def flaky_release(profile_id, holder):
+        if profile_id == stuck.id:
+            raise RuntimeError("database went away")
+        return await real_release(profile_id, holder)
+
+    monkeypatch.setattr(manager.storage, "release_lease", flaky_release)
+
+    # Must not raise, and must still have released the healthy one.
+    await manager.release_all_leases()
+    assert (await manager.storage.get_lease(fine.id))[0] is None
+
+
+# -- Export is fleet-safe ------------------------------------------------------------
+
+
+@pytest.mark.postgres
+async def test_exporting_a_profile_leased_elsewhere_is_refused(
+    pg_profile_manager, tmp_path, monkeypatch
+):
+    """The in-process dict cannot see another machine's browser; the lease can."""
+    profile = await pg_profile_manager.create_profile(name="traveler")
+    other = make_lease_holder()
+    await pg_profile_manager.storage.acquire_lease(profile.id, other, ttl_seconds=3600)
+
+    async def refuse(*_args, **_kwargs):
+        raise AssertionError("export must refuse before reading any profile data")
+
+    monkeypatch.setattr("camoufox_pm.core.profile_archive.export_profile", refuse)
+
+    with pytest.raises(ProfileLocked):
+        await pg_profile_manager.export_profile(profile.id, tmp_path / "export.zip")
+
+
+@pytest.mark.postgres
+async def test_exporting_an_expired_lease_is_allowed(pg_profile_manager, tmp_path, monkeypatch):
+    profile = await pg_profile_manager.create_profile(name="abandoned")
+    await pg_profile_manager.storage.acquire_lease(
+        profile.id, "dead-host:1:cccccccc-cccc-cccc-cccc-cccccccccccc", ttl_seconds=3600
+    )
+    storage = pg_profile_manager.storage
+    # The backend's own clock, as everywhere an expiry is planted here.
+    storage._connection.execute(
+        "UPDATE profiles SET lock_expires = now() - interval '1 second' WHERE id = %s",
+        (profile.id,),
+    )
+    destination = tmp_path / "out.zip"
+    await pg_profile_manager.export_profile(profile.id, destination)
+    assert destination.exists()
+
+
+# -- Heartbeat -----------------------------------------------------------------------
+
+
+@pytest.mark.postgres
+async def test_the_heartbeat_closes_browsers_whose_lease_was_lost(pg_profile_manager, launches):
+    storage = pg_profile_manager.storage
+    first = await pg_profile_manager.create_profile(name="heartbeat-a")
+    second = await pg_profile_manager.create_profile(name="heartbeat-b")
+
+    await pg_profile_manager.launch_browser(first.id)
+    await pg_profile_manager.launch_browser(second.id)
+
+    # Another machine takes one of the two leases while we are not looking.
+    assert await storage.release_lease(first.id, pg_profile_manager.lease_holder)
+    assert await storage.acquire_lease(first.id, HOLDER_B, ttl_seconds=3600)
+
+    await pg_profile_manager.browser_sessions._renew_leases()
+
+    # The stolen lease's browser is closed and its session forgotten; the
+    # other one keeps running.
+    assert pg_profile_manager.browser_sessions.is_running(first.id) is False
+    assert pg_profile_manager.browser_sessions.is_running(second.id) is True
+
+
+# -- The concurrent-acquire race harness ---------------------------------------------
+
+
+class _RacingHolder(threading.Thread):
+    """One lease candidate: its own connection, waiting on a shared barrier."""
+
+    def __init__(self, db_url: str, profile_id: str, holder: str, ttl: int, barrier, schema: str):
+        super().__init__()
+        self.db_url = db_url
+        self.profile_id = profile_id
+        self.holder = holder
+        self.ttl = ttl
+        self.barrier = barrier
+        self.schema = schema
+        self.won: bool | None = None
+        self.error: Exception | None = None
+
+    def run(self):
+        # Deferred: psycopg is an optional dependency; this thread only runs
+        # inside the postgres-marked tests, never in the default SQLite suite.
+        import psycopg
+        from psycopg.rows import dict_row
+
+        try:
+            conn = psycopg.connect(
+                self.db_url,
+                row_factory=dict_row,
+                client_encoding="UTF8",
+                options=f"-c search_path={self.schema},public",
+            )
+            conn.autocommit = True
+            self.barrier.wait()
+            cursor = conn.execute(
+                """
+                UPDATE profiles
+                   SET locked_by = %s,
+                       lock_expires = now() + %s * interval '1 second'
+                 WHERE id = %s
+                   AND (locked_by IS NULL OR lock_expires < now() OR locked_by = %s)
+                RETURNING id
+                """,
+                (self.holder, self.ttl, self.profile_id, self.holder),
+            )
+            self.won = cursor.fetchone() is not None
+            conn.close()
+        except Exception as exc:  # noqa: BLE001 - surfaced by the assertion below
+            self.error = exc
+
+
+@contextmanager
+def _racing_holders(db_url: str, profile_id: str, holders: list[str], ttl: int, schema: str):
+    """Start one thread per holder, release them together, hand out a results fn.
+
+    The barrier is the contention: every thread has an open connection and is
+    blocked on the same latch before any statement runs, so the server really
+    sees two racing UPDATEs on one row. The schema pin keeps every thread on
+    the scratch schema — a fresh connection's default search_path would land
+    on ``public.profiles`` instead.
+    """
+    barrier = threading.Barrier(len(holders))
+    racers = [_RacingHolder(db_url, profile_id, holder, ttl, barrier, schema) for holder in holders]
+    for racer in racers:
+        racer.start()
+    for racer in racers:
+        # Join before handing out the results fn: inside the with-block the
+        # event loop is free, but a racer that has not run yet has won=None.
+        racer.join(timeout=10)
+
+    def results():
+        for racer in racers:
+            if racer.error is not None:
+                raise racer.error
+        return [racer.holder for racer in racers if racer.won]
+
+    yield results
+
+
+# -- Operator-facing surfaces: a refused lease, a bad TTL, a logged DSN ---------
+
+
+def test_lease_ttl_below_the_heartbeat_interval_is_refused():
+    """A TTL at or under the 30s renewal expires leases under live browsers.
+
+    Zero or negative silently turns mutual exclusion off entirely, which is
+    worse than a loud failure at startup.
+    """
+    from pydantic import ValidationError
+
+    from camoufox_pm.config import Settings
+
+    for bad in (0, -1, 30, 59):
+        with pytest.raises(ValidationError):
+            Settings(lease_ttl=bad)
+    assert Settings(lease_ttl=60).lease_ttl == 60
+
+
+def test_a_dsn_password_never_reaches_the_log_in_any_accepted_form():
+    """psycopg takes the password in the netloc, a query parameter or a
+    keyword/value DSN; every one of them used to be logged verbatim (CWE-532).
+    """
+    from camoufox_pm.core.database import _mask_dsn
+
+    secret = "hunter2"
+    for dsn in (
+        f"postgresql://u:{secret}@h:5432/db",
+        f"postgresql://u@h:5432/db?password={secret}",
+        f"postgresql:///db?password={secret}&host=h",
+        f"host=h password={secret} user=u",
+    ):
+        assert secret not in _mask_dsn(dsn), dsn
+
+
+@pytest.mark.postgres
+async def test_launching_a_leased_profile_is_a_conflict_not_a_server_error(
+    pg_profile_manager, launches, monkeypatch
+):
+    """A profile held by another instance is a 409, not a 500.
+
+    The lease refusing a launch is the design working; reporting it as a server
+    fault tells a client to file a bug instead of retrying later.
+    """
+    from fastapi import HTTPException
+
+    from camoufox_pm.api.routes import profiles as profiles_routes
+
+    manager = pg_profile_manager
+    profile = await manager.create_profile(name="held elsewhere")
+    other = make_lease_holder()
+    assert await manager.storage.acquire_lease(profile.id, other, ttl_seconds=3600)
+
+    class _Req:
+        headless = False
+        window_size = None
+        additional_options = None
+
+    monkeypatch.setattr(profiles_routes, "get_profile_manager", lambda: manager)
+    with pytest.raises(HTTPException) as caught:
+        await profiles_routes.launch_profile(profile.id, _Req())
+    assert caught.value.status_code == 409
+    assert other in str(caught.value.detail)

--- a/uv.lock
+++ b/uv.lock
@@ -487,6 +487,9 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+postgres = [
+    { name = "psycopg", extra = ["binary"] },
+]
 
 [package.metadata]
 requires-dist = [
@@ -501,6 +504,7 @@ requires-dist = [
     { name = "openpyxl", specifier = ">=3.1" },
     { name = "playwright", specifier = ">=1.50,<1.61" },
     { name = "psutil", specifier = ">=6.1" },
+    { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1" },
     { name = "pycryptodome", marker = "extra == 'chrome-migration'", specifier = ">=3.19" },
     { name = "pydantic", specifier = ">=2.10" },
     { name = "pydantic-settings", specifier = ">=2.6" },
@@ -518,7 +522,7 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30" },
 ]
-provides-extras = ["chrome-migration", "desktop", "build", "dev"]
+provides-extras = ["postgres", "chrome-migration", "desktop", "build", "dev"]
 
 [[package]]
 name = "certifi"
@@ -2474,6 +2478,86 @@ wheels = [
 ]
 
 [[package]]
+name = "psycopg"
+version = "3.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/73/8fb739d0f6bba247b9b93c9840c402a4f88545be5f1d4b02b23366371c00/psycopg-3.3.5.tar.gz", hash = "sha256:d0a3d9ccf5788af054cbd745278cb02401b5c312aeaafbf2c6144460aec47da4", size = 166508, upload-time = "2026-08-31T22:45:43.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/2e/d0a645bcaadde68bd6d93c43f02f14b0191bdda367ce3f7722abe3da744a/psycopg-3.3.5-py3-none-any.whl", hash = "sha256:ce5aa5cdb4f9379f00f487590e5890bfa7df9a164648c969ffa628505e21af4e", size = 213598, upload-time = "2026-08-31T22:39:02.184Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/cf/f0577fe9c08b67c3c203506a99c69bbcb2b357e46e2f5f5705878c1e466f/psycopg_binary-3.3.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cd0faa2475ab254ad1b507430131cf7f7f0be927ffdc03c32ad3b33d2ef63f42", size = 4720887, upload-time = "2026-08-31T22:39:12.731Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c7/4449033137966e6c72595613a7b0660cb8be5087e3adaf8425e9e85c76a0/psycopg_binary-3.3.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0d8a4b7ae47f3381e2ded89891d2455b809f4afb7e5b58086844abb8cfa420ea", size = 4770016, upload-time = "2026-08-31T22:39:21.194Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/c8/87fee9bb4ab25500d7f1e608411cc3025ee86b5ba37cec90b094a3f5a810/psycopg_binary-3.3.5-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:04f64b39830887c2c737b522cbfd6ad215d65e67ebfff674aa4cf21c02af487b", size = 5587115, upload-time = "2026-08-31T22:39:27.591Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e9/6b5a23e4e64c3f69f55d15d48586436e90c5c3fb589d9c969c1d2a76b559/psycopg_binary-3.3.5-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d06da67e9c687c6a6fdac9da4b17cbeb296ddd59bd01f6416ed4294bc57c5faf", size = 5259372, upload-time = "2026-08-31T22:39:34.186Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3c/bfcc638f6865998348fb94ecdad87751ca34ddd5c10ad8acafa099bcf14d/psycopg_binary-3.3.5-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:972cc28e943746e71ede254a4dfd1fdfcdd6dcadd6f375703849859f09377f24", size = 6853658, upload-time = "2026-08-31T22:39:41.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ee/0f5afd823875c56736ad0d4f88fdcb4375407cb01b61e5188f607714500d/psycopg_binary-3.3.5-cp310-cp310-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:553b5443cbc94fdb9b0e31b62acdf615e0780982d6b13752a15eb3d6c0dfd0d2", size = 5100080, upload-time = "2026-08-31T22:39:47.094Z" },
+    { url = "https://files.pythonhosted.org/packages/53/89/1bdab84b79d1b9fb5a4fb82abf7e2e0e19952b2f417c3ce7a1e24f6c00c1/psycopg_binary-3.3.5-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:fd5b047c9fd887b767d063845413e405f5de8ce1dc7a9d0da0637b77b836b469", size = 4619598, upload-time = "2026-08-31T22:39:52.158Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d1/a9f1a8c4b2fee79ff929fd94367619e4ab3bfe39ad2e3cb475bb1e1dfa07/psycopg_binary-3.3.5-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:4901e5b9a31c230211a1871263b6594373bacd770b14ad9b14d349716cb69cbe", size = 4312051, upload-time = "2026-08-31T22:39:57.597Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/12/79f1ee831bca072053fad7e5623e3a569fdef3fc3df3fb815cc9b10a23db/psycopg_binary-3.3.5-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:5b981d25fc2dd13fa7328e40703ea8a03f3e9d855ec946431e96a23206d3b9fd", size = 4039401, upload-time = "2026-08-31T22:40:02.253Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/93/b786e6424684bd5e7b7d27729a93862a925d2c22af5d890272642aac42d8/psycopg_binary-3.3.5-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:39e70c8e3b5fad70e2970ea4cc502bf3b612018f128aa1c670f1fa78b9774543", size = 4344454, upload-time = "2026-08-31T22:40:06.832Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/0d/ab385a58e0e8849ec3c598ca44163e102afc4893b0d71b83c4b577654a06/psycopg_binary-3.3.5-cp310-cp310-win_amd64.whl", hash = "sha256:ae67072db949d0c094b747a8ec52ad0fa3c42b27842a5f746f3613d54dde3fba", size = 3664079, upload-time = "2026-08-31T22:40:14.649Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/67/ac6b3dfd2d495f8599f7179f8082af4b3be72caa44942ddb45e9613338eb/psycopg_binary-3.3.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:c6bd84e4cf67930f26f015dec33f615472b9c5871d46408efe112dbc1bc021de", size = 4720383, upload-time = "2026-08-31T22:40:22.262Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7f/c3870c7e5ba6b4444e3e5401c79d5e83afe2c7045844eabb25d5b39adecb/psycopg_binary-3.3.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fdbeb38c9b7ca8fa57a7bda3802bedb62f4494ad3dd46c7dd36dc3f77fd5093f", size = 4768854, upload-time = "2026-08-31T22:40:26.639Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a2/04834fb8a2af14d42e48abeb61ace0a4fee2d6f516723d897cff16fce677/psycopg_binary-3.3.5-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:06de14ac978a2d53e864069fb5487075c6e3cfb0740f1bfd7017bc8b9942067f", size = 5588618, upload-time = "2026-08-31T22:40:36.524Z" },
+    { url = "https://files.pythonhosted.org/packages/de/0d/2eed6e7f8c5ada9e08cbdca4b78083df12f5c2a8d13fa0c62cd6b2b1d762/psycopg_binary-3.3.5-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d8b66353b20e79bf7ac0a80f03ae97f522ccbbf909d687eec62f112e56c0276d", size = 5259471, upload-time = "2026-08-31T22:40:46.43Z" },
+    { url = "https://files.pythonhosted.org/packages/96/66/2347889e693502e8473a60b3defac0300829007275a21980a2197c200418/psycopg_binary-3.3.5-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:af5084124fb2fd16557073822519dfe8c389636a16adef661a4c0c3918733171", size = 6851181, upload-time = "2026-08-31T22:40:52.939Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/11/039d7bbdc8ac28292a2fb9f54a7385116c7d31a3bf9c87e71eda154b32b9/psycopg_binary-3.3.5-cp311-cp311-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1344fd57a19737554670e67aecabd4fb37cd7937f2925840009645d641117e5a", size = 5098916, upload-time = "2026-08-31T22:40:57.505Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/01/5f77284d0c682106279da7d9e26527ae99f3241a91f0549b033c84441404/psycopg_binary-3.3.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2719fe19a4da752c4110cc767716d0a5bdb760d1153d89018bb7c9c61717bde5", size = 4617043, upload-time = "2026-08-31T22:41:04.555Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/4a/c07000298ffa3eaf25a720a5fd4bc9326676e99712722ca1accb40071e66/psycopg_binary-3.3.5-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:893ce86a4b997f6ca1261a7826db2506727332a6ff66646fa7f024b39b5e630e", size = 4310458, upload-time = "2026-08-31T22:41:11.72Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0a/cc7da5bb2bed198354f8dcc7c5dab3f1473edf2b6a177c1e8ec3fa9841ea/psycopg_binary-3.3.5-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a5e45e4bb68656253ce5c7a344c0a425c293581eba954d7fd7c2e4b2dc9f3038", size = 4039320, upload-time = "2026-08-31T22:41:20.783Z" },
+    { url = "https://files.pythonhosted.org/packages/17/60/f65755f1ab74223b437f1d366f63915b6f5e1292234de47643f898c29faf/psycopg_binary-3.3.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ca8af7c0454cdce235d4aedcb5528857468f1490202d25e24fc7af40e176d563", size = 4342427, upload-time = "2026-08-31T22:41:27.068Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/3c/6b1ea5b5544fa51ee6da8e99e96ca6a639ed1e0da2e335467893f14d3182/psycopg_binary-3.3.5-cp311-cp311-win_amd64.whl", hash = "sha256:7b443f943abfe35aa5a776630cea27c9348aa66659286cee0b99084332252080", size = 3665235, upload-time = "2026-08-31T22:41:30.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/83/ba396428a4fb6b70f0dd41315ad86a2c14441b7214afd47b2d49cb450b78/psycopg_binary-3.3.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:25105f9b46bdf2a30fcb67f56976ed66f6855941ae16bc024192609b917d493c", size = 4700169, upload-time = "2026-08-31T22:41:39.712Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/56/b23c5978e55cf4effdc5a3e13a17d69a580a487993e01b7c3768dd24281c/psycopg_binary-3.3.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0249c3e960cdee686000eb77169fb6590105c05bacc37e057ccdffdcd8e6ebde", size = 4763037, upload-time = "2026-08-31T22:41:47.571Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d8/b41108bfe194b4098076c8b873b05ec2ca9582445eccfd9075970d7b948e/psycopg_binary-3.3.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5698ab5941a4d138c30fef858588e651fe7d583280cd6e41832825ad9e747750", size = 5546232, upload-time = "2026-08-31T22:41:55.817Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d1/0f244dfef389e52e9dc3056f2a9033d1f6901e97d24d9a9c8b836e32ab6b/psycopg_binary-3.3.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:682a17a57415c3ca1731eec018ed031f012ffcb81ba74806eb219cb396065672", size = 5227752, upload-time = "2026-08-31T22:42:03.776Z" },
+    { url = "https://files.pythonhosted.org/packages/31/88/a4781365f09807fb91435e2d00096f3f6ae5d06bce15ef3c3c385dc22772/psycopg_binary-3.3.5-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d2a61e8147902771df7efe14062a3c8736347850d0d8befcf048235752504f2e", size = 6824658, upload-time = "2026-08-31T22:42:13.263Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f1/072c4a46287644694731b3e40fab120ebacf6d153cce7ebf7a5b208f5561/psycopg_binary-3.3.5-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f7e1e45aad410e20de45df2b159df68ff6c8dbf47a3501f806c4489b27f4ad2b", size = 5061439, upload-time = "2026-08-31T22:42:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/d6/1776a95c16941b8bbce89407cc7cf9ea3fd557efb503a40873c9e2b6394f/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c09775c549b40b274206e1b043c5e5b5af39666e85c98382a30bd05d23ab677b", size = 4588586, upload-time = "2026-08-31T22:42:25.23Z" },
+    { url = "https://files.pythonhosted.org/packages/82/64/44ec87b9a74faebe966856307b65c0d35ee6321ce509cdd0e8d6a3f5338b/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:cf0e5e63ee86098299c673992053d556c489ba9ae6aca6cb6e24d16a8e0b09e6", size = 4265161, upload-time = "2026-08-31T22:42:31.864Z" },
+    { url = "https://files.pythonhosted.org/packages/24/88/cf181df5651395a80afc520f5fefac72beb035c0c9d58ab7fcc880c9b221/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c065531e8c1815276f50dbfa283e3a7f022671414cdda6fa9a16794dd53b28f9", size = 3998727, upload-time = "2026-08-31T22:42:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1e/c72a1107647db4bb3f534c7fe1b57b1957d9c099e795f5aa81f4a2e0c312/psycopg_binary-3.3.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:df9853b832b7b916e02ef68e0d5403a7dab2d5c1ddfe94f22b1b155eb862622f", size = 4310119, upload-time = "2026-08-31T22:42:46.403Z" },
+    { url = "https://files.pythonhosted.org/packages/03/8d/452620608cafff164737e20b42ebffee8151b865ee171ba0d6692a560a44/psycopg_binary-3.3.5-cp312-cp312-win_amd64.whl", hash = "sha256:35885e333020fc152d27bea1a494bef13b2e68f6fd92b6229015e93539152008", size = 3648197, upload-time = "2026-08-31T22:42:51.575Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/1c/e718752cc63cf4e99e4a10fd36e3a3364dabdd0819484a24c0d79fbb9685/psycopg_binary-3.3.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6e85d50b87257fb117675a19ee59daa7bf9a57f6431500adf7059df799232ef4", size = 4704421, upload-time = "2026-08-31T22:42:59.564Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cf/a0e748e27c09b92738e4460582d121ba1908be3e36791e150f435e54b332/psycopg_binary-3.3.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e5becd311f9af8d180bad372f51fb2252fd02cb2073056e2b170c9274f95fe7f", size = 4765054, upload-time = "2026-08-31T22:43:05.421Z" },
+    { url = "https://files.pythonhosted.org/packages/39/62/0cbac0266d56c94dd1f702d9af2b5d54bf80b6e658048f4f2c5bd63dd7e3/psycopg_binary-3.3.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:19e5bf9872dbd164c220567fd385ba2309c7d9df1541f78343510c6b0f36a1b7", size = 5547137, upload-time = "2026-08-31T22:43:11.768Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/3a/73c6f8871f38fc07a9c0b4cbc9467beb116a2783cecf87dfa53900a396dc/psycopg_binary-3.3.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cb3b3bffebfe07110730626e76238161124f35ac87b748d663316a28d22f58b0", size = 5227577, upload-time = "2026-08-31T22:43:20.767Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7b/9f17b9f4d297b774dc574199c4dcd02dadc32a00c4056265918de5c70635/psycopg_binary-3.3.5-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2111f880add40fb03c60556069ad68e884a0908a74d2debafc603caf93b73552", size = 6824606, upload-time = "2026-08-31T22:43:33.698Z" },
+    { url = "https://files.pythonhosted.org/packages/94/86/d84dadd94a004dbbb43ce0579f1f766fdc6b8cbef745090e24bea77b5283/psycopg_binary-3.3.5-cp313-cp313-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:40505676b1526b9ea387dace034040a8c8b0bcf984cd6bd4720a2ab15e813586", size = 5060854, upload-time = "2026-08-31T22:43:42.258Z" },
+    { url = "https://files.pythonhosted.org/packages/30/d0/e5078be2c7d2490c0d6cd4cb7b3601aec44be2fa8b3fe927e9419b06004f/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5816472e3bb05615f33a741e0835043d1f4bf9709ff30d2f4aed71815cfc6b5e", size = 4589511, upload-time = "2026-08-31T22:43:50.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/01/08dfb5b18fa482e025864fd91a022310d0782c42e4cf5dda5d0e010b6790/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:358748fc4c8ccdc0e2bdf55420494930e19c3ade586ea9c3a6de3dad1f897311", size = 4268144, upload-time = "2026-08-31T22:43:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b9/cb01dc1d63f3241b49b2ca7fb9f98d0f5c76127f0dbb9440635a6ad0233e/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1ef2e498be47800f6202b9a2304c22646325ca6d54001b7c785bcfdb24a1e8ab", size = 4001036, upload-time = "2026-08-31T22:44:04.429Z" },
+    { url = "https://files.pythonhosted.org/packages/95/49/7c17dd832c05b380562ff2ff5f6ab2bcaeca8b7fff2c2b355854368a5bdb/psycopg_binary-3.3.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:88e01aa2e938a45655a8a5213fc3a44ba78cb4cab8a569b3e0bcb3d1d0eaba16", size = 4313112, upload-time = "2026-08-31T22:44:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/2c/b0b2f887185d6a2ec0b3bef948cc07656d2d1a5d96fa7f2bb03f6ef06ca4/psycopg_binary-3.3.5-cp313-cp313-win_amd64.whl", hash = "sha256:ba466011569297114449df9d523438e1adeedf3e4f31ffb78e897ec3fef3076b", size = 3647313, upload-time = "2026-08-31T22:44:19.139Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7f/4e2395da194558533bd9c31f35e4dc58ecbbae6a7176b0d2f72d629e8a51/psycopg_binary-3.3.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:40f8b132c7243ef5f503f0b6f986bf16d38a51b0df1c6ba2577743f128be03e3", size = 4712612, upload-time = "2026-08-31T22:44:25.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/94/fdb2093c8ccd7048449156db526ad746740cf34fe9c01e5dc1b7a7a8b257/psycopg_binary-3.3.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c0cac998b9b1e82dec853d2e53b3d34d56a525cf231f9441a636cfd5992929a9", size = 4775139, upload-time = "2026-08-31T22:44:36.719Z" },
+    { url = "https://files.pythonhosted.org/packages/31/52/5195e87960715f7be2005761b72d56fce4e7757d5333fd40384f071c2de1/psycopg_binary-3.3.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:479b96fd78149cfa10369dc53fbfb89ee729be13146b584a23dbc7e164c0cf1e", size = 5556807, upload-time = "2026-08-31T22:44:42.668Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/42/2d616210a91e1327516ed5ae71961aaa31bb740e4a61d7190f2221685a40/psycopg_binary-3.3.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f45d77e398542ce0937d9fa3cd9d84e9c5fc6b34c50a66404ae840bada312750", size = 5236206, upload-time = "2026-08-31T22:44:47.943Z" },
+    { url = "https://files.pythonhosted.org/packages/08/2e/e54b0d4cc263b3526e3728bb50a69660d5e79e52255ccd2a1a71e40e6f9a/psycopg_binary-3.3.5-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98a388509306e5e08a4203253ac52846bc1b034e5cbd0ae6da1211593cc28594", size = 6838066, upload-time = "2026-08-31T22:44:55.701Z" },
+    { url = "https://files.pythonhosted.org/packages/77/80/ec22a110f81a44c411965982097efeee86006bdd5a1f51f628318106c84c/psycopg_binary-3.3.5-cp314-cp314-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ab39e2794b95af61a2ff69e33e5ab6ac5df36e9ffea9a3b18e38b2aaca8c5ad5", size = 5072036, upload-time = "2026-08-31T22:45:02.838Z" },
+    { url = "https://files.pythonhosted.org/packages/93/55/7bc3c3ac769ab4fe0c619f2179b4aab3ae043f4d478283dd8279d24c0be4/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9c071bf78e5c2e6efa40bc9089a954d7b41221347a72f35c6bf2d8c96e632f75", size = 4604058, upload-time = "2026-08-31T22:45:10.444Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/69/8e7414f7dc10b2959e664330cdcf393e412f67355975dafa876cef265264/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:14fdfd65a96ecbd8b586d14546105641f4a6ac7cbe335c786830ea4de94bbe60", size = 4284766, upload-time = "2026-08-31T22:45:17.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/72/33f293c1d3ee9114f47e9ef4880f31c9de864e84a9b09454c26e106c25ed/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:8dbd694f3741dd4ac5bc60b70e17f7841aefb3f0f38cef4d2756de270e03af43", size = 4011958, upload-time = "2026-08-31T22:45:24.792Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/c9/8e38840e5a7d006987bbc9acb29951912253fa50549a4db92b3aa535f089/psycopg_binary-3.3.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:14f432430fd9e1a9e7d9ab2fe14956c77f5d074ebdc556a1ad04e9a1bd3fca04", size = 4323273, upload-time = "2026-08-31T22:45:32.973Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c7/b7ebf601c307f93e7c4c4ebac0edc9db3b2729ca038efe700a18f86b5517/psycopg_binary-3.3.5-cp314-cp314-win_amd64.whl", hash = "sha256:df209e64674a34b41662c67fdc8b4e0ffd77d2136393790691d086a09f9a6cab", size = 3745885, upload-time = "2026-08-31T22:45:40.537Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3315,6 +3399,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

CFPM has no cross-instance concurrency control. `save_profile` is a whole-row `INSERT OR REPLACE`, and "is this profile running" is an in-process dict — so two CFPM instances pointed at the same database silently clobber each other, and both can launch the same profile at the same time. The repo's own comment at `profile_manager.py:809-822` already acknowledges this gap ("offloading it to a thread is tempting — do that only together with row-level concurrency control").

For an anti-detect browser, two simultaneous sessions of one identity from two IPs is a correlation signal that gets accounts flagged — this is not a theoretical race.

## Design

- **PostgreSQL backend** (`src/camoufox_pm/core/storage.py`): a psycopg3 mirror of the SQLite `DatabaseManager`, selected by `CPM_DB_URL`. psycopg, not the declared-but-never-imported SQLAlchemy — its `connect`/`execute`/dict-row shape matches the existing manager nearly 1:1, keeping the diff minimal.
- **SQLite remains the default.** `CPM_DB_URL` unset → the exact previous code path; nothing changes for existing users or the test suite.
- **Row-level leases** on `profiles`: `locked_by` / `lock_expires` (NULL = free) / `row_version`, auto-added to existing SQLite databases by `_migrate`.
  - Acquire is one atomic conditional `UPDATE` (never read-then-write), correct under READ COMMITTED; the `locked_by = holder` arm makes re-acquisition idempotent.
  - `launch_browser` acquires before the in-process check; release happens on session teardown; `export_profile` refuses a foreign unexpired lease.
  - A 30 s heartbeat renews leases (TTL 120 s, `CPM_LEASE_TTL`); if a lease was stolen, the heartbeat closes that browser — no recovery, another host is already driving the identity. Crashed machines' leases free themselves by expiry.
  - `save_profile(..., expected_row_version=N)` raises `StaleWriteError` on a concurrent write instead of clobbering; unversioned saves behave exactly as before and never touch lease columns.
  - Force-unlock exists only as `cfpm unlock <id>` (with confirmation) — deliberately not in the HTTP API.

## Open question for the maintainer

`psycopg` is imported lazily (`try: import psycopg`), so SQLite-only installs work without it — but it is **not declared in `pyproject.toml`**. I'd suggest an optional extra (`[project.optional-dependencies] postgres = ["psycopg[binary]"]`); happy to add it if you prefer that shape.

## Verification

- Default (SQLite, no server needed): `pytest tests -q -m "not browser"` → **394 passed, 16 skipped, 22 deselected**.
- With real PostgreSQL 18.4 (`CPM_TEST_DB_URL`): **408 passed, 2 skipped, 22 deselected**; the 8 `postgres`-marked lease tests include a genuine two-connection, barrier-synchronised concurrent acquire — exactly one winner every run (repeated 8/8).
- New `tests/unit/test_leases.py` (24 tests): ProfileLocked on launch, lease-gated export, stolen-lease heartbeat teardown, expiry, idempotent re-acquire, StaleWriteError (sequential + two racing web UIs), holder format.
- `ruff check` clean.

Draft until I finish my own review pass. Branch is based on `60f85c8` (post-#43, the current `main`).