### PR TITLE
Assert the timezone a page sees, not the one automation sees

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,6 +5,11 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
 
 ## Since 0.2.0
 
+- The browser tests assert what a *page* sees, not what automation sees. Three
+  timezone assertions read through `page.evaluate`, which since Camoufox
+  152.0.4-beta.29 runs in an isolated world with a realm of its own — so they
+  reported the host's zone while real pages were correctly spoofed. Verified
+  green on beta.28, beta.29 and beta.30.
 - Proxy health is visible in the profiles list: a check leaves its answer in the
   row — exit address, country, latency, and a green, amber or red dot — and a
   selection can be checked in one go. On demand only; nothing polls.
@@ -77,14 +82,6 @@ Track progress in [GitHub Issues](https://github.com/polyackiy/camoufox-profile-
 Everything planned for `0.2.0` shipped. These are the known follow-ups, in rough
 order of how much they would hurt if left alone:
 
-- **Re-run the browser tests against `152.0.4-beta.29` when it becomes stable.**
-  It is a prerelease as of 2026-08-21, so `camoufox fetch` still installs
-  `beta.28` and nothing has changed under us yet. Three of its commits are aimed
-  at exactly what pinning freezes — *clamp headful window geometry to the real
-  display*, *probe the host monitor in CSS pixels*, *apply screen constraints on
-  Windows and macOS*. A profile pinned to a 2560x1440 screen and opened on a
-  smaller monitor is the case to watch, and `pytest -m browser` already asserts
-  what a page sees.
 - Read the Linux keyring for the `v11` cookie password. The key is currently
   always derived from Chrome's hardcoded `peanuts`, so a genuine Linux `v11`
   cookie is skipped rather than decrypted.

--- a/tests/browser/support.py
+++ b/tests/browser/support.py
@@ -112,3 +112,19 @@ def serve_local_sites() -> Iterator[LocalSites]:
         for server in servers:
             server.shutdown()
             server.server_close()
+
+
+# What the page itself computes, written where automation can read it back.
+# Automation must not evaluate this directly: since 152.0.4-beta.29 Camoufox runs
+# `page.evaluate` in an isolated world, and a timezone override belongs to the
+# realm that received it. The page's realm is the one a site actually gets, so
+# that is the only observer worth asserting on.
+_TIMEZONE_PROBE = (
+    "<script>document.title = Intl.DateTimeFormat().resolvedOptions().timeZone</script>"
+)
+
+
+async def timezone_a_page_sees(page) -> str:
+    """The timezone a script on the page resolves, not the one automation sees."""
+    await page.set_content(_TIMEZONE_PROBE)
+    return await page.title()

--- a/tests/browser/test_launch_smoke.py
+++ b/tests/browser/test_launch_smoke.py
@@ -13,7 +13,7 @@ from camoufox import AsyncCamoufox
 
 from camoufox_pm.core.browser_session import BrowserSessionManager
 from camoufox_pm.core.models import BrowserSettings, Profile, WebRTCMode
-from tests.browser.support import offline_launch
+from tests.browser.support import offline_launch, timezone_a_page_sees
 
 
 @pytest.mark.browser
@@ -60,9 +60,7 @@ async def test_timezone_applies(tmp_path):
 
     async with AsyncCamoufox(**options) as browser:
         page = await browser.new_page()
-        await page.goto("about:blank")
-        resolved = await page.evaluate("Intl.DateTimeFormat().resolvedOptions().timeZone")
-        assert resolved == "Europe/Berlin"
+        assert await timezone_a_page_sees(page) == "Europe/Berlin"
 
 
 @pytest.mark.browser

--- a/tests/browser/test_proxy_alignment.py
+++ b/tests/browser/test_proxy_alignment.py
@@ -20,7 +20,7 @@ from camoufox import AsyncCamoufox
 
 from camoufox_pm.core import proxy_check
 from camoufox_pm.core.models import BrowserSettings, Profile
-from tests.browser.support import GEOIP_ADDRESS, offline_launch
+from tests.browser.support import GEOIP_ADDRESS, offline_launch, timezone_a_page_sees
 
 
 @pytest.fixture
@@ -34,17 +34,13 @@ def named_exit_address(monkeypatch):
     return GEOIP_ADDRESS
 
 
-CLOCK = "() => Intl.DateTimeFormat().resolvedOptions().timeZone"
-
-
 async def timezone_seen(options, user_data_dir):
     launch = offline_launch(options)
     launch["headless"] = True
     launch["user_data_dir"] = str(user_data_dir)
     async with AsyncCamoufox(**launch) as browser:
         page = await browser.new_page()
-        await page.goto("about:blank")
-        return await page.evaluate(CLOCK)
+        return await timezone_a_page_sees(page)
 
 
 @pytest.mark.browser


### PR DESCRIPTION
Three browser tests started failing when Camoufox `152.0.4-beta.29` became the stable release and got fetched. They reported the **host's** timezone where the profile asked for another — which reads as "every profile leaks the machine's zone".

**That is not what happens, and the tests were wrong, not the product.**

## What is actually true

`beta.29` runs `page.evaluate` in an isolated world (upstream #707), and a timezone override belongs to the realm that received it. The tests read `Intl` through `evaluate`, so they were asking automation's realm rather than the page's.

Measured across three builds, one launch each, config asking for `Asia/Tokyo` on a machine in `Europe/Moscow`:

| build | what a page script sees | `page.evaluate` | a worker |
| --- | --- | --- | --- |
| beta.28 | `Asia/Tokyo` | `Asia/Tokyo` | `Asia/Tokyo` |
| beta.29 | **`Asia/Tokyo`** | `Europe/Moscow` | `Asia/Tokyo` |
| beta.30 | **`Asia/Tokyo`** | `Europe/Moscow` | `Asia/Tokyo` |

A site only ever gets the first column. Nothing leaked, on any build.

## Why this is worth fixing rather than waiting

A test that reads through automation's lens is measuring the one observer that does not matter. That is the mistake this suite exists to catch — it is why the canvas tests already load a real origin instead of `about:blank`. So the timezone assertions now read the value the way a site would: a page script computes it and writes it where automation can read it back.

I checked the canvas tests are not affected the same way — page script and `evaluate` return identical hashes on both builds, because canvas randomisation is keyed per site rather than per realm.

## Verified

`pytest -m browser` → **22 passed** on `beta.28`, on `beta.29`, and on the `beta.30` prerelease. The suite no longer depends on which build is installed.

Nothing is pinned as a result of this, and there is nothing to report upstream: the isolated world is doing its job, and Camoufox already ships an `mw:` escape hatch for callers who need the page's own world.